### PR TITLE
Fix: pairing + file-sync die in blob: fork tabs (opaque-origin storage access)

### DIFF
--- a/notebooks/@tomlarkworthy_atlas.html
+++ b/notebooks/@tomlarkworthy_atlas.html
@@ -4525,9 +4525,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -4538,7 +4537,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -4704,7 +4703,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -4730,8 +4729,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -5200,7 +5199,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -11190,247 +11189,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -11648,12 +11656,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -11796,341 +11807,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -12179,7 +12191,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -12427,9 +12438,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -12443,10 +12454,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -12456,8 +12467,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_atproto-comments.html
+++ b/notebooks/@tomlarkworthy_atproto-comments.html
@@ -3696,9 +3696,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3709,7 +3708,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3875,7 +3874,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3901,8 +3900,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4371,7 +4370,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10361,247 +10360,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10819,12 +10827,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10967,341 +10978,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11350,7 +11362,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11598,9 +11609,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11614,10 +11625,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11627,8 +11638,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_bootloader.html
+++ b/notebooks/@tomlarkworthy_bootloader.html
@@ -3908,9 +3908,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3921,7 +3920,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -4087,7 +4086,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -4113,8 +4112,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4583,7 +4582,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10524,247 +10523,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10982,12 +10990,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -11130,341 +11141,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11513,7 +11525,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11761,9 +11772,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11777,10 +11788,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11790,8 +11801,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_cell-map.html
+++ b/notebooks/@tomlarkworthy_cell-map.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.html
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_claude-code-pairing.html
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.html
@@ -4,12 +4,59 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>@tomlarkworthy/claude-code-pairing</title>
+  <meta property="og:title" content="@tomlarkworthy/claude-code-pairing">
+  <meta property="og:type" content="website">
   <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgd2lkdGg9IjUwcHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDY0IDY0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjQiIHg9IjIwIiB5PSI1MCI+PC9yZWN0PjxyZWN0IGhlaWdodD0iNCIgd2lkdGg9IjE2IiB4PSIyOCIgeT0iNTAiPjwvcmVjdD48cGF0aCBkPSJNMzIsMzhhOCw4LDAsMSwwLTgtOEE4LjAwOSw4LjAwOSwwLDAsMCwzMiwzOFptMC0xMmE0LDQsMCwxLDEtNCw0QTQsNCwwLDAsMSwzMiwyNloiPjwvcGF0aD48cGF0aCBkPSJNNiw2Mkg1OGEyLDIsMCwwLDAsMi0yVjE1YTIsMiwwLDAsMC0uNTg2LTEuNDE0bC0xMS0xMUEyLDIsMCwwLDAsNDcsMkg2QTIsMiwwLDAsMCw0LDRWNjBBMiwyLDAsMCwwLDYsNjJabTQyLTRIMTZWNDZINDhaTTE2LDZIMzF2NGg0VjZoNHY4SDE2Wk04LDZoNFYxNmEyLDIsMCwwLDAsMiwySDQxYTIsMiwwLDAsMCwyLTJWNmgzLjE3Mkw1NiwxNS44MjlWNThINTJWNDRhMiwyLDAsMCwwLTItMkgxNGEyLDIsMCwwLDAtMiwyVjU4SDhaIj48L3BhdGg+PC9zdmc+">
 </head>
 <body>
+
 <script id="networking_script">
   const normalize = url => url.replace(/^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/, '$1').replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
   const isNotebook = id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id);
+
+  // --- streaming gate ---
+  // main runs from the TOP of the document, before the whole file has finished downloading, so a
+  // block a boot import needs may not have streamed in yet. __waitForId blocks until the block's
+  // <script> is fully parsed (el.nextSibling is non-null only after its </scr\ipt> is seen),
+  // bounded by window.__lopeStreaming, which flips to false once the document is fully parsed (so a
+  // genuinely-absent id resolves to a 404 rather than hanging).
+  //
+  // The wait is event-driven (MutationObserver + DOMContentLoaded/load), NOT a setTimeout poll:
+  // Safari throttles timers in background/unfocused tabs, and a fork opens via window.open into a
+  // tab that is often not foregrounded, so a poll loop stalls there (works in a foreground file://
+  // download but hangs in a backgrounded blob: fork). MutationObserver fires on the parser's node
+  // insertions regardless of timer throttling. The end-of-document sentinel stays as a redundant
+  // fast-path; DOMContentLoaded/load clear the flag even if that inline script never runs.
+  window.__lopeStreaming = true;
+  function __endStreaming() { window.__lopeStreaming = false; }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", __endStreaming, { once: true });
+    window.addEventListener("load", __endStreaming, { once: true });
+  } else {
+    __endStreaming();
+  }
+  function __isComplete(el) { return !!el && (el.nextSibling != null || !window.__lopeStreaming); }
+  function __waitForId(id) {
+    if (__isComplete(document.getElementById(id)) || !window.__lopeStreaming) return Promise.resolve();
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        mo.disconnect();
+        document.removeEventListener("DOMContentLoaded", onEnd);
+        window.removeEventListener("load", onEnd);
+        resolve();
+      };
+      const check = () => { if (__isComplete(document.getElementById(id)) || !window.__lopeStreaming) finish(); };
+      const onEnd = () => { __endStreaming(); finish(); };
+      const mo = new MutationObserver(check);
+      mo.observe(document.documentElement, { childList: true, subtree: true });
+      document.addEventListener("DOMContentLoaded", onEnd);
+      window.addEventListener("load", onEnd);
+      check();
+    });
+  }
 
   const b64ToBytes = (b64) => {
     const bin = atob(b64);
@@ -59,6 +106,7 @@
 
   // Async bytes for global fetch/XHR/blob URLs
   async function dvfBytes(id) {
+    await __waitForId(id);
     const el = document.getElementById(id);
     if (!el) return { status: 404 };
 
@@ -90,7 +138,11 @@
     return { status: 422 };
   }
 
-  // --- es-module-shims hooks (sync) ---
+  // --- es-module-shims hooks ---
+  // fetch and source are async and wait for not-yet-streamed blocks (es-module-shims awaits both:
+  // `c = await fetchHook(...)` and `await (sourceHook||default)(...)`). resolve is NOT awaited, so it
+  // stays synchronous — it just routes a not-yet-present notebook id to file:// (where fetch/source
+  // then wait) instead of rewriting it to the remote observablehq API.
   window.esmsInitOptions = {
     shimMode: true,
     resolve(id, parentUrl, defaultResolve) {
@@ -101,12 +153,14 @@
         if (el.href) return el.href;
         return `file://${id}`;
       }
+      if (window.__lopeStreaming && isNotebook(id)) return `file://${id}`;
       if (isNotebook(id)) id = `https://api.observablehq.com/${id}.js?v=4`;
       return defaultResolve(id, parentUrl);
     },
-    source(url, fetchOpts, parent, defaultSourceHook) {
+    async source(url, fetchOpts, parent, defaultSourceHook) {
       if (url.startsWith("file://")) {
         const id = url.slice(7);
+        await __waitForId(id);
         const el = document.getElementById(id);
         if (!el) return { type: "js", source: "throw new Error('DVF 404')" };
         const enc = (el.getAttribute("data-encoding") || "text").toLowerCase();
@@ -119,12 +173,13 @@
       }
       return defaultSourceHook(url, fetchOpts, parent);
     },
-    fetch(url, options, parent) {
+    async fetch(url, options, parent) {
       if (typeof url !== "string" || !url.startsWith("file://")) {
         return fetch(url, options);
       }
       const id = url.slice(7);
-      return dvfResponseSync(id); // must be synchronous
+      await __waitForId(id);
+      return dvfResponseSync(id);
     }
   };
 
@@ -234,6 +289,35 @@
       }
     }
   })();
+</script>
+
+<script id="main">
+(async () => {
+  await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").then(r => r.text()).then(src => {
+    const script = document.createElement('script');
+    script.textContent = src;
+    document.head.appendChild(script);
+  });
+
+  const style0 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/global.css", { with: { type: 'css' } });
+  const style1 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/inspector.css", { with: { type: 'css' } });
+  const style2 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/highlight.css", { with: { type: 'css' } });
+  const style3 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/plot.css", { with: { type: 'css' } });
+  const style4 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/index.css", { with: { type: 'css' } });
+  const style5 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/theme-ocean-floor.css", { with: { type: 'css' } });
+  const style6 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/abstract-dark.css", { with: { type: 'css' } });
+  const style7 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-dark.css", { with: { type: 'css' } });
+  const style8 = await importShim("file://syntax.css", { with: { type: 'css' } });
+  document.adoptedStyleSheets = [style0.default,style1.default,style2.default,style3.default,style4.default,style5.default,style6.default,style7.default,style8.default];
+
+  const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
+  const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
+  const notebook = document.querySelector("notebook");
+  const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
+  const observer = Inspector.into(document.body);
+  const {default: define} = await importShim("@tomlarkworthy/bootloader");
+  runtime.bootloader = runtime.module(define, () => ({}));
+})().catch((e) => console.error("boot error", e));
 </script>
 
 <!-- CSS -->
@@ -700,7 +784,6 @@ p .plot-d6a7b5 {
   --theme-background-b: #0b0b16;
 }
 </script>
-
 <script id="https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/abstract-dark.css" 
   type="text/plain"
   data-mime="text/css"
@@ -719,7 +802,6 @@ p .plot-d6a7b5 {
   color-scheme: dark;
 }
 </script>
-
 <script id="https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-dark.css" 
   type="text/plain"
   data-mime="text/css"
@@ -822,1541 +904,6 @@ H4sIAK6D82gAA7Uca2/cNvK7fwVjHAqpUTep+83bNC3uckCAJimatMDBMFx5V7bV7kp7ktaOz93/fiTn
   data-mime="application/javascript">
 H4sIAGWI82gAA+08/XfbOI6/969QdXlbuXHs2O112qRpm0ncndzko69J566X5BLFomNNZckryfnY1P/7AQRJkfqwZW96s7Pv+l5jiQRBEAABECTVblth5LGLUeRNApa0P0RXCYtv3KuADf/W9sNkzPppFLeTuN/2/GTspv1h6/fkyWAS9lM/Ci1Z6CCappXej+Gvx1LXDxrWwxNLPFtb8uH7d+thugkVN25seVF/MmJh2oV6RNCKbkMW74rSpsVu4AfbSriWxwbuJEh/89lta2eSpNGohzCI0B9YDvYfDWS7rS3LlpTaRI6lcIbslp4dIvpBUjhtILapxYKE5dpkdPRj5qaM9+3Y/MfmzQRsyw/9tKdhH7iATfwYgDn+8K7hP+eGZC4h4vDQdvrkSXsBsblx7N4bMvMTXubcuMGEEVtilk7i0NrmsH6yrdeDxPiTBXhTN+wjg/fC9DUHqqrtvJpZ/aJbXf3Fn4mcV+8E7mjMvNlQs2jA+llEfAwidz7Aq5ccAGWicdcPPXbnfGP3Bm/hnWskVljfrfWGtWrZ9sLiFG+H7oiZQs3KnRD+UN/9CCi2Qk11peYGbMR1FzQsJNUNW/3ATRLEAPC2TsPaWp8FAaK1CTJld+lOFKY0LS5XHrBuio+b2YjDhQc3iOKRmx7fj66iAEeHNiLhbyfRcRr74TV0IarHcZRGOLlaqajbzLihI3IIgyEME2mr7wYKbGGio6vf4UWS+2Bds/ToNvwUR2MWp/dEQ9K0FL0bADN0Ew0GjA3y7ogj2hRo5KhO3GteS4io9uPR55/3dnd7h1CO1jTjUwKquVVOwqauo2BoHSK8aeU11SSOmKPDGuqeutfRQFQbWKjoVBvGOU4kwS2umPEEmWj95S8lpS3UKGxgE1tso1c+HVW/2hDS+F7YbFJ9mrdbkhqAOyfri95CGDj+o/dNEGIcvJY8Qh+NseX412EUM+lPBJgSCVnwRWf1aDRJsUaq0fHXg5+P9o+B8lPA9yCku2HZHz5cXOwdHHw52f55v3exd7jb+6/e7sXFhw9200KWAcge2h/mQQF07Q98Fm8AX4AN0+YsXL/2vuYx/cruF8ezv3d8YqLZ95MU3rjX8ZNhLSwH259MJAfu2BZtON8r2h193u19luPggKL9UeyxGEfDC80RUdk4ZgP/jkpQiDPp+9zbga5MEj+zfhR7dag87p0UKTxmqSgwOUVlCUtVyVzqjk+2d341iTtO3f63Eik8OdcNg9RD7kdg0uRnVcBSaWnQJpGWtgZ+kLLYcSQ9EENZW+9w0p1SwTl3fdhhI5t+TwWiVsDC63TYEFNpU5u+ITkjCTgA1+o4CUf+NGlJITb0JiRFDPDQRRICDAS5/oCpKcOVoeIQLcJhoJVs06hJIuCRwiABjFYktMo2VN0w7A3xWSoFuFYxoPdiZDQkEKg9JbfLC6aXTdFO9CRfM3GrEcAQn1LPqg1/4y9Tw9TlrVw4CYKlDBy7gzjDY57hJj9Jl3g0aOZ81i5L+rE/huZJwTeSLVeNyd9puJwHDOHzkVFPUKB8xgVNDeGZaaCo3pqkZaQs3NumgACfB6G8zwIP/HoIoVDTCuUKhED1SBEUT3KxHKDo/BpKC6ArjKoAh7PyIAAT/+9s2rjcFCBECFILcxBCO4ClKmMJI1HhPHAadlVjyWfePlsGlRMOBusfHhngqD0ygJ01MkS11MjU1BUYBWmKrHxYMs0oJtOlaM53KpYHRm8YjRfsLKpXrvs9FRPAPKd+5QNZNOlu3oMtAINwWeDjVFClaXSo7FSO4KwC8Anq90a0/tmAWmHJtDpgN9So14y/2li1qSXHZQSM5Vzjc7mwCK/dXKNELYFwmVNrFYRPsxZC0pDZcsJniy3R2B2PWejtDP3AcwqrsoZJlouuId+oikjXpuZuyw9DFv9ycrCPevI2ubm2bn0vHW69tobMvx6m8MCHsPUst4pzwY4/e8dpfTt206HlbT07eGn9tL9udYav//4MeBkEW8/6kziGLneiIIqfWW1s8LYN3by7pP5nUHsC5vAQvIID0wdkBSqr6ZVtnaKm2taDPb2Ug3E9jyc4MEpkMC7HHkWThE3GEKxIIy6SH3o6ppWk0RjdhXvtchDlRseB22cOsrUpjT+MJHDHiWb90ZOZDoBEw/8qjaIHXd1gZWk56AR8qF7ftJ466AAUaAvfnEaj5UUhQ0/rW2+tLsCtrvqVWoJtWrQYkerB4yNejogaxprG7S6jNcDq7izF5vTbCjJJ7wPKQAVgAQD6KoggflT1tVTAss4m3fXuKwi3Y3ap0bG4zOdIXXAVxA3Rw88MpMQ0tjapFgafcooxwLvxocdj/yqAxalCsox0O28M6T4aLVPxy41Mpgm8dcxG0Q0j7tdEpzK1NDHsIHI9mbOcKr2bp1ZKtvqsPueTeioUTaZYAJO+Zn+uxSfOSMZEnOGk1rg4b9Jy+9yC4GGUxU33yH2R1IHmH/HVycAV9RzuuekHeF+lhGC8kMgQRiOEcgZAQZLFNzoF0I4oqNE5oijtnPvPx+u+pAdK4nI5aX0o5W7ytCBlhymK2eTqHBrajMrngxW1NDx5gogav6myMhwWbG+jmTcyPDWqtE4wThs75kbznXFTaGRVceLxDJboCAtnkZZpSkYctimQB4UziBNrW5SMzLUJ9paJibrO7EohHykXXznCcrU5CqnW5pXVoheBmy58LvcOt2rmqDItwKhxE4GkEnSqx+V3RCahBWsveANeqtV9KUk8pjPyhEWxVy4B8xHyHBHrWcFqGdeQ7txuFxCvJGph+WaJDeBgcbGrxSYq4sYZQg9Pt7by6+Wy0ahKEbFXilGYtdly1GuFCSkknGvP13rCrD1h/1+kRWMxW6h5v2xKd5b0Zs29aX6zJqNX25ckCoDQ0YzFm+ffEFZjqYeNagXItPYjbmObWjHyvGWi2u3hY1YtcvtmuAqTgLS2mke1ir9siLg0oksWnY6QwU3ke+ju87/cXusRGyLaLAqmKFU17j+bkNRztUBWHmCk0x8jizrcLgtvl+ByfSbVH6U1d5TcsC+IdOvd4zEvFxr/afhWPcCFkux9meUwTgYM3eSYBUysqWHEOl8ShmdPbiG4jm4xlMsgjbUcC1qUaud5Rze8ZnwvxcEKQJS6QAgfLOIXpgU3b/FVAXBoN+wPoxhhKwAGwEaOq2FuNFdmcpKhGwTR7b9uNr87K+ldJ50vETz558vnzxxbnYR++dh+cEa/m0tz/+lS+t3qnH63mNTXh7tULr6rpzXFfDVzmuiMu7US9OS4Z6YyRQ9Cc/JJeolgfp5e5uCK8FW2HjjSMKhcJtGJBBtGm6NqmPvjc/Oheh68W5kIVwM1N6F5I3Ot8mg7KMpL/QttofxkvdzvWK9/W/8jtlBo9AsrWqma5bRs8Z2WwjZ71UaLljD6sdstlMJ8hycua2e3gWm2PpEX3a5ZpCPaIrF1Wf7o/Hv3MRLw3boZ+O7MFHx3wSR4bnWrZR2rep+dg3+8/qsTsd1CJnYdVHit01w+Jcu1ugNqDahWLSjWRdQbjdN7rF7D6jWo3iwZQVX+1iLy/I6u3Qv1VbUbsTQf1AZFNSeKexRLsahUzNqeRo5TBq+yJOQSXf/oXZDuH7gN0nVK06lVWx8VGdR5Wenuj01Ld//QvPQ8FuZz0QvzUAX7j5QH7i6bCKbpYWRvHu/0DuKuSsfSGqyDHpXgcAXGn6yzu92frJUHNtXvN+Q9bPXoSxOmg9i9Hpn3isTA5AWojwLCKSZOZeNFk6cLp0RhGNw61eivJB9a2qzMg+qRi2w0IzvarUiPLsrTmfTxLjLqFmOBltf8h5lQSAKC3SJ+aLdmjJwfFTkekMQvnQVXbv8bMYo7El6jZ3Z24R2MDy/estrPrQ8XF5++fO5dXFjP2/yuHEI4qwigNqZ8UJxDjkotGyxxA0/2mbuEB3NL1lA7mGKyINPxYTSJcTmAEBiffDnZ+QWL9Hkw8sNJynJQB1RozBcGv14O7pgKTXxB4JcCH2g1RlYUlmfE56/MjR2txUdY8vAyMMMvG9O1lYex6+kABzC9hg7eAIPQp1sGwbnd4JUrD8SP79/VoOFRkspLNdLfW5cnhI234hg2qEC0FkhnIBDwokTA54FaEmlW3LReNKaXaDUv5c9/y9eSycxZdA9/jHtDWABB3jr2IfiyhmVN6xUh5wDvrDfwD2FWCcYAyQpemklkrBAzji/3jZ5BnrxuetkCuOPUjVOHQ4H7WrcXvxhGo0RJlsxNLmCaAhoJxry190Kgx/f41Fu6/14cR7E8ds/wRbtLR5U1rtJxwJIbo3R3KsG7JTydr+Onm2NyfbgU8Z/Zde9uLKmP+ZtGvqiuQT9BlgzAxPkIJAtEguTD3n/u7x3ipaiDvROguLtevKXIGzgJ/9G2M+RJY0qeZMZbAHDLSveJtYi2H03At0lc7VP7LDxvXzest+DpzarL72crD1CVRbxZgPGiZiZWT9/xdrWSqrInDDR+Q1a/ECm8F4tGMzwVrbDMTAnzYdsljcxw5z+Ojw5bBOwP7gW3tJyqCvxe6AliGk/gh9whUaNWMg58IPdMcQt5xWHEchaMmKkeeDFHSj0vFs+/qbN/acoEipeXSL7xHyIP+9IGL5lCFB64KUqEGJgEfp85602TgY3W75EfEstzI+PCgIXO8uMSHIph8gKUt4OzCbAZAl0z6ZFNZef50wbHQ5jGKw8mzmnWB0eerwet4UuUxKZLYJeFXuayXVxisAstl9mtmLsRkSWKgfMqT1y0d/yqo2Wq5TQ/9QBFceItsnlkGqx6u0C5ySGP38/cEipXowyHIaXLMinBclPYAp72r7iGYiiBhn7ONBKGDb9BcGk/2taPydwavM1xdpGtHI2vqn1Ni5PB1zD+mbHurPOgFEJnYeClEfr39caUsvi5urWXbygg1fxIVfKgRDhamCLQypnUPj07uzy7W19fgz9v4P8VPHTenJNPb2rIdoZu3KjoCOuc/lAG4Biv9CHYwawAFLbwzw68b6fOOiUPbn1+K7TPT2+QAei7CbNeb5iz1D47uxJaxevfFOtTvb7TKQLcGADdIsDAAHhRBIhtqcaijA/urdV5hRPqDLiGkwILVdzodF7hklQAvugKwCo4qONVwCiDxWaoJb8VgPwNZZr7FpSbWU7MWuyO9aXIYUKuhpqWLP4JDfH2UZAi49A0C5pVVVnYjLAnXz/1LraPvx7uAPSDuhZvu8l92LfOJuudN13bmuaBL/7aO+x93j45+lzd7LnZbmd/+/jYhOYz2IT6+OVw52Tv6NAELKOjggK97/x5IskNZ6DH2Zxl/MM9eJoJjzoYC4SBMR0G+a9ZDArnS4zZYm8jR2THtlRccZc5Y6h0fVdg+L5t5tv/FR20Cx3MR5TxpRJlPWyz8IgvM+Watf+HC/Tsqg22NkkdCBze67LfMEVcwCs3U9Tps6xt7mq6SL5KcZL0bPH9A2OjdsTpct5vcM08S5433jtnt6sNeNp616b5mGXiZ6J3cPqPTjvn6EgbNTs7c+AHe4RSeGrCf+wea+CpsRAFvO/3GiGZixCo0R3w7WwiEa2WU5dSFfNxQs+QUfQE5HJi//lGMltc5KW1RsXsvdnEja+TpiW/fpQZh0fbkVCpURk/mX3NORCjgNX4JXEnNP+WCadk81lkf2P3t3hSzYA3oynuWcgGK0bUO9lwnZSeZFjGD2bfmzC+vyTN+YZ66uY+wpT3EzJtmEvPVJw6FdZPJMPVJ4Skx9DvbJD9vYqigLnS6lLZBAL8AawAPXtDrbboXMLqFv90WMEGT7XW4WR0xeJC0y35C7Z0HZ1Vx2qLIkq62mvrOLVER/P7ufKv/TCt7AcwhPNQiL3JIgpjy1MIQM32GQjVpMpQynPVOa9fRGoQRmuGAhYjcTdLMQyc0kMaBxQyaeBBKX1ZLXSIzk9Jjtj4qvhpMMC8MVz4YN2uyjUb6G3MNdvNHMt5drqM4XN7xJGob2GV9QcdXPmex0KtU/tUlZ7PG5yaQ3Li6jlbvUMS4ak4xUwJ4HNNljpRMbsGsRXYoGeNC4zI0ZdRmO+a587PVUBlWWDHhmk6Tjba7Ws/HU6uIF4ctYPIc5Oh/LkKoqv2yE1SFrf9RCbx/22/+6qil92jg95dn41RrauGydPzhVFquf1FBpkL+PCfmB4OTQE8WGweCsSjxblzqI3C/NENal74ufn+f5eiCJf0peGsPM/KAwqGkjf5fXflM6ryBfrpy6PAo88KHLJbbaOAaogCTOllFy0K17L5yIFmiUVr5HpeJbx07NjN2MUDr+jCZeSWfZ8AMDYlIG9kfI2A16oPEizs6D12J938/tHONq4jLg62T3Z+wYD2LFmFKNVb3YD/Z42V9oiWi3sShzwCkR0ioGUb/6CtcfiKCtJhHN3yDXGaNrYvNumwWiYZ06GftC5CyqXgDxXzj7rOYGx2Lxl1DH2LeUj+wSKcGKdgF4T1IoeWvg2RFxlN/UZ5kxIRx5MwRN+nSBpMAjzZzDzDUtSgT5xcw5r8J2U1ncFQpFCGV10vdEFkoUEuLBPf16WBDfxYfA0DsebLsnHPrq2cLSr32siZy5ssB1lr5ki7Vk+CUiKFw1SGaJHbBS4gH7Wtzyo43XuK/BSBqK+LZBIxmlGJ/lGSXDvNo0hYzUIIGRbwKutv3g6SOHRTnJ1Cztgqoi5paS7oE9X2ZOyJ/XS5YkT/CXrN+VhfrxeTWv2ZZ4izXAz1Oc6/sl136xB3xmas+aTu5jdS6u4yztl4UwtAEgRfezRUEsC07JjZaTQMnhqY/RvVZ076MgR6oLMK6tM3080nyie0YEGD1/JV+kNYAhZnzlUs7VQNHXQSCwZNfWRtxv+/TVh8T7cuwH9kqDO26kjFsqDgdjKYMEohkIPFoq7StEyR9Oe/4gho1GCz3mrFNlxdRLph84mRUDVMvLZ3UVyLCGylH9ZGNWgob6DXlHynd/oEjHEUp7w7NSQk638B7sve5NpeAAA=
 </script>
-
-<script id="@mbostock/safe-local-storage" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _gi5bv7 = function _1(md){return(
-md`# Safe Local Storage
-
-If a reader has localStorage disabled, simply referencing it will throw an error and prevent any downstream cells from running. This can break your notebook!
-
-If you import from this notebook instead, you’ll be able to use localStorage safely: if the reader has disabled local storage, you’ll get an in-memory storage instance that evaporates when the page is unloaded.
-
-\`\`\`js
-import {localStorage} from "@mbostock/safe-local-storage"
-\`\`\`
-
-Please note that this implementation does not support direct-setting of properties on localStorage; use the [Storage interface methods](https://html.spec.whatwg.org/multipage/webstorage.html#webstorage) instead.
-`
-)};
-const _x8ty32 = function _localStorage(MemoryStorage)
-{
-  try {
-    const storage = window.localStorage;
-    const key = "__storage_test__";
-    storage.setItem(key, key);
-    storage.removeItem(key);
-    return storage;
-  } catch (error) {
-    return new MemoryStorage;
-  }
-};
-const _jodvzd = function _MemoryStorage(){return(
-class MemoryStorage {
-  constructor() {
-    Object.defineProperties(this, {_: {value: new Map}});
-  }
-  get length() {
-    return this._.size;
-  }
-  key(index) {
-    return Array.from(this._.keys())[index | 0];
-  }
-  getItem(key) {
-    return this._.has(key += "") ? this._.get(key) : null;
-  }
-  setItem(key, value) {
-    this._.set(key + "", value + "");
-  }
-  removeItem(key) {
-    this._.delete(key + "");
-  }
-  clear() {
-    this._.clear();
-  }
-}
-)};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  $def("_gi5bv7", null, ["md"], _gi5bv7);  
-  $def("_x8ty32", "localStorage", ["MemoryStorage"], _x8ty32);  
-  $def("_jodvzd", "MemoryStorage", [], _jodvzd);
-  return main;
-}</script>
-
-<script id="@mootari/access-runtime" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _xuj1uh = function _1(md){return(
-md`# Accessing a Notebook's Runtime
-
-Based on an idea by Bryan Gin-ge Chen (which he explores in his notebook [Dirty tricks](https://observablehq.com/d/4e5230c1d38f7c0f)), this notebook demonstrates a hack that exposes a notebook's underlying [Runtime](https://github.com/observablehq/runtime) instance.
-
-*Related discussion: [Check if a cell is defined](https://talk.observablehq.com/t/check-if-a-cell-is-defined/4351/3)*
-
-Suggested imports:
-~~~js
-import {runtime, main, observed} from '@mootari/access-runtime'
-~~~
-  
-
-
-<style>
-  a[href^="#"]:before {
-    content: "→ ";
-  }
-  a[href], a[href]:hover {
-    text-decoration: underline dotted 2px;
-    text-underline-offset: 2px;
-  }
-  a[href]:hover {
-    text-decoration: underline solid 2px;
-  }
-  a[href]:visited {
-    color: inherit;
-  }
-  p > code, li > code {
-    color: var(--syntax-keyword)
-  }
-</style>`
-)};
-const _1k2rjj6 = function _2(md){return(
-md`---`
-)};
-const _1qopri0 = function _3(md){return(
-md`## API`
-)};
-const _1hkk18y = function _4(md){return(
-md`### Instances`
-)};
-const _1xud60i = function _runtime(recomputeTrigger,captureRuntime){return(
-recomputeTrigger, captureRuntime
-)};
-const _1w8wxmk = function _main(modules){return(
-Array.from(modules).find(d => d[1] === 'main')[0]
-)};
-const _1uwo3kn = function _modules(runtime)
-{
-  // Builtins are stored in a separate module.
-  const builtin = runtime._builtin;
-  // Imported modules are keyed by their define() functions, which we don't need here.
-  const imports = new Set(runtime._modules.values());
-  // Find all modules by retrieving them directly from the variables.
-  // Derived modules are "anonymous" but keep a reference to their source module.
-  const source = m => !m._source ? m : source(m._source);
-  const modules = new Set(Array.from(runtime._variables, v => source(v._module)));
-  // When you edit a notebook on observablehq.com, Observable defines the
-  // variables dynamically on main instead of creating a separate module.
-  // When embedded however the entry notebook also becomes a Runtime module.
-  const main = [...modules].find(m => m !== builtin && !imports.has(m));
-  
-  const _imports = [...imports];
-  const labels = [
-    [builtin, 'builtin'],
-    [main || _imports.shift(), 'main'],
-    ..._imports.map((m, i) => [m, `child${i+1}`]),
-  ];
-  
-  return new Map(labels);
-};
-const _1whqobe = function _8(md){return(
-md`### Utilities`
-)};
-const _1d8v4pl = function _observed(no_observer,runtime){return(
-function observed(variable = null) {
-  const _observed = v => v._observer !== no_observer;
-  if(variable !== null) return _observed(variable);
-  const vars = new Set();
-  for(const v of runtime._variables) _observed(v) && vars.add(v);
-  return vars;
-}
-)};
-const _mgd7ct = function _no_observer(main)
-{
-  const v = main.variable();
-  const o = v._observer;
-  v.delete();
-  return o;
-};
-const _ga2084 = function _11(md){return(
-md`### Internals`
-)};
-const _1kceec5 = function _captureRuntime(mutable_recomputeTrigger){return(
-new Promise(resolve => {
-  const forEach = Set.prototype.forEach;
-  Set.prototype.forEach = function(...args) {
-    const thisArg = args[1];
-    forEach.apply(this, args);
-    if(thisArg && thisArg._modules) {
-      Set.prototype.forEach = forEach;
-      resolve(thisArg);
-    }
-  };
-  mutable_recomputeTrigger.value = mutable_recomputeTrigger.value + 1;
-})
-)};
-const _mp53no = function _mutable_recomputeTrigger(Mutable){return(
-(m => m.generator ? m : Object.defineProperties({}, {
-  [Symbol.toStringTag]: {value: "Mutable"},
-  generator: {value: m},
-  value: Object.getOwnPropertyDescriptor(m, "value"),
-}))(new Mutable(0))
-)};
-const _1trrrv5 = function _recomputeTrigger(mutable_recomputeTrigger){return(
-mutable_recomputeTrigger.generator
-)};
-const _1l3masu = function _15(md){return(
-md`---
-## Examples
-
-*Hit Refresh to update the lists below.*`
-)};
-const _qzbmro = function _ex_refresh(Inputs){return(
-Inputs.button('Refresh')
-)};
-const _1taed3h = (G, _) => G.input(_);
-const _1sbpgcs = function _17(md){return(
-md`### Defined variables`
-)};
-const _mcd64l = function _ex_vars(ex_refresh,runtime,modules,no_observer){return(
-ex_refresh, Array.from(runtime._variables).map(v => ({
-  name : v._name,
-  module: modules.get(v._module),
-  type: [, 'normal', 'implicit', 'duplicate'][v._type],
-  observed: v._observer !== no_observer,
-  inputs: v._inputs.length,
-  outputs: v._outputs.size,
-}))
-)};
-const _2couch = function _ex_vars_filters(ex_vars,Inputs)
-{
-  const unique = (arr, acc) => Array.from(new Set(arr.map(acc))).sort((a, b) => a?.localCompare?.(b));
-  const modules = unique(ex_vars, v => v.module);
-  const types = unique(ex_vars, v => v.type);
-  const value = this?.value ?? {};
-  
-  return Inputs.form({
-    modules: Inputs.checkbox(modules, {
-      label: 'Modules',
-      value: value.modules ?? modules,
-    }),
-    types: Inputs.checkbox(types, {
-      label: 'Types',
-      value: value.types ?? types,
-    }),
-    features: Inputs.checkbox(['named', 'observed', 'inputs', 'outputs'], {
-      label: 'Features',
-      value: value.features ?? [],
-    })
-  });
-};
-const _350we = (G, _) => G.input(_);
-const _1ij3t3 = function _ex_vars_table(ex_vars_filters,ex_vars,Inputs)
-{
-  const flags = (arr) => Object.fromEntries(arr.map(v => [v, true]));
-  const modules = flags(ex_vars_filters.modules);
-  const types = flags(ex_vars_filters.types);
-  const {named, observed, inputs, outputs} = flags(ex_vars_filters.features);
-
-  const data = ex_vars.filter(d => true
-    && modules[d.module]
-    && types[d.type]
-    && (!named || d.name != null)
-    && (!observed || d.observed)
-    && (!inputs || d.inputs)
-    && (!outputs || d.outputs)
-  );
-  return Inputs.table(data);
-};
-const _8awat = function _21(md){return(
-md`### Dependency matrix`
-)};
-const _1tb2c5q = function _ex_deps(ex_refresh,observed,Inputs,htl)
-{
-  ex_refresh;
-  
-  const vars = Array.from(observed(), d => ({
-    name: d._name,
-    inputs: Array.from(d._inputs, d => d._name)
-  }));
-  const inputs = new Set();
-  for(const {inputs: i} of vars) for(const n of i) inputs.add(n);
-
-  return Inputs.table(
-    vars.map(d => ({
-      '': d.name,
-      ...Object.fromEntries(d.inputs.map(n => [n, '✔️'])),
-    })),
-    {
-      columns: ['', ...Array.from(inputs).sort((a, b) => a.localeCompare(b))],
-      header: {
-        '': htl.html`<em>_name`
-      }
-    }
-  );
-  
-};
-const _kmu6ss = function _23(md){return(
-md`---
-## Explainer
-
-Presumably, our best shot at fetching the runtime is to receive the instance as \`thisArg\` to [\`Set.prototype.forEach()\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/forEach) in [\`runtime_computeNow()\`](https://github.com/observablehq/runtime/blob/v4.23.0/src/runtime.js#L110-L119):
-
-1. In [\`captureRuntime\`](#captureRuntime) we apply a temporary [monkey patch](https://en.wikipedia.org/wiki/Monkey_patch) to \`Set.prototype.forEach\` in order to gain access to any passed-in parameters.
-2. In [\`runtime\`](#runtime) we define a dependency on \`recomputeTrigger\` to ensure that the \`Mutable\`'s generator value is observed.
-3. To trigger a recomputation we reassign [\`mutable recomputeTrigger\`](#recomputeTrigger).
-4. In our overridden \`Set.forEach\` callback we then use [duck typing](https://en.wikipedia.org/wiki/Duck_typing) to match the Runtime instance.
-5. Once we've encountered the instance we restore \`Set.forEach\` and resolve \`captureRuntime\`, and in turn \`runtime\`.
-
-
-`
-)};
-const _icntqt = function _24(md){return(
-md`---
-## Updates
-
-- 2025-09-28 Added a FOSS license, per request.
-- 2025-08-01: Replace \`mutable\` with a notebook-kit compatible solution, per request (though you probably want \`__ojs_runtime\` instead).
-- 2022-08-28: Rewrite and simplification, documentation updates.
-- 2022-08-27: Added \`main\`, \`no_observer\`, \`observed\`. Added example for \`observed\`.`
-)};
-const _g7meyf = function _25(md){return(
-md`---
-*Thumbnail image: [Austrian National Library](https://unsplash.com/photos/ciMJn3mD5u8)*
-`
-)};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  $def("_xuj1uh", null, ["md"], _xuj1uh);  
-  $def("_1k2rjj6", null, ["md"], _1k2rjj6);  
-  $def("_1qopri0", null, ["md"], _1qopri0);  
-  $def("_1hkk18y", null, ["md"], _1hkk18y);  
-  $def("_1xud60i", "runtime", ["recomputeTrigger","captureRuntime"], _1xud60i);  
-  $def("_1w8wxmk", "main", ["modules"], _1w8wxmk);  
-  $def("_1uwo3kn", "modules", ["runtime"], _1uwo3kn);  
-  $def("_1whqobe", null, ["md"], _1whqobe);  
-  $def("_1d8v4pl", "observed", ["no_observer","runtime"], _1d8v4pl);  
-  $def("_mgd7ct", "no_observer", ["main"], _mgd7ct);  
-  $def("_ga2084", null, ["md"], _ga2084);  
-  $def("_1kceec5", "captureRuntime", ["mutable_recomputeTrigger"], _1kceec5);  
-  $def("_mp53no", "mutable_recomputeTrigger", ["Mutable"], _mp53no);  
-  $def("_1trrrv5", "recomputeTrigger", ["mutable_recomputeTrigger"], _1trrrv5);  
-  $def("_1l3masu", null, ["md"], _1l3masu);  
-  $def("_qzbmro", "viewof ex_refresh", ["Inputs"], _qzbmro);  
-  $def("_1taed3h", "ex_refresh", ["Generators","viewof ex_refresh"], _1taed3h);  
-  $def("_1sbpgcs", null, ["md"], _1sbpgcs);  
-  $def("_mcd64l", "ex_vars", ["ex_refresh","runtime","modules","no_observer"], _mcd64l);  
-  $def("_2couch", "viewof ex_vars_filters", ["ex_vars","Inputs"], _2couch);  
-  $def("_350we", "ex_vars_filters", ["Generators","viewof ex_vars_filters"], _350we);  
-  $def("_1ij3t3", "ex_vars_table", ["ex_vars_filters","ex_vars","Inputs"], _1ij3t3);  
-  $def("_8awat", null, ["md"], _8awat);  
-  $def("_1tb2c5q", "ex_deps", ["ex_refresh","observed","Inputs","htl"], _1tb2c5q);  
-  $def("_kmu6ss", null, ["md"], _kmu6ss);  
-  $def("_icntqt", null, ["md"], _icntqt);  
-  $def("_g7meyf", null, ["md"], _g7meyf);
-  return main;
-}</script>
-<script id="@tomlarkworthy/acorn-8-11-3/acorn-8.11.3.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICP8iLWcCA2Fjb3JuQDguMTEuMy5qcwDMvflzHMeRKPz7+ysas37gjNgDzuAiMdBoHg8dXJEiTVCS1xSMbcw0MC0OukfdPSRhAl/w0i1Ksr2SRUkUKd4Eb4KHSPGI2P3Rn/0iNt6u16F96x7o/TQRG/gXvsysqu7qCwBp74svSEx3111ZWVmZWVlZa5555r8pzygbWmatodeU8WnlTWeT3jD22ErLMcxJZYfVaLSayp7enrVDPUVFM2vKTt12dFvZM9BTHOrp7cH822xj0jC1hjJhNPSSssZsTq3RqpZt/o91PcViT9+amuG4LKRn6k0HsmCuTZbyyradUJGujOzYrOw13LpSmza1KaOqNRrTyqRu6rbmQruwWKdL2WrZumKYE5Y9pbmGZZaUuus2ndKaNXv37u1506lRy3uq1tQaan3esY08FpvnxeapIKh7zX/bo9mKW941UBhSC2pv71r4LQ4U1H61d6hfHVKLfYPr1F74V1QH1T61vwivA5hmcBCCBtb2Q+AQ/OtbC2HqOoxeW1SLBRXK6FOLvX2Yvl8tQrpeDIYwtVjEkgbxcx0UBW9D6lpI17cWqoPnkIpl91M1+N2PzcA6sBlQSR/+YkP7qLHr8JOV0acOYNZeamuRZShgoiJ9DUK3oC1DELcWI4aoK+sgEa+hF9qJWaHL61RW0yD+H6JEvdTTddSbAUzd34evCIoh7PUAgamPqi3QOxVa7C1QoVg7BGMZ/djgXgJdARsC//uhRQNqf2GQQLEWWwjNg3fsTpGBcoCVwHuIlVBhQzhaFNjPxqKP4FygoALG845j9EDfQBEC11LL+9b1YUfWYV19WMwgNrUX+1MsFFllMHrrECRYVJE6NTRI0OlfC42FUYLuYqo+qmOAjwN0GEFRhMohT39xHTZjAPoxgGn6h1jPEfy9faz52JxBBpciA5foEzSFMA4jadT6BnD0Bwku/UNs7NZhjmIR24/N7187gHWsXbd2LQxub9/QqKqXdxEmADbTSK3jFSBuYhEAiiL0BBB5AJIMEg5Al9bhf+hMEacE9mstFYLoCDkGaLggGRQBrSoOsUD2gy0YICwoFlhFvX63oiGDWAlhQm+R4XfvAGEUTbl11CxC+F6sC3P00wzopTnRyyYX9H5QdAxD2e8AISe2FKphk5dwlP6to+Kwp/DTx7APqAB8DPQFZUCZOEDYdWhaL04zmOA4D+gXutvXT2iNdawdoulTJPyE/P003wDBYSJARC+NG8AYZy6bwwA/KATa0Y91Y2kFPr0Bnv3UUxxqmiLU5QJhNjS3SO3tx6Khc/18WvSyqd9PxGQdUpg+hpZEE4rSMPDCh3gNUMEQNq04JBL2FanlRT6ZiusGsLh+rKFvLY8q4LzppwoLCB2YQH3rEB3XDVLnoZGDfUgA11Kf+gjIhIhEYFhnhgYoGjIW1/Kg3iFGu/qGiFD28ikIc663wFpNleEE7SVgYKoBylcsBjMI2slANshJFPWKJl8fDtQ60YgiYkQf0hqii9Am7Hehj+YVJoM29g5CcUNEFYuFtYQZSLawbCAR6wZhuAYAl9fhEELcWiofGzRE40dd7FWJJELE4LohBE0REqzFwYPgtdgMQNOiAMFgkYgUEMC1CE0oe6iPIbDoYO9QgXWhjw19geEJ0jRocF8BqRmSBYQd5sdpOTRURFJO872X42GfT76LvHaqYrCfSmXDNsjnByXrZwSWEfM+wpl+jo+sLSt4g/6u6yeMX4vDA1RtEInNWpwStLAROvT19gooApoCEkIb1gLBGRS4LvAdqDNR8bWEMrD2DLC5LmBV4ERkiGdkmIZVDAiso7/eSPron4gT49AnlTfEaDiBihF3mAf9SAl6kRr3IR8xQODsRYAPrB0kdFzbv5blw4nXDz0Y6MfwAoBiiOZTf3GoOKoa5cw/zv3j7X+8/08H8v/0+T99kf+nO//0Xf53B3/3Tv53v/rdyfzvzvzu8u+u/v56/ve3fn/n93d/fz//+4e/f/yHd/7wXv4PH/zhoz98nP/Dt384nf+ft//n3fw/H/znD/L/69r/upH/l8//5di/nMz/63t//DT/x7k/Xsv/8ea/ncz/6YM/Xf3TtT/dyP/wmx8+++HsD+d+uPrDtR/u53948MPjf//033+d//dr//to/j/O/seNP3+Q//Pcn2/9+faf73snD+S9k595J7/0Tp7xTl7wvoXvb7/wvj0Jjznv2+t579S73qn34fGxdwoCT7/vnTmS987c88489M5+6p39Iu+d/dY7eyPvnTvgnXsbHh955z7xzn3qnfsNfFzwzs3B47p37qZ37g683fPOPfTOf+yd/9o7f9w7fyLvnf/WO3/dO3/DO//AuwAFXPjAu/CJd+FT7wIUcOGCdwEKuHDdu3DTuzDvXbjtXbjjXfjOu3DPu3gs71382rv4jXfxJrzd8uYg99xRb+4TePzKm4Pscxe8Ocg+d92bu+nNzXtzt+Hjnjf30Lv0qXfppHfpW+/SPe8y5Lv8kXf5E+/yp95lyHb5gncZsl2+7l2+6V2e9y5DtsuQ7qF35WvvynHvCjT7yrfelRve1cPeVch99QPv6sfw+NS7+mt4fOZdPeZd/dK7+rV39Rvv6gnv6mnv6hnv6gWIm/OuXoXHPe/ap951yHr9I+86ZL0OX5D1+gXvOtR8/Z53/aF3A4B740vvxnHvxknvxrfezQPeTchx8yPvJuS4+al3E3LcvODdhBw3572b0Mqb97ybD7354978N978SW/+W2/+hjd/07sFg3brI+8W5Lv1qXcL8t2679166N3+2Lv9D3nv9ufebejT7W+92/fh8di7A/Xc+dy78yU8bnh35uHxvXfnoXcX8OPuO953B/Ped9e9725638179yDs3jve/YPe/UPe/SPe/Xfy3v0PvPsfweO0d/+sd/88vF337t/07s979x9630OG749437/jff81vJ3wHhzwHkLYw3e9h4BqDy97j97Le48+ah84kG8fmGsfeNw++Gm+ffCz9sEv4XG8ffDb9sGz7YPn2gevwvf19sHb+fahg+1DH7cPncy3D7/dPvxu+/DR9mHIdPh++/CDfPv999rvfwCPo+33IfD9z9vvf9F+Hwp7/3j7fcjywXvtDyD6g6PtDyD6g+vtD27C43b7g+/g8aj94YH2h4fy7Q/fbn/4Hjw+b3/4Rb790aftj34Nj8/aH8HX0S/bH0NrP/6k/TGU98nt9ieQ9ZOH7U8P5tvHLrePXYPH4/aX8PXll+0vIclXc+2voPVffdf+GvJ9/av21yfgcaN9HL6O/6p9HJIcv9w+DkmOX29/A4HfzLdP/LZ94uv2SYj69rv2KQg7daF9aq596nq+ffp2+wwEnPmmfRZ6cPZK+ywEnr3VPgeB5y61z8HX+ffbF+DrwuftC1DCxX9oz51vA+q3L8+3r8Djykftq4fz7asn21evtq9ea1+9n29fO9u+Dlmun27fOJpv3/ikfQNgduNh+yYE3nyvfROqunm/ffMhPB635y/m2/OX2/PQ5Pn59vzt9vyd9vz99i1Ie+dx+zt4PPis/QBg9eB4+wG04OHb7YcAzodH2w+hnIe/bT881n74Vfvh8fZDAMXDh+1HkOXRrfajO/B40H70qP0YBuHxkfbjd+DxUfsx5Hr8m/bjz+HxVfsxlPj4cvsxDNzjW+3HkOfxg4WDNxYOPl449Gl+4dDXC0cOLRx5d+HIB/mFI79ZOPLZwpEv4O34wpEzC0fOLRy5sHBkDr7vLRx5AI/HC2+/nV94+/2Ftz9eePtkfuGd9xYAEAvzZxbmL8Hj6sL8zYX5+QXo28Ktswu3zi/curJw63p+4fb5hdvXFu5A8J3PF+5AxjvnFu5cgMfVhTsQfefOwp3v4PFoASbSwt13Fu6+B4+PF+5CC+9+vnAXWnT3mx8PvJ3/8cC7Px74Fh4XfzxwAx63fzzwHTwe/HjwYP7HQ5//eOgreJz48RAkOXz/R8DwHw8//vEI5Dty7ccjkOGdj3985yQ8Hv/47vX8j+8+/vHTA/n/c+fx/4FR6Pz6o85vPs13fvOw8w/w9cVHnS/g64sTnS/mOl9c6hyDsGNXO8ce5ztfHu8Apna+utb5+rf5ztcnOl+fyne+ea/zzYf5zokPOic+7Zz4VefEbzonPoPvY50TN/Odkwc7Jw/D4+3OyXfh8UHn5EfwONWBdaXz7Xzn1KF859R85zSkPH23c/r7zumHndOPOmc+yHfOnO2cuZ7vnH2ncxbqPPugc+5IvnPuZuf8J53zEHD+TOf8OXhc65y/D49HHUDlzoULnYvwuHiocxESX/ywcxFSXrzTuXi/c/FRvjN3rTN3ozN3uzN3pzN3D74fdi4d6Fw61Ln0Vb5z6XjnEqS+NNe5BK25dKtz+WC+c/mdzuX34fFx5/Kv4PF55zIkuXyuc/kCPK52LkMDr3zZufI1PC52rsDXtVMdwIv//Ob0f35zPf+fJ975zxMfwuP7RZiLixevLF68nl+8dGzxMnxdfmcRlpbFy79dvHx88fIJeLuwCIvM4uU7i5e/g8eDxcuPFq8cWLxycPHK4cUrRxavvJNfvHpj8RpkuvVw8fan+cU7nyze+XV+8e67i3eh3LvfL96Dx71bi/fu5Be/f7D44Nv84oP7iw8P5hcffrn48Fx+8dGjRZgyi4/fXXz8ATw+WXwM2R//dvHxl/D4OqM65f19pYw27ri2VnWVcctq6JqpjE+7ulKta7ZSbWiOo9Ss1nhDV3SzNaXo+5qW7cLD1c2ao0wwHVLD0lxl0nItxZhqNvQp3XQdfMWkhkl/uj2hVXWlYZmTiqm5xh5daWrV3dokPG1jj+bi03L1KmqPmlChUVWcOhbguJAcPlpN3VacabNaty3T+CUkc+Ftr6NA603HgDqVPVYD0jb0jDpQyrDG81az5rIyqpbpuKInrJUZdbCUwaQAFNc2qm4pI/ckaL7urqDZrMHTht6oifI2GGYNatgD0NLsyRaVm5lV7XJm3Na13UpVcwDmmlutY/Ncw2zpSk0fb01OQoNr+oTWargwEIregHQE9ca0MmHZykTLrKJmTTEmFFt3W7apOHsNLIegA8CZVlBztrcOcGEaO7PVaEA41DChYXEGgEMzq7o1objTTXzssYwa1Aq91RVT3wspoDTDyahaef9AyVYzA1NWrQVwLtmrM3FIYiADMh8DDv5QQjYYAAOzvOYXhpkVbchVfrJGtcpY7Q598vl9zWxmV2a1sTozmsmp9YTwhQMfLRw4+o93/98D+d9f+8O7/3w4/8/v/uuv8v/68F8f//HgHw/98cgf3/7ju//2af7fvvzTh/k/XfzT9R8+z//w9Q8n8j+c+eH8Dxd+mMv/cOWH6/kf7v37r/79ev5/f/Af5/L/cf3PB/J/fv/Pl/J/nv/zQ+/k58AlH/NOfgWP097Js/A47528CI8r3rfAhX77lXcKeLVTJ7zTHwCP/K13+jTwyIe9M8BMnXngnXkETPIn3tlfweO33tlT3tnT3tlz8HHNOweM1LnD3rkH3jlIdP6Id/5d7/x73vkP4eOod/633vlT3vnTHpA+7/w17/wj7wJkuHDYuwC8MmS4eMi7+K538T3vImS4eNS7+CvvIiS9eMO7eNubg6Rzh725B94cJL30tnfpXXi8712CtJeOepdOeZdOe5cg+aVr3iVo6aXHHtBA7/Jh7/ID7zJkuXLEu/Kud+U97wrkuHLUu/IZPH7rXTnlXTntXYGMV655Vw95VyHptUPeNWD7rr3nXQMIXDvqXfutdw1SXLvmAX30rh/xrj/wrkPCG0e8G5DwxnveDUh446h34zPvxufejVPejdPeDchx45p3E1px87B384F3E3LMH/HmIcf8e9485Jg/6s1/5s1/7s2f8uZPe/OQY/6aNz/vwVLs3Trs3freu/XAuwX5bh/xbkO+2+95tyHf7aPe7d96t095t097tyHT7WveHajmzmHv7gfeXZAY7v6Dd/dzD1Zg7+4J7y6kuHvNu3vTuzvvfXfD++4W8Lv3vXsAwHsfe/c+hccx7/4N7z6E33/gfQ/s6vcfe99D+PfHvAdfeA/gF6SlBxe9B7e9B3e9B/e8B4+8B4+9hyAoPTriPXrHe/Su9+gofPzWewQY9OiB9/id9oFLwO8+ah8Evufg++2DwNgcPNY++A08TrYPnoLHmfbB8/C40j54Ax632oeAITp0tH3oE3gcbx89DnzoifZR4MOO3mh/Dczp15+1vwaG6Otb7eO/bh//Tfv4zfbx+fY3t/LtE79pnzjePgFM04mL7ZMf5tsnj7ZPQjEnj7VPXWyfgfAzl9qwILfPfN8+C/zW2U/a54HfOv9l+8JvgYf8qn3xM+Ahv2lfRFbyQfvi43x77v32HCSZO9aeg3xzD9tzEHjp4zasfu3LR9qXodYrR9pXIMmVY+0r0NUr8+2rEHf1UPvqt/C40r4K+a7eawPitK/Nt6+fAc7zbvsGJLnxfvsG5LtxrD0Pj/lft+f/AR4X2vNX2vO32vN34eNeG1iq9t3HjBosHHi8cPDAwsF/WAAhYOHw1wuHv104fBberi/MXwMG7sbC7ccLd4E/u/v4xwNzwFld+/HQsR8Pffnj4e87X8Ca/8XFzrFrnWO3gBd62Pnym86XJzpfXe98daNz8lDn5Dudkx92Tp4GxuZ85+TlzqkDnVMHO6cg7em3O6eBlzp9rHMayjh9o3MauKgz73fOAOdy5krnLLBEZ3/TAZa8c+5w59w88DEHOgDVzvljnfNnO+eBnzh/r3PhIjA2wMMc7lz8qHPxaOciJLh4rHPxe3g87Mxd78wBvzJ3qzN3tzP3XWfuUWfucefSwc6lS8DFXOtcut25dKdzDRp3ba5z7XLn2pXONeRT7i1e/mYRuL/F7z5Z/O4kPK4tfje/+B0wD0eBh/hk8QHwFw+OLT54vPjwLBDaYX9ZaWZdVc/th6Umi8uIUR4cGOgbBNahMOw8q/c0dHPSrQ87q8u9uf3GRDZrrC7ru5zR3HNuji1HXcXhIHx1EWLKflRhVqSZ9SusQoVGbj9fy9xnBwcqfYPlctktuc8OFWdmsvBYWxka4EHF3j4Ko3YNVNznysW1he5uq8fVHTc7AouvOdkzYVtTG4Gh2WjV9Kyby5W6il3lstHdzXqXywXVN7KG6vjVG8/2r2PVGyXj2YF1MzNdWQOalOvuhic1x/Cbg0lYcwzRHIM3p57eHEM0x4Eym1C7npuZwSe0E1uGUG+VRfvYaND6XIAqdcijl/fP5lRcn3sa2rjeKLvsY7c+vdeya2VdvLHgcR3GUof10y53denSJ4uGZdh2HT86+GTRhrPFspoUxV5F8HrHMSZNHsE+WFTT1ieMfRTBXnmw5bh+OHvn7TNMqEBnz5kZZFZYRKtZA3ZrI3BHwE+UMXw2QNMaAwwfNmQSWhCyP+hdqaugUpElfZYBdaIcjp5Vp8r7g/5SyD6AbVDJZKiShEHwQQ1jsG+XO1oWDdFZlXvK+4HHLLHQDLGbUznV1ieBMxKh7IsiHEIXEcG+KMLUpnS/FHinQM6Pbq6JGD+AooG1EhHwCrzUODD9u3V3iwjdlYnCKwwMP8cOkWOUl6L7ZexfURm6X8IslNDUbN30S8guWwKl90vIQQlVa2pKEwFqRp0A0OlThggZppCqBbKHCCpRUM1yRUAPFPNWC+aoESSqUCIRuilIXMHUmg3stQgpP0dpXR2EBgC5CBbfkNwwgfc3ajsjKSLBkFBvNIymYzh+y3p6qOxxgP1PW1aQ9e9pWGtWo6HZG0Kj8JPlh0F/y296LK2Yvyylxt556rHlkhtmdZNeFclXr16Tz0MONvMxNZ/riQPLEvGsXWv+n1hVQTHRvA1rEm0Qtu0o1bKZmZmMWvTD1r+yCQO7uzNqL4DRcPcajs4TZtQ+P+hnLOwXGbXfDxN5QaBEmLVgrNxpDCmX13SV15TpASAZxFncIBMHrYHxz655bs2z5TXPQdxaKm2kbky4FANRz8F/wJh10OdGy9lq+OAFcGWSqdbQEp0nYczCwv87dLyQowT4+Qz/BCmsjt9rgmhKwmt95plopbM4X7SG7lR1zFepEEDHSFYtTWaZ0ArIOoZyKwbgk9B0jIRYFgQvlIYLtBTI3zFcyLcYLt5ZOIm7LJheWck1i4IsaCxbewg6kWaPoYSM6fDJ8nFxGQP5K9YC2SjEsuXysARB7ymav9NcGzMmMMxA6jnGVgH8Zm+sLiZ7Yyh7w5QkiGMQvbB0IJZTiE1tgbUBv+DB4eW4HFiOiyEkvGMIvUTbi0I9RcITU8Oo4ic8liUDY7iysqaheI99JLGcOkDyOYWRGE8twhcWxoV6AjV7ZT1jQj4LJoUAwm1KhAklAZaASzg1FJ4sBJUSDCwttqaNkYaCBkKj8aRRIKgbZspMWTtLaYQ+gaUVX0vlYcoPqp/enoD8jCEzQEMIzyfJx5QsDNXxbeV5Z9Xp8po37DfMyswb5swbrd5C7zr2GFqjjst6kukex2rZVV3NTMqc/RhwwoKXKSIf487MFPvYc11vX6//RmEBh7wb+Rlk0X0GyEBuuOxyYQCq4MKCU9ZBSDBAOlgNqSHAhkRVzviud7NODkWDsaydywnV1bNGvtjdTc2w4UnNCmVZXcxVnNW9JXjhwkO+SLzVSHnNrjdaxcF1BQRCoZCnh0YQmcDfAfjtg4g3WhP6xMToGnVjeU22UnrDmXljzRtrep7BxzO7fjH6TOWNZ95Yk3tmzaS6t7xt/E296vagjs9CrFCfL+/tqWvOtr3mdtuCCeJOq5shyLUYb6+uF1lYopmZMOfO+/l8DxrMMcZQ3V5eb9vaNPLN+JSziAyZXRaVqlCKUVh+ypt5EVDAK6LOKpBlV8/ihJIG+jVpoF8BrhQElFcEcypUab8ASGRWuz22DnxIVc+uUaD7sD7mVmdyP8nIAtJOqTRf7EqWs0pZN8/lxaQEAwO9Q4Ors+5zz+GiNDDY11tYnS0Wevu6XSH4bKEhgnHdtI5GdNOGF14YzVa6MGQjC3kBQnIzmOoX4WQzv8hFk61Rd0QkKSY2GaYupCZgE1tTZlmfHd4RjHqPNTHh6G45PjAkauzI+sXIhayGsRnGXmwKVYpTJxC1yjwLENCyoeLIdSHKsxn7AlB7mFssNYWEonKSbLItKqcXSUYfFhMPZ60DKXDG2c8WcqHmg9CZh8m4ejXIvmV7lkC/obxfr05pr+m2QzwxymGs6p0AkVLGqdpGEyi5ZW42HZgHem0EeG7OZWNiy9xpawYAZXIj488xEFDW2rtDhwx79FooCJuzreU6Rk1/QSzAXUUWu5lWjedpPXl+j25P763rtu5Hr9+rGW40b1D2CC5kPHqr7tYtueKXgDXaoIGUBYVV63p193YmNb2A2nsH6W7DqhJj52AS6JS1W/d7iD3TTZd92lCMTqkAcSZtbUoGGo4X+64ZNszVkUgo0HkCynaUbrCQWXVruasYDPALiHQ4MDrJpGKcUTe/IafvMkbLbnf3elKeVFz4LG2AHxztDAoWwEegpNojDWkl9FUu6uuoJdFU2a6twDoz8gNl8B0CZE0sRE7+0rNXs01AVWhzQZXDspkREAl0ZT2aEivrego9BVWxmgRQuR7FcBQbOGwATq3nDXMTY/zQoNm1FCDhkGu85dI2hLLXaDQUx7WaCsjauzENbVDoykQLsEgH6QxF8VDnirlSKOS5cm+hOICCuxyah9DCUE4VcAhhKyUOhYQh9SyICDAEbAq7PSHsApKrh0PKkeYUQejYDok4guXYWMMKKkKG/bckMuT0NFtOHVcDvioqrDCOoDlqvP9ZTlyU/ECgAqqtaqqpWqwZ9fJ+HPeSUclsgOmwG+TnLUDsMioIr8CxOYw3KdkqULGSNjsMrICYNFBxHb9otdlEpIzKBVj1sAlDKei1vAtqHcWxo87UoTNZXZW7AXFEnF4t9w4MBnPjrVA/emeybqW/VIBVQa+sgydleTOZCHNULLtlnGCqRGpxbobIbUit5pRfy2q73PAgDlYGSxm+NVYOyDgSzEqwZzYwmhtmRDmTGe4qEL2PYppddpIKJ61naHoOlPpG1ZQ6sZzV5YyiIX3ESUEd4ISm9jrvhc1aY5azdgV37mBwYdnH5Qk3LofjeUYoAnKaSSWO+PudmALL88vCQJ7FMJstt8y4gqyeE8um6WrAqz/vVIH0qUYlK1SFsDT6S+wILZtBKT0gk7ibzZq+bxsQuzdALAAeMre6yMts2VtoeQ/SOw0DOJxCpMRcj9ME6T47nRN8bCmoPlJ5IVx2kbcf50h5Tw/QR/ZNs6McaDCdoOW43IvSpcgtMFFEvP8O1Wy3HINQ11f0Oi7QguelVDxoRBQTVCvHlCPZI42ocu0qhxbUqTW4xlVUDVKdvR6xFehfV0GM5lZCwHIKIooeEt6EcszMSFGbaGU09ug+4HNCWQwCJrZlPSrd1rvlfDEpYrP5gmUTM4DoQwloE367GEGaCOGvzTUoAIMKkgrdKe8a5UpnwKsJGOMaYz6cJE5bJSmFt7i7O0L6YfH8m66MSBHGwF6gy6z/u40mohKnc9leQYmqIGPAwFV3+y3S0RhhBMOzRX/+ocoYkrkytnH17yvalF/CrPpieb9h+jzSfhjvCWOyZWvjwIegwtswX2RneCw7MXY9GmAkxFQ1kwCfEBXwYGmRbNzTkrgIatFkZ73zmpZa0Cv63k2Wu1OzJ3U3sfkbUX8xQvYZtJDFE80Ovynx/U3NdvRg4WCrIUdhwcRwZs/HZJhlr6B4kxsWUhKGmzCFaPUW84iK3mk1t+h7dCbGvdgTDE3PpCxuiKUt29stKAJwiS5AgiFCrmeioU06uecKrBR/DFOKWbdcMd3dXSkpOAyJPd4MBIJVSGiRUln/X7cygWnR2gRHzEcnmDmcnOeLw+5zIBG5+bzgoyMJQSZGflmPVTszo7PGdr8a2tTs7ebhOb+rejAS8ugLcsenewL/CxxgH0chEZsq2yAYglkVBYQEBA7RnfDOQaoiS0NNVFFjE+0pR9nsIPQE+jAzYyS1KS5Q+S2SpnIKOhR7w9gnNS6ExQnTPrlEBuGE5JtNVq5cG68p5zdYJhn/FZDsHVgnQMmmSpQEpYBpqTkDaIgwerOHKV6TZ8EuPEfm25qJjXo9nx/Oubv00SAKPgJxknrLd/fdYHd/dQ5idjmjWcOnagY2IEIfo3uwWBhw8MBbUcJszs+DakzdQcRf78YYcyb5+AUA74eKC1/SkUmpEy2O1eFitPFL3V5B22ZVvqazlZ6r9QzdyUorgfoi45JfKsuBr5fXoOJsVRb1iG/0zOz6xao33hjNPVPJrZrJBIEZHpjJrRl+KcrrhKQ5ICppBALES5/24HChamdjwPui/mp1eSOghF7NBqxGbldhVAwjI3qvR5NwbgSEK6RpXXqIxGXwrC9rMfIwWX1XcRTI4a7e0Vyk+tV6pCojoTWAWQa8QobVRpBctWXmCLW9TDnMdZ/DWLM9M5OZ5S/TzJoCSwAGqiu7Zlf273t2rX4jv+aZ//7sc2W18ovu0TUsjZ2DfMR+2cCIlSN8mKhqdREogosWKkGbngi2KmtkEAdrCdD61atnZ9WXeoAyJcnsgcxQRt1N1ucTAK+7QGqFnIbDue+W1liuiD09aArAVxgmelC5XVHZijdpyZK7urhdR5AqS1qEhEYC7wmonFIc41nl2iCULyotk2XVa1kqCJZ2pkv0NYmp1F50GWQtXpgfxCwMfCyJI3pYApKkrxyDeXoTxPSMNzTrb2GE5m+CcjTCAiSkSG5hSORD2GNbnaRWCpBn91C8gLYRbXHKKGgTIGCEVLcRIiqgIFA3peehImK9DsVmY3KqmiTTwprL2+wjYIB/iViXjmvBdzwjNM1hsl1X2a24pQBD1Myrfj6FFpkM1/H/MjYCZL1e18waN43ibIoMVyEIwDJc1x20aZfThiJIoULBzBx/Oy5CIAfPworC9NaaC+NmPg+CsO0kjBi0Klz7c7jTFvR3h1619ugkB2UjKdUMPVBFa1quAsvjlOEiBAhVSPMKq6+r6MxgPpPj9F+vuEm9K7nxrg0bSzTHUPVKhuXlCmGb6FumlNkuF6Q0GQxgTIicIFgCziANMl2SpSLngaJjB8uWK8M9tFAqBogVMzMOChf4KvcCmp4ZEWXhSQHaMVSYTQ07XAAdUMgGSLHMxjRqsmsAS7tVhbKxt7xPTgYWz0jpMowcNbNDJw6GFEWKNaGMjRGnMjbmV5zJ+XD5O2RUSbjYLJTtAEttyonhsVChAPHvCmlR+MwS8c+GInMhMIQSqhmqHI8D8KFRgKAiZo3riuafdmBDzKVlUWy8VBGjZqg3KyyVLa4jdMiDjTETARKWwjCOBfjElFxIBCt8rYwXBzMpaE+ulCFtkzFh6HaQGxiUrfrUuG4nFc2Iy09lrnP4p2HdQajJjMdL3A4GntHtGbdq02gvSy8gI+SGfVLexddTvmVolAM1BamWSDFF6qWuAvLjrAymqjdys2JVEKJuLrACKACDx5u0W592somatRxIHLZkT1xkzdDKNsgdwyl0KqmgXdqoINYsRFmVWa2tzqwS9IsnBySQFy6tpjUDrhymecOabOkcUhwL+bIjqzbDuqCoyhOno1MndRA0ZzvTFIkl4+Xy/t10LKhhWc3MrPp34pubDs3CSBvOlghSLiUiDM7MJPBtmYaO2n+fyIU4W6625MJBAsdu+GlkDl91onw0N9AwSIoYKgIGA4EYQisSxzf3HqaFSJYvir19LKXzHJoDDHR3O8+SJUAoTxXIGzCbgXhrl43VxeFGNq0VNjGnw7nVq21qTu9ylTBUi/GKhmozqchkzKSWSzBdV39KJs/TZlXoH5J4xqTxWpc8XhqWtaIRgzVs5WPG5amu7JKcMe4FGDkUm3zbt65yEmSM1esgFfyGo1ldsFgAo5+GI5AT+TIxGi4fjRyCMkxwknUDQmAkIZwPm6x4ZRMoKyzWkQ7naFNtTw/a2gHysjkBo7ufTt5BOLNtFF++zaJMIqhpGzDdRh4dEEZNtcXWYG5YlOJbOMZK2cRjpAKkbFZCBisxKVoxxtK+YCWX6xs2ihy+bQkJ+DDkxgQNNojKtA9CH7mllJaDPFJmryX9tpgQMpy6iiqwXH6jmG1h0KKliiPdGRZRCPIbE3EAbJ5I7D832YwlZ8YniVm4PWcsywiFJ2Zh5p6xHDsxODmDPZ2Q3J5OTMyMQ8UXGo4KvVhZMGTE4qApAhmUspMlS0EV1YvS+DhBZczuNNa21zE4sXVkihpPD6FJyfnZgfgUQ71oFriMICnZ88cSPj/VdJPBxK1QfSRhBqhL0OLnisBa26RA4Kkj+i2Z7JpJRNcKiK4pLZT1FCJo0cLSj3uH9ZmZfjxjVM/Fe+jzhPIQJcWjUjtJEF/CgAqtUjjOSAw1551WMSisIg+Cqxg8VylT2jSTU7RmU8c10yXxD21xGsiMZnJq0v7ukxTPS6Za6LzyKsnsTGEbzKvQmiE0WhVp9lMAYEMpBCcKgyVkWNiX+xxrePGWVDmp88aUNsTTCV2BCB0iTLMszcxqOXn8hIbblpR5EYmhSksebxZT8ZAyJyd1fwtSbr0mt6SpVlU3Ao4EtKqi3PzTpZa56Dk0khP4aQC0LxuOQWcFeqiKyw+ukUF4WB5BKFRig1DKiizSqCOgRK2OpJeTzJFpVyPY5Rd80erVjm+fHMSi2AEowmzBeH0zMzY1qeyH0CdxeUxfBFwA8PBoEA3LKTH2qHumwFyOAEVMMMvc3W2wMN9qyxFa5FALw1JvoIoCtHW1KjobyKwWRjQhkQMNtrB8fwAzpUxsUDMB3xVjS1KVzvIYS9BOEntihcoVWk9WFQcLCZ0voyRGcmySpIoHRSKZrKZkxAKolBVLHBaELLFUEAn98uxUl2CCKlFUL60ILlZ4IZXAInNwcf0kA8iwtImd2KwhjjZixzwgGyFhgxmHVWIK11KeJLREsEcMUQpRsLIzfbJZFE5mAg0fWT3Q90kzWw/RVNRYqEx7IWkkGEOfG46ooRk3FN0MYPwSiCliVzEqK8AqApMEpYFSQKKH09BP8Eskj4L0EBtWR81AtIHaiU06sLY2WUECIkbbapiRnfVEtjosF+KxTeDGSbbuqQXFCzJRyS6JDPEmVNJGoeQyvVoZE0TGZDMSfycHRHjFY+hwc34hYce1E6qJJlvM7ccvBc8UXSG7qEYUTRnSqlbYxiYM3axZfioA/5dBUevuNkOUvC4o+c46upaZcPOkJkazCtTfaujgJQ8vuIwQa4TaK8rCGSMA3aoeQeVci2keSTNWRzHLEnaVqPDd8prW4HsE2XrSkNZzwuIxUXGetVDsUlc85nVJnI9xRzGxfskJ90KQ+OczWaNSKP0kh/3TgxokiW/ZdWQFpB63Sx39rRYWl7i40BlAtPRDeKLdnbQC0BFEmSOL5CsFNnrhBUHqhLQWRKTT1O4FxmNJNjuJByzSuXNW8CrFYhkQHX11UAIPvDIuT5icMEYvKwUkM8RxXi4JahH4SJCLCOlxRXmYXe2pGXioZcowNXNZ/ADBMrAS9dc9JtEm8Cp/l7RoSmY3XcWIIp7tYg/n4qscVh1b5rhME1rlwlmGhdggQU9XMwxGG/H4rt8v1mQ9tlaiZb40MUTvOfycih6dWTLQSlkjdbsxtvub2YqHP5oN3d+3gcWuBU3Dk/RodsyrYva34TFgAtEsecrSE3Z/Q53gxyZSdjpy4fVF32e4vvXXCqCZxrwGfGgYkyP4KmFyWHm0HIV7GsuH+MaalDCzudHQJ7UGGk6hFby/8YvnmYkOPuFETup9uI9ik+RngGZix2sjnijfSIhAe5UptnpMfgWByzAn17vWFNnqJW69hUc3mJp6pa+3VEhbPWHJqvSXehN53h0QGoyapMNL3MPxKc84arzKUQ0YxiBH0NBtya5bntYAj7Axq6QETyHSnDWvkHEzwFDSrkbAmxX8QNLWRbGQpBwRhQatDRE8TBAR2Liur+hDM5hiQecTZprUWGkjr4cO+JPhn7wg82P/8prMIczXYlETkIugiPDqKJbGrYZD92wwZ33ogY9746vyxiTitoQJ0rSWNa9PxhKhDOISDwRJVzS9EsUSvyVhSfSvwUI9obTOPBuskFCmys0hTXNqL9h2R5ziCeYHmetVaInBEqLOMUbPe9iJyGXYhCX6y5w1JHVO7oPUt7Cye0XaknDB4QKkkqMawwgqoj+sYOO1IDbc2CAN289q/v4i7dpru+xRoSTTw8YwAsJUIW7L63xbXmvYulabVphQS3vzokYzYGa4y6kK06uVItSQbdVUxO45P6KboE3LF4ctNNaxxEmAekjtZ5Haj2QzBg5iSdipbFormRYvmkAiwGqd9H1lM6SQlyfDfvLgpKu032+q4ZIke7PZJZHIqeSZLsAQp9/Yrh16SOCvJackApOmFteiGknoEsUKGRXj6uNkQ2vZ/EWcdF+GTiWULdVMZDtGKglXhDcK2tUso6wa8dCVxM5yM5g0Nl6ozEJcezKjLnPeSazksC7Zyzj+kmWE92DL/koo5rFogrwwxpdDgkuKJjFtaNBUzHc/ILpOMlyIwIfUd5VAR5/C5cVKYn7bImUxZukJSvO5qyVoKvrySeIjVrKkyBrXMPg2m4m7HjE1UJLSMHHVpYP4bB+H7RnoIWUe7h3i0KC9nZGuJETjkfDmPd/t1Yn4wLfE8VJwrJIatSLM+nOXf2rWqCA884aZKWWYHgqdgTBd1B7eK0Uq0ldQ1bU9ICAAZrPjo8hJkYyACi5Etx7bmKy7ZaOSIicGwVu16XFuTvd/Gx+g9zT08sYJBGybSGHjUpZMNwR0IjRsaTACzxwxxl1IB6LszbWs7XN5jKPV38pVbDaBk8Gl50oOoADzIIW+LmMag6dVQFecMGrR9hZHpZkZPUlBKlRCCbpW3omADqQIoBstNK3cp4wzsc63ihU+I0IIx/CRW3qWErZww8rzQAUgoYAdn7uITTm1K7T3OjWl8W09f62X0WJzLepvBkCVKqWmiJuQRaXJjYSjUiz1At/PpeOfl4vqT8q9gSeEv5VJFLmjJFYMzfV2GaPob5x8a4mjNez03ibfbJgRCm6VOqm7AT3p7s448vfMTNYuM2rhGlXgumCCGEAhWCxQPgOzl8n4JGM47B0P8Yh3Cp8Mwh0pvSOld6T0Io1dyWJ3eGcQHKWuLgftWjHUJvj4IHHdENnGQWu2ABHIqBsAJMzicCWOILbDybTj87PQoC0GDIvWCMeL8zZ6bjai845RBjQ688/XB6ptsUWUvO+wzFztcnKxiYckpbtb7/5JohVDz6Q4IyxLypgnt9RW5zqspocMFMsActSD/ZyCAK37uwW7H96+jyzyYqO+CzMhxfgJ75yP+cyOmiF+aImTWo0f1IxK2vFPnCmlvlxOtu30TdDNsEMAISeEXAKEFnTfkUAhbJAe+o46E5D4xrcE2GTQ5wh+ZI8tyELoMFclBrWSpPEMoRkz3vddmITiNsAKiWsa6gvEnqXfHy3SHzOpP1bCEgkth0WSVyHzNyU/VLJoj28GRY8b+Md2YpvITKnkxOnmFsMJeAFV+HxIRlyZvKYefsgGzSRbwyRvYdLuu1GW0HM4xMYXomaLm5mL4mgwHZXOcjMhpxygDcXSyOXUOJMAQjg/B2ovLcMsJa2Y5Uhjnm8EAgsTeLF1FJUbRvdOtiTDmEDkY+sHoK7JiSJjPvAgi2WzcFwZKlktbRvAFOqBTa1mw6ji3RpSEcLHkwPzgt0rkSEoFGBOIBmHCrcLh8cyDadI3qS/zcLMz6XXjyl5G4JClFV/k1lt+kspaizqWqCyGNd1U9JbhI3wODYYEd1RwLKGOQ5/zGW2VUaEhFlYYbnCE5CNZtLsk8c5USctbeX5TuIAHZaxNlGNOIo65UwGUBe9tOGPWc5MEbpkgNp2BbYlEXsUxlAAILFFOrpFCJm7cbSOW0pGz9VngWM2hgXjKfWaO0SxXf8EZGjJrEDjCiVoO28IHmwxOJsDdLAL+BCd1sFEYxpmue8flUqtObpQYs1iGUw4XFqB9rCyS4Ty1AyEDjAGXVouBCFaw8naXSTsginXZYd0XczMJXEAkMcSkImODR0kEZxGaucqZrkOEKzToSCnAuATPBe5dcKpFMGW9e6Kj4Aa/kwsO7H5QJHy5IXmlpKJHLYXcUR/1ne8EdZObAFejyMsDBEIMTBAGgNis9wlUAJA7+IpP5nY5dRquQkRw/AjFxFRhkrUZqNE52D8V3EpGoZiDcAcFdC8N9h9lB+blVCNJTO6rjDKjAdYVDLspO3QSBpyVhF26fDTtFFd9iQ2jkgMjoIgRyPM1lR87uFxx6TD3OikXgoXxywSSRq2N85SxBtUyUaXp2BapG4MUEW6I48QiJ381KuCAKjBYiGVu4rtqUvI7wbIzzYNpCUrG8JV4V6W8NSNEHA2uglKB+FlF+WaWA/5AhzuoJ2Og3Rw0mdWEfmeJKepEMVS+ATAzslzBvL5RxozuZSCOcDDqiVxwZZ/nJZBXipNsPxcLJNUJGxWMGAJIZgLlS6Xc9Ehn8ZZzgT7W5lj0ERDoQjcEHfqVqtRY800LYWVAXDLOOEqik9RhROvQt+nVd0GGuTrrK6EqjI7dMflkwPDRbWoAJRsyRPqDdLxFoywFvBTtegYhE59+71M0KrG+MMIHhMFirEhhBwhgloJ7cTKhDNhSioTdLyYz8fwdFwxDi5fC8fCUGV+aasyUX1daJ8+wZ0QqmtiToTiQSRZxPE6pClNyGXwBUDySRgSb5fZlBHEKH0kJc4rTH+FeCIzkHzrkDSkCU73JLEZjwUuJcIYS2y4RA4op22SpqiGy4lHeKVuRiEQ1/XF5flsRP8ndCFiGiaqQEjflytluwrSjmpEmwOlUqcjg4LiW2Q4ApEubLPIfPjnIlr5kdY4c/Ts8KPfRaaCwHrCYmrcGGe/kIpKSU4TgX7USrtGZ0NoGPVZKLza+ipbnZb9kFiUZgUUK4pU/ei1SxRFjruwHcPRg2FxT9DScfbk4n1XRjhKjqz0iqTc5eSLoyASFYa1Z43gCIomZHJjlzY6vB7WKJOdLUFNa8WmdgrBu7SMAM1bzmkTk1+F7DrVcmh9FkBAuRq5GLPasJhhC5OtpbNA7PDU+kZDEjJTNhXTvdsVhdgQE5kyaHLdw46A6fLsYEfIWO3EBsk6HH6iCzeURNa4xEBMh19yzFpQbge6ps9IJxa6AqY0ecoJh+yh+SJr8pff6I5BNbzHbtluiuudBNtb0twmnR+MVUJFDYflfd+ANFREGNDBbSxxOIf3VMrRBnAlm9yIJWAST50J2ssYoO1B2QHZz+WWa4UEg/TN2VAhkoMPgobII6GfnFreWOLTNIqtcnJUcEcCuJEJIhggG4l9fOOQIxyt3biaEzaEOsyN2aSMURCM+FG+zX5kPrJ5kPurzAPWzMDKuUB7LkHzho1n/UN4hu/yA31fG9zlBwHvVVN4mAbRAD2LN0J7ZRjA4etHy7s0PDDG7orUgmquV1g3lQbLK/mPQeKroNLPVAQ18bci0ZLLarnK3yPk/r4HpnBoqGajtCDEiCShP5K62lJEIZkMh4lwEkcUKyY6zWJLacIhqwn/7IDv3yF2fjbVJjWJB+NDkn7qQ1f7Z35O2v3Ay4xkBEva6f0hdXxyhZILAUOlW4dwIm/elGGHk5w0fjqVUXYQoNL0jnuYxy1Ffm9fl7g6gRkjRXYa2aZrRe9hhmGMTc+p64lWp/vFklTluu/rBpd5XMnQyye56Ptp2ENY0sIiNozJKhr9PoabZ+RipAy7yI1F2DxXMBvj9HhNLGfYDxDeAikcbC7v8SfebqhX49osrI/uw0mszoTqLLxlgd/iPWw+a4nKTL+yetnaZY4O12X+O1pfndXnC0FUTyU9vRi9EvdZhtXLTVwyK1rJQM6I1G4s1T7dN78Pxjq8TCW5gwtTZX2FpDhaN5p+ME4xfV2Oqw6FNUNMp+ebrKRFEm+aEukfUEqOlw+P+l8RyhWhkP5qmeBjK43U6GxRWZqN1SPsbhJPvFQBJV6LmjQtA344ePW5irjpYKSrmVQgOAlQAMYEz+MEonxs/7ErunmzIzdMKGjk6NiTmMrRQzxoWcO3omMOKYOiuDGuHj3HE2k6ercV664eHBqcikyOdEvqiJoaBRaJy/rZ0mwQ+StIZMpYCySmbFnxJFRPtFVJlcftn1YmnrCmJbMhkWanSOBJ63AP89axIjEvcVLEZpcwjMgm8otBhWSCyPLKYclaFza5epcATNJ8ESAjtuqpoJPSuadvZrQxsdYiwJ0mzKWnaW9clRZFW83JSID/6/Ur3ux09HTiPSLn6NwfXYIL5WzsXGAyNLPJ9oC+DB0vn8R0f7gTK4l3jabs05BYPaf/1UhsSmvlRsZNIKNTe4WO8aRd/wiJix/044JeNti/8/FzCz8HyYOTvaisFyId6fCFzGeY1Uarhmr+Bu6uOC3btiaBn6HT9rNxh2OEz5zZTvYkGVpmBPOllwvD+rNueA/IcPzMGzWQMdF8PovcPN7Qp5P3/p6a7z6ePoNTFtC9vfy4Z1HNF3NsSzdeYOqqlzgcA93diQcz/JOUEC9J3PKxDxHNxSD/BrlQGr7vml2VWRVxo86GaRTYu1WZ5ChuCqu7ISepuhtyiBATzZbEPrR+zgkngsxInvwEylJRiTeFOEjoH3NJQZ2X/LBHkG1jsHe2ijKsQq2CEdgaGSYdt/c3T4ND98NsGlIzwlIWeTkLS0I8KCZ+sHBZuCjFipXMhkqs8+VIhWqiOMK8RBjknC8s87lPJPOF/FhoaDIXajBtnXIL5VCfKUJIQgLrwg2PJwmd8ZTi0r19S/DyBcJSBnfFyFsi33ZN20lk7RHm63xDkfvmV/gusgVwo7dEzx6cmqEKV2oKQSJp5EIgWnbg4vWRiaXrS9GRakeaaATn45KoVB6vxC4IONPoJkrJbnQoQxCNjtMOyf24I2g436eNeH4OQc2vWQZdpsxGEgcXDR8idaOEjvezwWCii7pV5VWKSIk1++rCCRxHWh2nUU0YagYtI2KEYt1X2V3QStCERCBiQyLjkeaqupSUP6C/RBLlcjbWAR9j+RP8xAu0JiqKKlPMyI5H0xhwZ36A3GH/NuFxiPm/LjEH6yyJ8NeXuHoneIUX6qHliFTArUQWC8T5iMpEuiAn8IBciN1ujURM4EsI2jY6qyGhl9M7d5eRL44OD4o1LWEdQuP9bi3JhIMTt/ABLy1xxkiCX5S8yfya7nKNMU3oJ1B3yDKAnuQHQlalkg43SQcRpiO5oD3YdW7s/XRyydIAjp9WSN7jSOhXwtGdqF+aYNSkHkn5VswND+Zkj8YBP6IEBnKlJxDVfGqealHPS91BPiwLid0LLSzLunSFdY/Y4xTOOQ6f2ByMnkPfNUrW35Lw4+bIXY5WQXPjUqKwo0elChZu8411dk6Xb60J+pEgG7myK8fwfTSNhtF0DCduYC9hsnDOEe3vZuCq0aze9g3sExq7pBMd3yDvia7rCJ0ccDllnrWjAl+YQFJjnUDos4MhjCdMIygBheCitdyN0LWoCVs5UcjpeDtwEh7FWhCne3IbkmQFwz9BmTb5l/THH1iBCVPb4SR3hOvZUbXgqjM6MwuIz8/MLnk0NuyFMM5VsDkWUbbE/auHz8wXxMEUtIrUh1ckE4XdayTfDSwkc7JwSb+Ghp9FdioZDnG8nTi05mdyq11u2xL32IFG8r2sL+RmMFE6S2RoIDXOn5rhaOyuW9r9BSZmn1Elby/jVstkZn/MLja7Hu+pW1l/gHay5YSrHBqag75AjF0sP+3aqQNdgbEXt9VhpsDsQCdaEnDXTf+/YtycZTsvRnKK8kr3tWRWxsqKybHiikKXDYXqS9M/RjnjJThQCTcjqEnH5X2WNDz5+JyMzT4+v2KTUA3NuIj4/5cI236LNpumbosjxxq1ZjYqX8ZqZHus7lPsscaqrMtVhuAdGx6WMgxQuaynhGogzS/RTF/6jghMCaqWtNPcTGyL5A+pZNJyBlJzkDsZVJKrMoIVO63opp9FJu1Gma+5Bh0dK3d16eImaUbER1ArDcH8OBvOOBtIgjiHE5wo7uoCbgD4t/3jY2glXUKvroabzeyns9rqOLrnt0OhBQx1YXz90J/wxM1wEVkRGioiy4p4K1zE32cY/6pmkxb/Htee3gFSx04d8miuzq8Unc3l1Ilwnb4SjqqeCFctRRZE5BiAIjEBWrHwK5QwbUqyopxsVrXDmk3bjdzMHt9f3+W4PQz0o5gdzc1T0yryxe+75A/fXRIrhFj7zU7cxDts1+5fF+9viKM9rNvDIDMz439i89CIqIuxtg00KUI5zG87yL/iE7NWXGbww4oFbix656V0M33laVwglngFKACI4nGTVLyzuyYl9zXiS8PL58keyrdP31Lh/eQzgPUSPVRDY7sCz9Tii3WjK9qPXKlL59OREEG+2zthRCN3YEfHES/ALsYuwPaHnvxehawodEYXfJ/dwRSXbj+yhYufWIMEbqiSt5xhQ1hkQNcJXjWLX94g9RsFOCDRRrhkdFqI3BeNon+hgZzN6BnXAQi0/U0tEzQqqW0xjO2S7mFdekKU0dRGoEGk+2LjLA0qJE8UxaVJ4aLDd07zKDJcH3bLoakRt3aRe8LGjRxhxYsK5L0A3C7HMumcYCi+gN1lmL3EaIfr8qVHmXJAskowLfzJndQmqrNmNYD13bBkzUkVU8m4GqSWzA55Loe7ZU4UDH/u451L/jsafwYf6JZwON4WHXvc9HvcXLrHhlndpFfT+4ppfCvMGO4xe8glegVDHcwRv+lRmtfdnTQ7/G74+RgZ6O5+GnrrU0xO/GXymUtogDwBKokjzhYVYXcdi0wDexFBSo1Ih/rK5lt8sqWN8rhW3f3TluXqyyF1DACMyanEq0ru9lups4C6jWOxBLaggits95u0dkgrjEw7QZKVlv5KNM6PIT4oMRYiZlMAiCvmspNXuNVO3eXt4isQGupaE9FzwLH1eGYmQ45TEg8Mx9fmLB2W18tdhQT487s9tTB357stMl3pCtL0C0LT3F74YuC02CyNqgakIszIRaWzmiuOQFlNtJiuJ+nEupa+KCGi1JfuO11ySLLBgWn08cNOD+ObfyevsC+nawDppDMX8Ow0tZRTZtf2yBKXMFeAyBEyTYDs3HwkLFmxIRD3V9D+7vAy2vqMf/Wu7+nKZMYBGuIDG268I6hiyNcKP1vAsNAFz/wodNqJLzvYAF3+7l9yz0yl4u4XqbmZEK/vcsqZn2RW8wuPctmguZWQRs8kyWNmxgRGkB6ODlKSCNyljaaqvlIbGjSPmSlRa0bL+zFJCcQgqAgfDj1mh7ESJAAg/mtu1Hlgup9GVrmsbt1iVYVbnZhCNXQ+KrJVsF/yJiXrbelAOfLfmjSRnPIumytaZAOx4VwoUVTPHm1KWPUtqXk1PJONbuyresjXS6CR19xYkamWMGH3fIzM5aTogLrFj5mRQyXcOkhaZZhuCn1PlfPoCyaPvmBgrdArWToPEL8hHBLpkSvITXRgGUwMNTFfNBfUgtfU8FtlHMJ7bI0VctYbxorIaWPGJSbtFCL7wi78c5HSaI31KAauDzkCTkiw2XzBssn3VFmyGQpdExcMGYxIzWAaWh8rUdncBEknkISaqoXXraiyo2QGEIau1Ti6YgaBVlXfzEC+pS6yr/UW1Rrf2G6yi1hyKrrfW9mg6JEr7JEuRS5cf67cZM0lchmJLPtXEknNqyQrwJq5ZCViM6dW2e5KM+SbqbrkToubU026/yYb7oMZ34KpqsnWJf7sdGR1aOyyHZ00RLaoLAmswMpqIj4MYC2nNiNzX0Kkv4RKYju3NZ0whUzpgb/XZUfOmgLFcoiTXJqY8twac0Vsq1rypTxLOYllV4FAzsg9PUkDm0BcJaAtQ185XP7iBehVU7OncfCL7LzbcNJp3Cic8VJCKpIdFMoQmUlwwUdHIemYmV2KDil6mFUdNU+H7CLdStQaSyNHFGfcMK3msH8NIvI5XfJtbF3cFyxwCNpz4e1xfxY3rEncXdu2I+oFiEesf2WTcNQorcpaQ3eq+jDyU1ooLWsTo6wht1dRN35NeYyqkTFqxNA/mzho3D0C97GIN25q+NJi2cdbRqO2weDDa6iu2lDrKgi9/hVmWTNum8C6Bolizj1XAKpcbiWmAltYemlbzKErWUXloYjgQOyUsU+v9Siv21pT0Q2gTLYyPh3stOm+PxgZbi0ffSTLI8A1CTgJuKYC05Us4zhx00An6gJBsq1F4zy6VXac3bbmX7Q2TlWHdyIl/EzbnjfF9rwZLKA2fLAVJO6cDNiaioB3yN6QdT3sri9EvV9NBA23OgtdgK6aEW4mmbvjlz5GLojMyfSIQrLo4RWtbEJHCGjCQ2MnjH2sDVbc+V89Mk+ZVmvYSuQ1LF6a7zaTr8ZWqkGZPOcKMJOciGuIMI10aTWtVxJZgaCSXNh+IcPMMBHTLMkYNHI01gqb3VWSp5zl+7bEMumQOZ5xCTypR20XSim1g6guNXi52kKOQGj+KnwCs9KBwy/h+KrxO3aAQ6xkXiX9SghZX43hqsANPUrufW9rJEVE+QjJtYy73PhJvATKWMMSGlqOC5gjdDVJzhOHhdO+2GwGsSI33ExEyaaPkkV499HQTjYZsMOXNsSh2VTjsMzNEuiywDkXhD4pxa2MmKnp/mmS7BbtVEdzamxdTsjvuwUMWzEhAOkYE7AReoU21aNZ4/5BSrFVEGCv2upySyngReaZZ2jjNcyWBNjzl/KzZMQlGNrlmScgALlMl3wSJUHVHXdg+TzqrXwklrgnZnYbzAXGiJFQNRzcQ56oARSGwFk3SUB4rqz5MlRiAiZHhWPQlGWJjBjNs4VEjnCWmAwOLHgweikjJxhLsYeplZf0Qp54nxsewyEvqVFDr2AQ2OkkPKKRTjAgEybJu4KtHuDFxER9/1Igur9W3OlgJY2s30dCfEI2i/dOawDYTNISW1gkO9mShoYW13KSqk726SpTNrIQqcu371iCdZaoUl2NaYV91syadcsWU7NJR/vptBM1Lm5JsCRAA/pBu+W5BHxIKttndWIqJ0ooXRySyKqhz/MCZE+oLZHTVM3QCKZ4sgLmxgp1SUi0mywQ2YAU11NvUxxZsdkdmumiikcnFhU1WBInngkJLsHJT7QEJ9RqzszUo0qrZFWWvxEVuPzN0pZILlV5RMhV9W9AU5uVbNXfbiiv6DofYWAuXJ7GPbTiBgK6qmNncYi1SqwkvLCVEtOwyIyp7+HlJVyPy8xUUQMU+GvtaqooelX9eVrGm5PLCbqeGHkO2KIuJ4Qr3Ks9A26DqyZbkesJapHrCSaSrid4mnsJCG2mImMUdqO/BNnFZalB+AWcaJdAsETykE3wJBY+hEPOBFfmlD+hK88V4nMslOAvOmwZuSOhFYFtLQm2E2oC1ZcAgkRmChnOJRjdRnDaIqicT0wfOSJt4dE+riQ1TU7j4w+iwr6U2b2vh9EemN37fO7XKU/RfNi3zHzYh7BvNBJnQ8S9syA+uf3ZOrrXTvW9vEKK6WqTSC7hMYlnNrlpXwLpnEzp+GQP5IVeTwJR1xzZvaiwE8zuN5ydVH6pqzCb1P9JNcMSiCxJ66sb5mfD54GE/6jwCXjciPXN6rXaDn0S+sV1WI7P1ybwKH5Ph1PPEY2RX9DQwR0ijESD0+8Jp1yrFG7S5V8Xrvlen1UnrhtI9K7SJTteD+pnJ9fjrfCbQC3I5mit9OuX740AdNAUpzUu7owI10h7/3EHs7iQLrl+hg+Ixc9fsLXLPxc1hkl80/UVgCRcGjoKlpFIFEvewqJK9KgOSDB+/Jix87xTFeoZ2XlBMbf0tjYw3V2WzGHXQ1aLy/J9gQVJaGWIWOjFLHXCvuASRXiV7GrxVnB/bUptUvSiC8aN5p6cvaSKd9VHuai2HOjiYEtyPIIA5ldHpO0agnBgTfhMDCkrxMURwfj6HUocZ/WJOPWkK9SfCk44PoL61QUG20TEShI3y3T0XCnuJHj6aHI7jRzLXN7PT9OXmj38TZ1oaJMOfNNzVnX8+dKaKvFX5o8iflIxyZ+ImMTk1Nef0XZL9z8mNFjfSuFGy1eNyh67A9+FWJ7kKTiIwLLx1Je2N+7JbDlaIQxb/GYzulWKMvOhnQ06bbPerG0CVhDA0oLypEG1w8qIZHUCWq+IW0+YWoyF7wT2QXezjVyqHqKaqIYga5gk/QNgt9oYjp5/XRltdZLOvko8cPjga9JpZUeNOVtY6vRrAnkbj5E3Oh1L+30+PnGC9yRLRphSOmohKI7WvlKKM8xYybgU+Civ743ne0UH/t7vtODh4ul8likoj7neKq3AX3TEmxlzN5Q1EhyaRUy1lLh+T5wuzc3Gua7YqU/Od8k1hHMl+I1LOSTvb5EHpHklm3KQTGvqisONe5C5FRwWg18mhYkqy3xKlxtf1jZNw0JjVDkwk8ycUPJP9KaKHDJvIHkf7O6mh3ABKpTF7GqeDG8nJAVOUIuxyEb4kh416lZqK2SC5s0uMRKhriReZeWfd4/55gsbDXRFxfMdCR5s42ZccbF+R9qGjA4sHFeKKlX5cLY4XQojzCCWzSVcWaov5TSYASB59zAAZtxOX9oA12MMYuCSLlWdgpIq3m6kMQ2Nb2669PlaPxlH9Z0gtNGmLCyQRg3FBi242AVdqDCwILxWsVdCKHRwu/wp3lAO5vkegS787eg0zWooUgLhhlWT7mqZIp9lmajfCIZDO+MGrDSE/iDgL7Rjem9dt0PehRIbKKsoQm2VBCnWnLTrVTT/2KI07JwFeCKvpZxBgQnrcx2x3Q3JqE3HS16LRTpOST7HEIgbBZnAAGETTibQPePGpGG6PC0rsoD+yYCHgyUCvtaMrQG5OZNbWhbSJf4m6C9xL0l2oClXSg5HncjJmsqQzU38vumYRjyisF5eGx5pdxrXlbSvFZKmQ9dCopy35JbJcjbLMaJgqkuZSapN9MBRxb3jBu6RtrgmsxbRZE6ENZmBF8N0xWWSBeYO5tCwWqmm+vbQ0v11BFeEFoCyN9Cggfm4WMJ/hyxE425w2EaXRo68TqR4+Mj933LewXvSXMqKGMdHTWh8jnk+nypHj+nsi4bIpiTxOZGgCCaVZzNJnlxOL9x6Ur2wj0m1CCZNRPtMrSJOH3d7mijVNH3fi12NuKSbcNFFwk65uaTxQitBp1tbWqc7EdXpilY+V6xks0ayOW8uZHjejJJOMqtMshdXp9R9uVzJKDd3FUa5njYqGYboY5SQiOPhlJJbJSWoV3F3V9DWSXln0lATFKhp7h98TsiIkNElnLyEya3Agb/qJiNaKrDzPBZ6lx0WVYKklHhO8a8jDADJzYQWsyTZQ15JU89BJYsAeoIBnGACmAjgyiKAznl/bJbqJjP+ehLjH79S+SlYUZf0DP+1zCgd1gdOFJ49rL5V0WsRkxlRKcMK+dBABQ44tMlymRplWY4yVJNs8Ug+CaEygY3czBM1AOIqu3F2rdkKOM2o86IoKxKMmdhGSjJ1SbDD8U1/YESRRpPLhNBFR5yFq7jSttTTb2fi/VBBOZab1HeAf7J05W/vJFynzKdPj9grUpe5nEQylCTkE2VXsulShEQkNmg1jkYhQtEyozthDcE9qwZn+fcDR16SLN+qlrVbr7Fb3mBZiKVaTioIOPo37DfMCnL1b+CWKi83qGk2xOkbgLVGo5yyP6gmKBAi4E8amfCQCP8vpMIs75/1hV9/lIYjPmJQE5Zys0y47aEzX6PD0ftkIk2VthD1WXZszGD7jZDbGR3ucggYw7kIc2pNxPdHm7jV/SpexTdl4AmHxLEO823ymfpI4xPuUfAX/iQbDn0HFsCazo8cr7Tb6W7kk4c5LPfxqzuQJiUKX74VR4KpWHAhvGwuJq6VjtnaJ91s/Ne4wHipg7BDcffndKt319MctA/mxbbxN5cxl/Tvbiej4P2zHDkDn1L+LZ180U51Pu/knJU5n0/zOL5Sz/RRY0qxTjGjTrFkhs8zZzXVJtZN6hnDXy1V1wZ8aiXqeyvuM1sW7wW/kijJM3uzdL5tSbzgDgWFtOrLVJWsmWQzH2z9/d/0KBk6+xD2h5orJTc0IrXqKQ3WUfkcMjOl3aLoQThpEiS1KOJ1Nre0rwBoMDNqQHWHGRxKxM8sYBn6/cvKfFDoYAbdXY/+joxy7NbG0KHUJM43+VJwEzXXbM946V17w79YwKeZkLmSpUlulFeKbdRYNbUxuRId8o3Hv4aLPcDb9a0sddVKHJAkXeaL5Aqd3T0ducoWj+JLhFtNvTxdTb0JXCzwILWErgGvFEpFmoksY/iubvTM6FNOnoDtEUQKSb22ben7wkup+VZ2CTi7rmyZi8DDPVvuOvB46pVdCh4nhoQNKca3gBb7s8bMjJOLn4VrWGaq6Y3YlcHTnhXR1rJeeVIfs6VUQoQqHoZvzDcCT7oyeZqJLMDJJzuXlopVXZ/GFNKRFnUVuRKeC5yZWcoJxwDabkjeNCIOwwNGCKJ80TlggwiDQmFR5oaocRLHo8fOJYoT2mkQWxnHhtovCT3imBC//wmy5lR+4C2pMyGbSHGmP2w+aUdHCTAr+Qp2gWGIzZyaN6eZHEkNiVo747F6E9fsyBF3Ws1ioeH17ClbgBKvlDMSrbrywlZI2GwvLTcEMaqdDbGgMmlO3LVN258I22351u7BbUqB3TbOHejNCk+J+7boLNewXFLRZwaDApcXApa4iO1J7dGZsANYJww7Imsgv/hdXc6nTuCcU/b0U/ZZwjTmAd2OItNQDp3AYoQo7jw6wad1cA7NV3ZrEet2M8m6XeZ95P5nnWV0mVnZE6m7XPcc0b0uPaqkX5lFvVB8ILrDZNKzg/0zb2XRestvRQ64vkqxd12pEJOhuTZLdfjKmuqRX2xgFZfqzxNtm4TMhTZYtemsw80ofaTwQWFHQKElgcJMspVKOMMk4VFEv552xPkvxR9pdIqDMDqosBdDEcItd8Wzoct4WnQJjXTsqh092C2KD5DLXcg6f6XxYdc4JB40kwZJbkLqCOlJVtT6lkAGwrPN7JQcmujm3J5xLC6ZQjt0SYVEpQqqvFtIWOySmZrvxWqpE1tro4aJVAS/2YiNRm5YQ0kK1n9TbrB/b1rWV2/Cwmctq+/f3Gjok1pDWYUMMStqleLf2Sar4en6cGD+zbxDTWOcs448dQMamAm5r2ho49DhYekdtTGm0FixigJvcxFwYQ8hbZceEglTISKuCRXe/GGpiXrw9h2mGzV1AMcsMqbM4ycgLFOrYku7tOjYcoqWfGtelpVJPzlV7nhdOAY0XDazhV4w0qG0e/dQ8B3WnzWEv3Kd/JVHrr4GTDbwfj06KuG7vOUvBapQAnLqnUFMSdRTtXU0hqRrRlTfWztlfXpP7UXgRsmE2IgaNz7lFSoIAy2nLau701dwPwrzosFGf9hIvHylYpYTLKCFZquSle9QYQobJA9OYlnd3U6CVshJ1wrlSma68smRbmIJ+/yJSBmJGz+MEhjstDHa7TAPhDFnaiDt+C4lU+800MOmYpQh7TSb4vMdGX+Ji11SuNKanurcXLVl4+Y9HlrhUxOaQLbG5KtgM6y42Bax7fZE7RGZViERZbuX5NxC4T7RjV/StjKn96zWEdreJGIEkm5QbxfzzejLhk7ohFG45sxqh90wEtox9SulG5LDG6hcy+8whb0TPtqmh+4WFPv5q6iWVZmlrpTp7s4Xk9wPIAMOATV93zagYW+8kWEOdgMSXkm7j6UUj8gFjc7KKITgS4RW+pD5feOo5Fs2pmFPovFsXY8CCZXRos0ZWcAk8r3khUOUIu1+rK6u5CvKwlYLArRRfYMu6xr0J9Qz6IIq4T1Goe5gI57w/rPQ9lWFUR/pgE0pth1VycqJQidOMuzsXFfgVSFwh+wH8n6GXS1E7adWF7u7+wdDF7nKlqNxeyvpbFPEpzJ1kHUvQU2hynY/0hHxp4Wify49DZRxRUjKlmbgliduCLOUf5fsck5iKkkXJIY8ACmr/ibjX5fEDVHIFxBdL0TmITAtdbPasBwyVWdHJkuJte5aqi354mgPWpzw/eRcaDxINI0bpAtpRkwOX7qRFuzhld9GGFHMsIsc0mxyo66LsGwhNdBUoMroDGYFnT/qyN+7aCAg33pInF1Jjo9tnyx7R6KbSyQ/BLMUIZqcicbAKYTBEK15enDqK/TFlXrHIzUz1AMm2oT9X9ddhsGJ29TbpH1vPC0FPHtGyWZWAxNvmIDSJXyFEW1NmaszuQw3w0CjrZFp09X2kUUmnnpx6yD1KmQ8UXZVB43Y2DVrWHVN+HBF0wpnVhVNktaksgjDSGB3AKyGG7E8j+oz0eEXvQmNJbZrR1ZwTFugB8JfrJNnhBCCGBVkoGqGQKVWEwadDjyKe3wgj79bz28u8799MzA/JMqiofJzuOlKypN4dQ4Gs3nPGGXoEt0hCOiJWYVwFrOBlDMiSafkLspHQtvgrHde0+zNZrxmDr5eEEmpu8I9lWGy6+a7u4siioqVbk9L0VgypQTdFBfSOHFGljOxw+hGnMPR57Tc3HP5Inrg9AEaj4ISw4FqUA6nj2qsBzbrQXe3uAyYLTLkPZssYi2gR7vcUd+zQj9rfkLDo5X5WfqCHmspPWYUMD4wFS0ZFCUtDURaAhw0CWyhxgU3jEXRxb9qwHyuXBjO58Mee4KEeOUY+VhKbA7Q9mxfb7clgOwn21UYJX/MAqnScTJroSoobdxz+53QMQOLep862tYKR1vtHRgSiZmMPZsqOoXO2CHb7OKiX8eLDBsoR6NZqG76q3+GTUKmZ7CYj8roybp80XcnEQC6MBqHsbgIMS1DCBVE4mxKr/mtiC5voISiaddZSZWl4c+oXBiMaqy8yGVKSSgYu0tJrpfQD4dL58MljlrNyjX7QvJ/ZdWI7cVBvyFSS2hdSbjyNGCeMhlpk7ys+3aepMqOrW1iEHFBxcVgExRoIEfjJ2Va0BE6TfeC0fDN7Rw/pJyeWC7I1sxJ3a+Qvsq7dLUwCmjSSrlUo+bGjf1ZN/E+TeyVoSYv2qT7R1t3TBTdggqawl53FUfLuD8w23IDtioBVxFC3B5BTTVKwN7IJvgRziipKHS0gLkCBiw5U82V79NSdTXRijB0Ciha8PolzlHEijfIFRuKfHzXOUFMD3Uk+SZgX7FKXn9y+i5jFO9TH/UPMzK0nnDLmfUjGzdvVuh37CV939gmY9JwlfXwqqxvNOvauI5qHHpV1pvTCmPCQRTaYNSMMTy0b1sN/sEeWw1kIkWKrcpGzdHHNk+aFhFdZeNmCqkpG+uEFGOv13VzDIMmrEYNw1/f+EI8cgrdGFHk1nDkFmuvbldZia9vCce98sLLG8NFvxwte6fhNnSRfWc47lWo0i/6VWWT5tQVvlMYdGgMJfOx7ZZhusqmzRAP/HuVzIzhVdlkaFXbQBDCm/L8lPWmwX4h21TTMvGOW/YNSx1bh8KfYxvQLwAL245aFNNlqrTn97kw0zD9Pld50daadX1KZ6lftMWTh7K0GI6Jg2HGUd68aWSMeRwd28bdvGLYBorYacdjdsIPDbxhtnR434jfxIVjrAIrqjWJFUOf8V35WwCNjyjsQ+FOnse22dADaFRVJ0KhbNn2vOIPKHtTtmpuXXnFMv3DHzLEX4EBsxWu7B9jQgx+4qsf/HrdcPUxupyT4l4fUdBmnuA4tlWzdys/pd8dWo1cfe/QJ8mV1thmEwOw3zs2KyPI55tVfWwnsyRvKCP4poxYE+7YJovMPUc2KSJ2bDvO3BYbLEr4qokjWhvzIaS8SgDy0Yy9Ka+hy2Nq2wjwOuSi6bURRe6EQ78/k8fhZzgQP/NHAt5GMuoU0B7gaQSu1Ma2G1AcH52Mus8tT1E0wzHESOV5QDzlecQ0zIXpM+qkW94/VJpw1WKhNAW/RfrtLe2D3z767YffWXUPpYP1ENLhb5F+e+m3j377Sxmoy6iOyTPhZX26qjXHxMk7ZceLm8cikyAh7gVYqZPCdyYH//z1v00Izsyq00AEiSCNbWGWels2KhsbFtAseQC3A+GyTJNGIxxRVQRub6wqVXiDF+JcqtOAhFPjEDFSJdoRzof0oWpMAaK80qJ7nl+pKTWalc8L9RLDza268kIMobZPKC9Y9pTmKhsnlM1MyR5OYCiiP/zFr6ehoCgN0MCdNcSunzeCSedDoaGw2qF7U+PkUI43B6aj37EpxR8ikU8KEql24/RFnA0KMRXRGgVoixluuqNsI4f5G9nTL9ri3yKr+A5lFoGickvBvUfCebnLTYUr/sZedXBslVAhShO/FCm9QjNPLsGhoKBLVWUExt1CrZayESJ5/Yq/wvj9cIEUaGId3WgGBMBP0cqo47g41xralAK/8FO34MeEqhuGZo69BPC1JhvTzbqjvNRo7VXWw2KECzU84GdKNyEVvsDPHh04A3w6rrJBQ50J9Bhf4GeqNUW/8OM42thrWp3e4MfVduMv/ABHTYnhqWyoa8Zup7UbPuu7IZnVtKasCYtelA22Vp8y6IE/RgOWe3wqG1qTvFZ4gZ+6UcNf6LxmAs2F/qwft2x0gABUFcIc+LGxA/iAnxYAh1I1xjXWscn6OK7Vu6c0iN49he/+D0Bmt67TCyLvFAzoz6enp+G9iQsxPpSfahq8tUzdAF5pSvmZ09qnbJxu2oYFM6oJBHTjtA3tx+TTMKM34faFDgu8A1Gb9D3Q7ElsGr4qm1rNhjUNrcIX5fnJaagmMkQYqDwPrXcgGT6V54Fls5pQPr4oL+qWPYkdwxflRSBtMMzYWHxVXrRcXE3xgWu66QIvhk/40fXd+As/rTcRMQ18gRJa9lRrNxbcslvKS5AU/gz8mWw16IE/LdOy8Ik/rk2JXBuYAhCb99JDecmAqQOdpRdl8xTgKRIawLIpjbANhnuzCYA2cPX7uWHWEbIYxo4wsmV0u1ZvaHsMZXu9EY+yoW9Q9XYb2v63GkAW8QRflJc1A2HzMv1oJmAKhJn4g8iJrXqZ/Uxr9bEtmAaKfxn4AcupUx5kDV6uT+n0iz/Wm7sNesBPq6btBdxTRkDKVrZoFv7hDyyn+As/ehNYDnoAwZwab9Ev0U7NHluPL5r42oAvGOe0+M90FXuFD/ipsXeobatW197EoYCXN+GnAY3HOb61MQ0/GvQOwIpP/DGgfh1ybmUZ7CowpfSEHwetIsZexAt4ADFMyKzrrg5LpjYN2LAVXiEE1vyxl43d2u4W+4If20K8GoMlykFDGwioBqEyymKgstUAwGxv2DUi6vBjThL9oTdlK6awAWpbgSOmNsJT2QpTYQogv3UaYP6KNg6DhZ14BV6UV/S9sEAbY1uAY9mpNVoYoPGf3Rb+wU/LqUME/mybxBm9bRJ/GmMb6wYM37ZGdTf81MZeapmTjErgGwVtdjWcsvig71fQUHeMSCO2QLPHKXg7smhVBR/iG8mL8rMmcGMYAPK0lG9E5NvZsndDvm327jr8GNMa/OKPo03q8Es/U5pJQUCYAO21vfWxl6YQVi9Nwc92rTE1DayBTm/w0xrbCPzwS1oL36FFdW3SgTlBL/BjARknPNpeN4GtdeiWJnk6NYFXfRNn84438acFyfHXhjbDEBgutX4KP1s2cCAwyelVGUFeGmbSSB2GFj72UD+huTAdajUEOj7hZ9J8HcUXKHxk0sRYsw74Sk9YWm0NQAVEAaMtLNuaBmbBoieshoDNNJvxDdbDhuUaY6/AUmzQB/zA6FXxUQVkgDXGmlR2TjYm8QPoPOAEviiEL4QuOr3vxOZtwZmPX68ZQJZ3anvwZzeUjL/wM2U08Bd/gOS59AAuvNGabNFDgVKoCHjgj8F/DJB3ARTwhDzAxQCdrys7JzCzYddbrkZP5VXEPKTP+AIMu4F/hvK6htoNGFOXvSt/Z8B/iPg51DWu/RIoxchbLc3WMWA8o4655XFkwDchT06/QLDNNwHCwcwmSg0tGdth1WEcALngBeYeUEAHZxk8Ya6igzejBtIavk9wJJ4kugNPHBH/o5ZRd7vlMWL8geogwcEnTA80p2XrGr4rr0wb2m4YW+CvtGq9pQeY3ITegTxmKa/DT0Ydccu7sbiNdUACZ4oW7rrtoMi7G36A/xhbvxsXopfriJJjI8D1NsZGaBlQXjZcR/k7/ZcG/dSMjLrRLY9QcbAeW2NbDdPCApvAymC3Xp2erAMGb2tN2jSqDgyJiT+WaymvwYqxu/WWQS8ZdS8JJOMkuIyR4LKbBJcRElw2kuCyEat6yd7t+ssKSKVj/sL3srYXwQFMHqIzgWYSRbndprUX+Ipf/vKXIEM879JBUKFE2+wG2prn8d748n52g1LptewkfkONmdXTbk5lwdsm2AWrDsTvwficalomE8pL+5khFJA/YCwnLSoEszLwwcdeyjE7i94lRK4eFssEf3boOh6rykGT1VCKaKWhtE51udKc6r7yks2ZFSqq9W65oG53y7uGYJBghGB4YGxgYEaH17vPbhc3J8MHGf0BaLe7u9ZjhzH3K+ENv9cSNvxoG9YOdvwaRu0F2gPMTBpTmdVZN8VOvpJpTWdAaM2lJhmqZJylUxT7KpnaMkkGKpk9lETlyn2jatXEIRA8TowYlJK3vwIInBjJtyy5Xz+homabn2GFNbccZn6vX/WtTdn3a5HvV4IDjIEBN6o/N+MWAZ6ZkcIYUrNgUSeGr3fQtgAaudn5aUuj7RfaMhZFm62pjVrTbWFu5jJHlDql7dugVXfv0Cd0FLD92iZtq9XE7ctgs3ZcTieipDm6U7o9WukbZLeKuM+V+9Ft/v9X3bM2t20k+f1+Bcm70xIhZBEACZGgKFVsJ45rnTiR7ezWOT4dTY5tODQpg/BrTf73ne55P/CQkr26c5VLJDiY6enp6enXdJ/NR8l+P+JP00T+Oo3w1+kIv0Vxgl+jeHyQHT/SO6aN0jF7Zcg6OOVvxIdfS0W5GFxWVjhfMZwtV6FrH3sBVoo1n37o8eu5fFn3pUECZGASQS4jRNkGqaTOvkkeQ4s8hhZ5DIPMfKNoMUxaT3NtupgGh9DEqBUkYbCD+rvcD1mGkU5BqLYEXFzGZGSdk95AQ+ugd5JRVl7agy9sJ0RD2gzsLKSrItgdxEacz4VL7DiaMad7bsSC4VX4rkwwzjG+3xdn8/E4no7pp/P5+DQZAbkOItWfLLBk9jeIVFFR+mKaxHQzLM6wi+SiX5ydRcNgsDgep2mUTCaTrLCmDZEwD4Eg/9TZd1glBqjjZ8+fB5q7KFhIFCwsFOz3/cKdd3CG0wWMsdnSh1k5iK0Jcp+kL9rCSp4irwgtSpWGxKGT9Xb7++INWaxu06PEtj6AO8ZiRZXqZW2mF9n1tYh+8vZtdUwWFa42d7mNsOc+CcTI7F4DwgeRoZR7uGOAhX/XTFDqMoEKTWI3COquDsirUZD8jWX7RY/8Zr/fUP66kHcaZrmNmDy0ss4C8qCc0iH8qWSCBhWeLsnr7z5fM4nDf9Gi1IQSDIdHBh3yguBdKAg+nC3UPYzFYCCqwzIyhhzywQzBJvI82FiVQpp5WwfGxbRHso9wQbcGBoP4ugJzF7hHSE1n9FgCbMIlA7x2Qw8v/r2A74ea/Nb03KRHVHHLaXgWgbuD3DOBpdi/4rnxIfykW4rDpy51BGR/0GQPkYKQpWVXJ2LoH4SBaD627q5yIcuRsLziVaNsVSFYeaUqd1r41JWqtF+1Wa7y3Vv9yiDMBOOgGa+XKSUpniD2cxRhSTm2xr1nm3cLijqy6vwlgFB/3mia4G19+EgFrkB/4xHkdnjP5wuVdtmF5R0my3Xmd+7DhNaboC2WLqynWAu/FOXBgntPiolucDeK7UwDo2KD7QLPsBDLs+osETzYWnwcCD/SKUZDscNY9KUQlb3xjh4VETkCRwFPnlXRTPuJvvCLxC0rFauB/RMYpzevO1T7Lsg1bdvD+2s4SNJukfRpaXA405ohHZ05VGQBC85WvKg10zvmP3gzYJrvyz1Em0DMf82+csbWEYWT5xKJZ50VKnp48mXdrmQbzy5smLAGp0h8Ih8Lxy7/WYaIVQDEDlgDJ3Ji3jtaFN0syUsjb8EdOpI7NElFEFV3yHrABjEvL4Pf0lQ2n0605ozvkYNsOGIEh+8kgYh1ZjGptdy5j7fL4DW8WM4+RgrIxMy1W8W8OIuC1ySL0tLJ4cZGqq/FEooGKlUnTDHsRtZyqOVqLVp1u5VL/jNW6MUOJK+lGPSQgf2Of3SOilhicKR4cpqIOwKqV8ygtzKYB7FHttv4068pShScRbDYIerCkhRUx9y9jpEuO9yNkHrPOEvF2o4CZyN73i6stxWfo6eR1NToMUdlluJsxy4SS5LZoNN6B9e7oOLWFiJfIDzr68HmBDONaxhdPNxA3g0MfzVeYdSUH+T9W2uLm5XTqtgeF4/uyRyr/VKtc+ou7iUk59iRJ1vKzD7sYBCWiLdfum1lp7ygitvi2WYpDuQHsJ+8vdgtrIlWQVTP2gzG5HJdOSmXQVXg255K8/CjocEXE8nuxhMXrir2pMNXw6YODdDfq4bdhbea+RoHGA795JpuKX4QZcymJjVCnxwk2Wr7uXd8kh0Vx8JGpFQgQz9fvVvo//LucFpwzLpc2W0qJm4zBXfTVXTaguF4Todm0dJZIhbzJwH0bjZJZsJg1H0KVggWsqzrVnAiCHuE75h0eGSlTg/2hxzuX8CBgHKIBAKylD6FQk1UAlejzXTRAO7GVpCiDUK7CTOrBtnv0dRN/xJm6iaaqZtwUzf9O+WtpyP2l+oLeBOGJXipQpC5zf2sAwU4l9M+EMqRYrTsFrdPbXL0X51olFVCqFDYA6pVlH5QgDJ6ZVdOnC5nVQzpYC2MBN2dsFdNF/KoBwvMTqHupHCESOE39jF5AZ5vulV8zTdQO/DrAcbgU1hCpobaPQzmT60d52iado8/sw5hq7ToTCYeaTlvhLfqfK7N/BlFmLJCbLRc279if+RBOI311A0WGM+Yq4+dCyI2Fa+DeETVIPQw1CVjmXxXl3S/juHvob+TiqtkbbuQ+Wak5hE04Obn/9eoWftRs99P4uFIfvoD6KoQL8UBY29twwLVLAS0EBb0Jpa1UrX+q8FY4aaz0i3602mjEMbd0dIWFlZayQIPjkyzYp0Y7FW+lOgt1UB9jZj8zKcjJMD83DX44anlWDlz1LVoH/nZ3Cc3tpb3/1pzAqB+ODxte+Z1vCbWihMq9J0CzHoorYbVR4BFRy3kNR7nXkOavMUjkdXSafFfpNj6nv9APtt73SdS17GGboRXUjWDm/n2I/J6sfzyeFkKuqobinHB8oucq408Y6Yt9MuplwJsfLUmOcCjb8VGE3tHdx+XeC+P+xn7gUfqHTZIvcbCt5I3O1GEEqXDVqf2UBkvkee0jIaephN/08htOoz9TWNPryNuT7PbJu3wUkMEruLxqELx+M8kbhithvxbutvxWIbTuwCZXm4Vza4W+TnV9/lnsqJ7VFjDwlEgL8U7LLk4OgKf+ziepix6IE2iqfBYunYXIdzC2M6mrRx46xl4K2MWtjxmQXFVi7Ti0Tf9xTHCGAz622N8Lxik43GSgpmWbb+N7XpbqMx2bKKGo8NhaZrxUFkK6ZL07ZMsOJ9TqOk5FFFipP81RlC0O5QB3F0VtzC5mXtImUeoY0+2NGzkl7QRM32ceoh5dArkO6tWRlHwIIbcQg9JpWHeSCc3hAXLgWqyOQ9EdP6gCU9REx6fBl9X268OtXxjPhn0yfEIUskqsA6f3uRr0u8bndNVHU1Exx7VRAWjXeoxYxhAJkV52ea+3uaStQHeHqgmj63QMxi9hNFVk7tVTTA6jceqnZqxasNYvf+jP7rtdHhRHqfjQTTMjBfp0+kpPqUYU718XwHF+OAXUTSRuIHN0vX0HIvRcMhD+SbsbxQJbSARD6b8wSlTCUhQwTyOzcMmmhneKEv8qHRMURYwQQ4dwNgssQr3aCiHW9WYOtcR5YR0W6EeQcrKCegV+gKDHUm5+ehIKGQ2u5EF3rgJZTdraiLcXEPHMl4H2g0UBKsj204SWRqDJjU3d8aqcZTSweR24RGPRaSJB7BvNyveJV7vD6MD82wyxdKWUrcbXx+PCxOq4g9DJXsMC/9ytZiRE6/6LZ2WE8CswsBDovtQq8irtgvMNQuZF/ParjDtnBlY0IyLKp+nCw4L22eAkOAiysS+/xVIsKq9DPOXL8YZN0c2bKfaXeQonjxUZeY1wc17vRk9PcyDqsK6RowzjhNYjyU0tJq32Og3g/H+vxzG+q3WQh+u4BtVejYeYn4LwVQwLDKXkRTCxMZ7wkyDoHBAYlYV+toxYqN8Hi6ZNkEkK4S8xMDqc93Tgsn4nMadd4svsggnq9ywQxe1V9I0QPThb2o5/fSNc+FM9gkpjWMrM/g25QjfvbsuvyBWLzFpB3gETROUp5EnqMjSyaEtj6eZqVVxDU8o/o5dwV/voMJwpcwU+z26OQhPWpt7mJq7gOYrVMI819cS5+mEGTi9HGw/hoT71u5y03Jpxf8IJUNiRAltTB+gc/8e+LrPDMmosdkIKZ3b4uh2DBPThCU1du29Dbp+gwhq4mdSJT1OQgsfQmYZjateGY35O13npSqzktiIbWxLnT/NDu3wAmMHu1ijHM4Xt3OPv4p0DIDLLOtkXtEU09NsVrjhYm73yOexitzkhg8W/YgB5f3nySRMJi/oHk8mXcto1mqki7grRsIquZXb1rf7YN4sIpaCJWXwGY9yVEDSxR+NX1ixml54ajlHexBYdsGbdoVwzwIk0obVBHrttkKwQou+pl62JQa4gQoh3tPtGnV+hlp27+3H9lPNNL92zrk35UT5+e7m3FsZqaoDeUyMtjHwe6YCZ7SvFQoD941wHIdF/ETFXLISQS0WeNqPLRiqrtEJAWlXLyCpl5M6Lfdmos/OjU7Fw1DLidrISll9F3kTy2LHWFbat5I2xhuxxlnINA6jKHmhR5ip+EmPkOkM5EWqYTuoYBoygL5hivXDVoXY+OG2Y9xjkV7T2xRZfRyovHh+qKpKpMxabKBZQAYD6RZBp0SUxRV7tT6qx5HBhD2123g2iwtyHr7JM/OL/EfbQnqKuSjjOFEmjm9c3ufzGHvzs+F+n6Pkr7mhjo48/ChRN20TZlhMJuxWbsxu5Y7UrVz6dMzMhumIByqBl5//GsUps+OhPNnv+nxl3CY4ivhfbhIcnTrXfRPnum8/t2OhLBxBtHcQVJ1VDs5beo9qcJZw8BMOfsJNnaOROT0Nb/F+n1bh7TaWeFfubBmcBk5KGHA67lb4AJrdY44LuXkLRfGwnbvLjLuqvtJhOWQqj2YjuLwmxka3j2huDIqt3GsbqfNZ5LbPoingUCLg5gDebQYwtQH8EXS/m8BX6dD3Fs1U7+EbODMpqXkV/Ma3HDmRUH7lyIfGixcWGtLRN2Qw+SYfmM8zm+HSVvKQNTdGY8ibGr+d5/57tEw6G5BSj+M5d+MI3BAgcy/VXO5wiEjpbsPZ7ozMBgNV7dD0+HQpvRWa+swv4kazNkRXmI48iU480Z55EopgNmSWFDlUNU5EuWg9tYaRnZdgKW4oddUyK3QpE/qyzMuQ2bcxvbMcEt6ARM/vKxI9v9VccHqtGmhFNY+7+WuKJFY3jX2G1M3ker2gWDq5Onkd9qCm0PsSL0QbSIKS606FHFEYT9VurywRqCViYPu6sxN5O6koLooc8TQM+hhWzunt5un2d7KxPHH8KRZieMYu0geBncZ5LlYsdOrtzO001EbyZ/kirpr9rmygFlZcKWdA4XrdeU3Y16rc7bzeiD6DQ9iTWeHVIrIUlJRC3pfP2ec7eckS+b7wl/nhTOArDJFZLYDEBWiSXXxdbTckI1pduu2rkBX9IQf6Lwg5iTgz0tK30818j5Uv0rg+HK/XvGwU5t7k6uXu9/wav/cDY6/JNAWV2cl1zMuBRWGSfqBSIJzrxZf00kEsqzfDAE4V7D5AuUW+ghJS4iNbFO7cYcfBYsVe47VF1ut7MgEFBaEfsKWX7eYV0b51BaCpFIfazoUcEkqVibrKYum+L7bv7mGZJTakA0vFIvlLUYHpCE9LmW+j5FE4kh3rJXQqO9FSjxAeMoR3FDB1x0VJjxqWfITI5CMIPBADlq2DPJ/VxavU5uftBDvS1z8kiohyHVyZYuebk56kkQGojSJbRG4mKRA1auLQcsWwwXtaso18EFdQbKDOP14ctKCnfX83/12v8VPIrgJI1DALBgOjXg63SchCOXNeHLUKI87zvshfYJTSo1BTYU2V4wnL0LOh5BIBKM4Kudq8J7C8fsV2TVQ1F1fZ8d64vampUnzVp/QbVPXDkYlEflO0RT60lWq5dOzltdhDbmcUCMqU48o7sVnbnctUGVgKzD+exBn+jdJhpubOarTM2C9JFg3rq9Ox3Xx0pHXAXh2yziexGIZ+SrRxqlm3RdQWSavpaICOTjMxuSZQ+eRHcSYPGJ2n9O1+ZSuNrPuxaLViBQIy/NYpD+ZTNH6X56iARyyL2Pg0HR4dPWFBAczedOcVMGkOLJrCA97dTKELHHjvS/1MsqRrJXa2OxuJJsKYpKhna0IxUhOEdRmYL82Hawi0EEd6bh1tV6ttedMzBo4HlhRKBqxZN/cXK5YVvK9FHtZ3GZtV3PyHqijGyP+SC423JKFPKOB1eQOqHtmkbbakaLBP/asdFRff3AY5RjH3z9fFt+v19hNZXTgwwFiXqJ3Rdc3SSAkMDLrH1xQ0lpw8jLnooP2CAKKX3YD7HZTEeAfFmrZXtOuq4qJ1UwBvIGXoIybCsGqA2cc7rNPmlTqlKxTzlRLuosEAQp5ZV/A/bEETQZgyI20FTvJBZGOF8m8bH9f5NblavLsVIjAmFUts1V+xjmLwt6VRMzeOzTQX7qQSk4BkA3btE1ZjzQp2PL7M5Odvf7pPKUTY9Oux5lCS6vllXn6iUhP2zD9Dzw6JLRcFKT0qURsERMENSJwD8ffHly4Q1+sPuysqzt1qXYV8ixMfoamT6zSi0Nl+n8bdFsu53w+7Zu1Yqn5SaYaHpDmCh7dqEcqMDl7yzfI+WQJe+t5zLhFal62GaVos5yvkBkgHxP6Yb1yMU77yurwtPzFR3s/nKWcRadxm11wkWRy2oa88uAG7QAp78iZ/hYW/siRhhJDikjoEgXTSgiDatEuCC8YvhC89tCEryHrBMvMjbH4SGLUhAWsZyXt6LizXf2TfVNAUef9hsc7LL2E7TghrKs49TgekLlg71U/82HeOL4pi+ymwV5mfrABfBsWRIamOS93vP9D9apVF9eitGkRcDIqiG50nTHgxXL61ghHeihxN9vv83JK0NMwL4O9vwUMCDvGU18vkMP7rD6iPd5bbxZrslgQgODQA6uKfJeWBNPfuCiTj+vxSUaI0ExCvln2+ah7rDruKzMwzvrkKWpJFtEPDhhOBDO6xMIB9QRTV1gIY/tIbPKUbbND7S8+0KArbj7ENLR1wlGa2ZC3FdqoKsTZD3qZewr2Ge7SPxDtR+3cu+Tvjaat3oHS1GGXU6g2wxCz4K9N2gPF0dWI60+Qmb4kJRXH718gj+dK4/UsSdZOWiFhvN2JKaVZD8Gcp00FnrUChs4YSa0QsyyS7AbeK4iG7HzbB+56Opgd12j5zdS9Kg/ptmiI7iiKe0eR02tjlBHucTnhKlLTxBcp62CynzK4x5paOccT/cnvHOOF/R/zvmP9N+d/TrEqpjTgiE/5qMnWaqvgXYajw72NU4cROTk4zYfzwt7Y0O9k9FeA5JJOKN4UOJF+ZjipaomgveQtH0mhc1S+XwWW/KUd3WjUHlCFVc74qSVLRnMsq6oWqhuJc6UucmLxTl2+FAMDRXjU5dSD1eXLc23F8MbTf4erVD+RWho1IzAMXpR/i7vRSV32ZWcFbpheuB0kz1GwmcrF7XS2GLT23TOhuvt9ewKvYW6zF9lBw3WgX3Lj/sAwgRTaGIQMv6T2HHMa7gED9ahGb3HvRY4GFBJ5H6vkJf94lnH+W895vv+HDg2bM0wII9ZXJla6mmf5mWkFyWLbN3BYXZhXu1g+SeiBntFYXnHnsn5QUCxD7ZT1Cp/Svwl0627J6BRS6ItwEWmUNM+F1f+v9jWewor8iAG/m4GWelcWXr29wHNaqD11Tvsplk0O10MTgDL/yHMpZEWIG7WzDHZFvDopGH27cKgtakHiNseXoSF2rDwtw+bBkC/UW9tBYpWG4pf8hWfI1ThqDAU+GGZm9Obum6/sm1DwOuFmXjQOsuXsIw7khhIoCtQyKWvc6MhJ6tJAiX3Z2sqRhvutstmVnwWyH4G1fY4xNZwsxJJ0Nf2GNTuQ1hMPiaNvbjPXuw67svCR0o1EOtqZDbEgHXNjFbrktIIQKEP3mT5jFoqQ0Qzqv8mKHMdVYYxNg386Xckv31/Ml3Fu+WPL7yku42ky/sTvNS2Z3XoLdmT6k0gxdtYDyLr6laVd0dTfflIO1VELEWjRi5zhqPwuw4RiTkI7E+Xyx3wNNdaU+C30vwLjAwjg2ilEr2aVKIceIHKX3zoxYYdxG2h00RsoeJyh62wdx2PtOHFnsfAPSKgAIrJ0R1qWSOjqKWjicAjDuvPVYvohm69I3V7as9sR7nblhT2XG6rCq65RqF6/g9GWT6gU+SZj+pp+RLbAultHEdjQMuRsYVUkNQqKy4QtAZmYhhGNyPo9r+RVUPuDThlj3ZWngoGqEXZvIgG4Oscd1Jha1yDLAq2kpXSXkf3M9i+BAJ3XyfDJ9cVJhcdWBRWMbZGoepXDjY7/P6Qnr88uwdW52a4OTYsouj0TDSPU5AlNiv4Uzm4KE9kL6ngYH28Y22QVNpBD8S3DPRBzKVfuLeR12w/wCS/oAsItwEmT47fv1dkG/uxFrPjuSvrQbtVVhGlhk3DENMR01aeZKXM71atOuQCb8lpqcV6rV+IFgCpa+LzDloOJSgmOFGp3GznlqGT5szhaR6YwMAXRpAf7ONRZW5zeQXm7poQy3RVnwqQvOSGFUYq720kSvR1UBbYo3UAb00EBDamf3c+C6DlQ6Lm/CnnZokmPHOEtJeNEng1pBPBS/w1xZiOIKcdGNAk3NCTKIdJjjLoNIB9Z3JUFEw1vONWwTQaHHTwwGlREUQda/slWkW0Ei/YL1uBwMvEyW9Qy54nEhH2B5RUpcVEe4BFWZvKPbuiROTCEfSfz+3ZpgyBFE7VPtQqna9GcRcCkVDDAiUZb4gCp7b4rtJ7rLNUaIm8UYVqjnntEi3AjuDrN0cWG1cnqozR3DoXtQGvZgTKsvLNtidl5NHPYfmf+pu6/k4JtyR/22w/smOc/OSQ/TNux0EJmmc15TRoLFpSIIS+lCKKqASwtHxue5uZx0Tw7qjxgPhYq+wxJceDiJRkfRarteL4q7zLTbGB6iTKgMYZiyIWgEtYo1DfX4RmmduIL7UdID0NC3Bm/OnQXtwsH8wWB0uN5vm54VNkWf+mKgcqtU1C2iw7T542mmR1Ip84C70+1tVBd3p/E1J/rsufjxBUMeWIH8UXa9/+iBJb73tWf4dJ+rjfAi0Fr/Ty+rFmosYg/9tj8tnh2PgcPN9r3En0ZyrV29epAlR5pGaURQWiR8Tkg0/NlIPivEs1i063hj6Wz5JQ6E8TaSBvOnqpkUAvuqXSoHLfmg04l89FLCpp59FM+GsXz2qjf7wzvIFxTlXilxdkJobpiACsYz2w8hDidDG/QIjboRw7wFJ29toAH1q6WRRrOqHvPKjsBqIGiOCx+U9LTISqIS7o3lFXyN3j+8pG/pICfBHSw11j/57+fD49MXg5Pg+fBFWMylSrGjKoUQcIvzeDzGjGs7vneG4XEU2M0DLUZclEejY5FGS15vyE3F45RllhifstCQrrEUXRUkUrMcx2LosLzo4R0wYbfzoTFzm7DhOu8olHQFfXtJJQ67gitjvV7ma0UCxV75pqsxf4SWkSlKQ9vOJA1Nfh3m7kJ3jLi0mEto0FTuiI+azRzs+Jbg1B2GRoHJGr9jc3x2URkvACf+ul+ElBUrYirO5pCgdAz3x6XlcgoBY4VwLTgTGIZlvTJjuRJmlA1WBhJpnLqZIwijH6gIz4yEpWpD//bbh7/Tf4bmMOOJYj0ceNYnF8tsHfQ3FDHVm2ChOMgzJ1Mq5Azb6GraAdw10rswqMOVQTkVITuaD4aSy8c7kMHNsDnwy2o8CRxPQfAZi747xzeIl0wF+oHS3+ROFN1JeuoO399KI1PdW1bcmGkDstE/SuHnMJupzDzfihbqpV/snkuAJ/+HKOH19s5iuS02868/Yznl7G34kdF99kMZco78mO2K7G4oIsmzy/AJVu57xA+p7H74mpRwCD3cvNpmj8Of6GJl6zLE6T+lAnv2IaRDw6dd9jHkuGNfP0MrHmSe5SW049922a4M850yMsHuytbGIzwSsyUbKXsG7X8inwCU7CqEM/Mu7Kjsi/r8IHsZbii2ntx7+PDTG8oodxD7lj05zMjn621Rfl2XncWuA1MI38InhpvwEj9zFIT34ZuJhTDHF9VswmfiAdmEH+RHmHZ4F76aGA4fwzMNkeEaHtgICJf2U8RBeMUe89mHn+GrjujwCzyRaAhfGl8fhE/gu4uY8G84CaS18B/qs0534Q6faysXfuQP2NC/iN8Z8YU/4HdOawLxAh14Psz+7eTk3zusQOSPi+tryhWeXT6an+zenSRLQl5NVvHo1YqM09ViGJHJOCLD0+VoHMfjl6eLKVlN0tWrBYnSl9EqSuNXKRlNpi8nJBkvp1RWuP4nZ6Cvw16yAQA=
-</script>
-<script id="@tomlarkworthy/acorn-8-11-3/acorn-walk-8.3.2.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC5mydonhQbDnRjC17JRkmh+S/n5bkm2zHITsvjNWt7v76olYrM3779o311rrMaRjj0JourG/8GsfkiVk5J3Rm3aZxnGfW06H7/sQ9sBANrXvMOGbW06/uwYl76Er5z4zMCEWxFZEYn1pjmiVjFKSM7j+j+Pu/f3OP3MNxSLgYy7WbfOMgJQWvU+vT53uwha272xvrmYi5FS4oSkiA4nhhzTDFDAmAJjXzHetjyrBFaJSyBAmS0lNrLkTGT8fj5+dn9xsPFXg3SJOxcmCfM7Iv1e4XaveVIrA9fhPlNJA6LGELBzvUYU46eqHLpU39ZOQ02MBwyOjlCTEL+WS5ZK5YZNijD+hR8cTIwfC9t4cLymgFKtW/lRbcNCI1Ef/h0VtnDek93EelNSfz2Y7vkwfixpjOwKODRy/b2yNulvO5zUYOfeANOFzB0ZTlkgB+R+9OM7sHHu3Co+eRDYTl8ikloTUZnTJvpwFT7R69kAfYgRXER0UTSjs2tDNbjF4YFjmju1wwSMyu70uRNLLEebnNxuUmC/vAX52K5bJilrydyWolAaZ+xQJzoxcxJ9ylaYh94ahvLqByfLzyKhik4+QWCfCa8SWQCra3Z2NF4EDwWU9UUWmwritPYXdU9ncMowj0KKOZz6usBz1ZD8ysZ49KGFClDVRIJd3JgArQnMDMfQMjLzASDQDkbCQDAh7ZZOQJtngxcXJQqnAGflYFh0S2TfM49n0saRB7Js58PAI0mkwlGdPwd58CET0Ej0oVoO7IQe57BIEqJYkdAPyRmLP02aL42UqlHuUV/A2QCOay2ACPgEYB+mggqywdFZUlPC0qVnUIsjoEkCjwm4L7EAci89UNQF+iZAB27MKB33GB+Uz5QRoponYm4bfwI4Uf/VP8wT/AX+DVIHvdKZ3x8d5eAbuN2mu4tvopF/KmC+rkecXulj9Oy5WscqUI/ahbnNpN6Ye9Ay7qNqFoijOS/smqAj73a+/AqC7ThnsOrzFHuvFIa9T/PP2GA+EGDEPXsaEAIPRwTdmSC40G4I7oA3v0BfypXKt1xdp/SJ9SWjN+lAzV9BL/ZeUl7heWzhhK/MS9jNPg+53sdAmmAgjymwSKbDRIqaLC40+gKwh3moYLj52lRW/x2C/+gUSQAkaQ2K307oL7jtat7cSw+iPJxKIm/ZCkHxnDnIPJJqQviMHHHHPyPxzWW4BzNUeENihtwGWcbOHiapdEVssANDB8E9UG20qktMBctOUcyQhSyvHfOci1HHaEi2KBGQWKrI/Gsh0asP8BTTFMUOtBNDyRUe9RcQmVY2TyKqWC0BybIf4LhplhX1NVib3erjF9BxNSsEErjG8BIwmMebSj22sXVoA45t3K0nOFrC6PqJTIwJLe5FQqEajkPmkkykNnvNSLiorlMHh1KrZ27QrwdLwSFQQxDKHyqoawxaG5VZlvJva/BMfmObh4RkQMnAMoPjbLpXhRisWq7yjcy95qdATgo/CPeGNhDmpli+H6mMqO0z1DcySfFkzDLhbQ34ATyRcDdISCVy176vNKXilXMcp7s5ghaIVaifqUCr4gIQ/rcNn/NYe3QDNS12mLtFUrWWPlz5StVyhcQkmRVPkl5UHgBj5V+IYrFDbkWVg1KP29JbYbozSB8HlDK41x1IIpqfACnIutTZOuid3/IEbQNMbXOIghnZK3K18D6io/19fjqd7eqdJrPM1nM8zMlvlnYaKhceAYKN8Krtbag2jj1RrWe/n6bqE7RFt/ynoDT0Kzsvtqpx2Q0pG+wgsLUVNtp+upM8WHOl4lu2rku3ljnzdxnbYroRDvVsJNCHtIRDBrF4BTVUll+3T3I06mmDUsdYT0jlqkmLUaKSixyLIxdquJ5xbO4JZ9tI4NyF8whhbr3G3HHWtDG65RdYOahqQlPY2+1lTG0gwzQTbc2btf9L6FjCzRkbXlzZxkucChvsy/40VPGyDuE4pzbACFlDUCWuvUevqDuDKGTJWUe3jrG5fpXQ4gfZk/gUrEKqEq/AO37E9mwDh7dRK2MDiUB7NllOfanCIY3Py9nJ4OKGcjNcwEeJuQVFsHO0InFPc4yWI49R8IJBLFG+38nSNOBqNQShCQQC1k5AyVYqQQQw9kGFl5rmWhfKWILYwAflVX60CgNs1Pl6Sj80M6kz9zblBaXrede7X3xlVdBr5nVAIxq6Mir2sLTXPmALXWFrxRQiJ1bPTjlS+wDtt4dbXNf8LP5nsSxUM4SGQri7AL455hqkwgH7XrseJsVfXtG2mb55ow+mrVGxZ9YYB1ysQnlOCwOaOUjGscoTwWQ+OLMbBogw1CYbPHRn3HLpeGCIwV542L/rTtHE9zFhRzq/5e79hFHA9jx2pbGalyJZ8Zw+pvEh2e1491PMOBmkgGe9NrrG6oik3idyUQv3ZDZbnLkDnjGQqwwapmK/kDDSNPkCmDVnZq2Q/vEQzVYdUpNxx0NOs9yKql9/aQGHFu1q0ivep3IalQ7W7oev2wKwtRTgtKrCjGaj3wmqltXcL6J39nK3uFmKdwtCI5yusolMNLL7HHSbNh9A1iQo9hekM1kRkJ8fTxecEW4pb85ZbDe8RJ5GqKOHYC+QV4wk9piC8iiKOTGSSW5jR0uEETTt5cX2KIEHaIouVx7KDy66I0GElKgr6Da/KL4SBnnDzBu0IuOYFSxCVWK9Slb8n/MPDejMf/svTx+YiyjNDZ19sP/pgn42gSTN4fTw7fhYfRydFheHz07t0xOkYBmh5hdDJ5Nwl/C8LjSXR4go6O8WSCDkHz++gwPJkERweBm6Ds/8t9I8syHQAA
-</script>
-
-<script id="@tomlarkworthy/acorn-8-11-3" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _1emgxs3 = function _1(md){return(
-md`# [Acorn@8.11.3](https://github.com/acornjs/acorn) & acorn-walk@8.2.2
-
-\`\`\`\`js
-import { acorn } from "@tomlarkworthy/acorn-8-11-3"
-\`\`\``
-)};
-const _1xdqqxo = function _acorn(acorn_url){return(
-import(acorn_url)
-)};
-const _vctqpi = function _acorn_walk(acorn_walk_url){return(
-import(acorn_walk_url)
-)};
-const _1c0mco9 = async function _acorn_walk_url(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("acorn-walk-8.3.2.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  return objectURL;
-};
-const _jdtsxp = async function _acorn_url(unzip,FileAttachment)
-{
-  const blob = await unzip(FileAttachment("acorn-8.11.3.js.gz"));
-
-  const objectURL = URL.createObjectURL(
-    new Blob([blob], { type: "application/javascript" })
-  );
-  return objectURL;
-};
-const _17n6uge = function _unzip(Response,DecompressionStream){return(
-async (attachment) =>
-  await new Response(
-    (await attachment.stream()).pipeThrough(new DecompressionStream("gzip"))
-  ).blob()
-)};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-  const fileAttachments = new Map(["acorn-8.11.3.js.gz","acorn-walk-8.3.2.js.gz"].map((name) => {
-    const module_name = "@tomlarkworthy/acorn-8-11-3";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
-
-  $def("_1emgxs3", null, ["md"], _1emgxs3);  
-  $def("_1xdqqxo", "acorn", ["acorn_url"], _1xdqqxo);  
-  $def("_vctqpi", "acorn_walk", ["acorn_walk_url"], _vctqpi);  
-  $def("_1c0mco9", "acorn_walk_url", ["unzip","FileAttachment"], _1c0mco9);  
-  $def("_jdtsxp", "acorn_url", ["unzip","FileAttachment"], _jdtsxp);  
-  $def("_17n6uge", "unzip", ["Response","DecompressionStream"], _17n6uge);
-  return main;
-}</script>
-
-<script id="@tomlarkworthy/cell-map" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _1t29kxm = function _1(md){return(
-md`# \`cellMap\`
-## computes the mapping of reactive variables to higher level notebook cells, grouped by module`
-)};
-const _199r1h0 = function _showBuiltins(Inputs){return(
-Inputs.toggle({ label: "builtins?", value: false })
-)};
-const _v3idap = (G, _) => G.input(_);
-const _jqf42f = function _showAnon(Inputs){return(
-Inputs.toggle({ label: "anonymous?", value: false })
-)};
-const _10za42b = (G, _) => G.input(_);
-const _125g1nt = function _cellMapViz(hash,Plot,width,d3,filteredMap,edges,linkTo,isOnObservableCom)
-{
-  hash; // update links on hash change
-  return Plot.plot({
-    width,
-    axis: null,
-    y: {
-      reverse: true
-    },
-    marks: [
-      Plot.dot(
-        [
-          [-1, d3.min(filteredMap, (d) => d.module)],
-          [1, d3.max(filteredMap, (d) => d.module) + "_"]
-        ],
-        {
-          stroke: "none"
-        }
-      ),
-      Plot.arrow(
-        edges.filter((edge) => edge[1]),
-        {
-          x1: 0,
-          y1: (edge) => `${edge[0].module}#${edge[0].name}`,
-          x2: 0,
-          y2: (edge) => `${edge[1].module}#${edge[1].name}`,
-          stroke: (edge) => edge[0].module,
-          headLength: 0,
-          bend: 90
-        }
-      ),
-      Plot.ruleY(new Set(filteredMap.map((cell) => cell.module + "-")), {
-        y: (d) => d,
-        stroke: (d) => d,
-        strokeOpacity: 0.5,
-        strokeDasharray: [5, 10]
-      }),
-      Plot.text(new Set(filteredMap.map((cell) => cell.module)), {
-        x: -1,
-        y: (d) => d + "_",
-        fill: (d) => d,
-        fontSize: 14,
-        frameAnchor: "top-left",
-        dy: 8,
-        href: (cell) => linkTo(`${cell}`),
-        ...(isOnObservableCom() && { target: "_blank" })
-      }),
-      Plot.text(
-        filteredMap,
-        Plot.pointerY({
-          x: 1,
-          text: (d) => `${d.module}#${d.name}`,
-          y: (d) => `${d.module}#${d.name}`,
-          fill: (d) => d.module,
-          fontSize: 14,
-          frameAnchor: "right",
-          href: (cell) => {
-            if (!cell) return undefined;
-            return linkTo(`${cell.module}#${cell.name}`);
-          },
-          ...(isOnObservableCom() && { target: "_blank" })
-        })
-      )
-    ]
-  });
-};
-const _cjxin = (G, _) => G.input(_);
-const _1nt2irf = function _detailVizTitle(cellMapViz,linkTo,md){return(
-md`${cellMapViz ? `### [\`${cellMapViz?.module}#${cellMapViz?.name}\`](${linkTo(`${cellMapViz?.module}#${cellMapViz?.name}`)})` : `\`<click the above viz to pin a cell and open its dependancy graph below>\``}`
-)};
-const _1lxiffy = function _detailViz(Plot,width,nodes,variableToCell,modules,linkTo,isOnObservableCom){return(
-Plot.plot({
-  symbol: {
-    domain: ["simple", "mutable", undefined, "import", " ", "viewof"],
-    legend: true
-  },
-  margin: 50,
-  axis: null,
-  width,
-  height: 1000,
-  marks: [
-    Plot.link(
-      nodes
-        .filter((d) => d.parent)
-        .map((n) => {
-          if (variableToCell.get(n.parent.data) == variableToCell.get(n.data)) {
-            n.type = variableToCell.get(n.data).type;
-          } else {
-            n.type = "connector";
-          }
-          return n;
-        }),
-      {
-        x1: "y",
-        y1: "x",
-        x2: (d) => d.parent.y,
-        y2: (d) => d.parent.x,
-        stroke: "type",
-        strokeLinecap: "round",
-        strokeWidth: (d) => (d.type == "connector" ? 2 : 20),
-        opacity: (d) => (d.type == "connector" ? 0.5 : 0.1),
-        inset: 0
-      }
-    ),
-    Plot.dot(nodes, {
-      x: "y",
-      y: "x",
-      r: 10,
-      fill: "white",
-      symbol: (node) => variableToCell.get(node.data)?.type,
-      stroke: (d) => modules.get(d.data._module)?.name,
-      strokeWidth: 4,
-      href: (d) => {
-        const cell = variableToCell.get(d.data);
-        if (!cell) return undefined;
-        return linkTo(`${cell.module}#${cell.name}`);
-      },
-      ...(isOnObservableCom() && { target: "_blank" })
-    }),
-    Plot.arrow(
-      nodes
-        .filter((d) => d.parent)
-        .flatMap((d) => d.reused.map((reused) => ({ ...d, parent: reused }))),
-      {
-        x1: "y",
-        y1: "x",
-        x2: (d) => d.parent.y,
-        y2: (d) => d.parent.x,
-        bend: -10,
-        strokeDasharray: [1, 5],
-        stroke: "red",
-        opacity: 0.5,
-        inset: 14
-      }
-    ),
-    Plot.text(nodes, {
-      x: "y",
-      y: "x",
-      text: (d) => d.data._name,
-      dy: 16
-    })
-  ]
-})
-)};
-const _j5pb2k = (G, _) => G.input(_);
-const _glmq4i = function _7(md){return(
-md`## cellMap`
-)};
-const _izhsfx = function _8(Inputs,filteredMap){return(
-Inputs.table(filteredMap, {
-  layout: "auto",
-  format: {
-    variables: (d) => d.length
-  }
-})
-)};
-const _7t7pwf = function _9(md){return(
-md`## \`liveCellMap\`
-
-Prefer using this variable for an always live view of the runtime state`
-)};
-const _1xnzq7y = async function _liveCellMap(keepalive,cellMapModule,Inputs,cellMap)
-{
-  keepalive(cellMapModule, "maintain_live_cell_map");
-  return Inputs.input(await cellMap());
-};
-const _14vvdt2 = (G, _) => G.input(_);
-const _193osz9 = async function _maintain_live_cell_map(runtime_variables,$0,cellMap,Event)
-{
-  runtime_variables;
-  $0.value = await cellMap();
-  $0.dispatchEvent(new Event("input"));
-};
-const _1vhxngh = function _usage(md){return(
-md`## cellMap function
-
-You can call it with zero args to default to the current runtime, or pass in a subset of variables to extract the cell structure from just those.
-
-\`\`\`js
-import {cellMap, liveCellMap} from "@tomlarkworthy/cell-map"
-\`\`\`
-
-If you wanted to use the visualizations in your own notebooks. You would import the views e.g.
-
-\`\`\`js
-import {viewof cellMapViz, viewof detailViz, detailVizTitle} from "@tomlarkworthy/cell-map"
-\`\`\`
-
-and then call them in your notebooks`
-)};
-const _17c6bac = function _cellMap(runtime,moduleMap,moduleVarInfo,importedModule,findModuleName,decompileImport){return(
-async (variables, _moduleMap) => {
-  const map = new Map();
-  if (!variables) variables = runtime._variables;
-  variables = [...variables];
-  if (variables.length === 0) return map;
-
-  if (!_moduleMap) _moduleMap = await moduleMap(variables[0]._module._runtime);
-
-  const byNotebookModule = new Map();
-  for (const v of variables) {
-    const info = _moduleMap.get(v._module);
-    if (!info) continue;
-    if (!byNotebookModule.has(info.module))
-      byNotebookModule.set(info.module, []);
-    byNotebookModule.get(info.module).push(v);
-  }
-
-  const isModuleVar = (v) =>
-    typeof v?._name === "string" && v._name.startsWith("module ");
-
-  await Promise.all(
-    [...byNotebookModule.keys()].map(async (m) => {
-      const variables = byNotebookModule.get(m);
-      const order = new Map(variables.map((v, i) => [v, i]));
-
-      const cells = new Map();
-      const moduleVars = variables.filter(isModuleVar);
-      const moduleVarInfos = new Map(
-        await Promise.all(
-          moduleVars.map(async (v) => [v, await moduleVarInfo(v, _moduleMap)])
-        )
-      );
-
-      const moduleVarsByKey = new Map();
-      for (const v of moduleVars) {
-        const info = moduleVarInfos.get(v);
-        const key = info?.module ?? info?.name ?? null;
-        if (!key) continue;
-        if (!moduleVarsByKey.has(key)) moduleVarsByKey.set(key, []);
-        moduleVarsByKey.get(key).push(v);
-      }
-
-      const viewofs = new Set();
-      const mutables = new Set();
-      const namedNonModuleVars = variables.filter(
-        (v) => v?._name && !isModuleVar(v)
-      );
-
-      const sources = new Map(
-        await Promise.all(
-          namedNonModuleVars.map(async (v) => [
-            v._name,
-            await importedModule(v)
-          ])
-        )
-      );
-
-      const imports = new Map();
-      const moduleNamesPromises = new Map();
-      const groups = new Map();
-      let anonCounter = 0;
-
-      for (const v of variables) {
-        if (v?._name) {
-          if (isModuleVar(v)) {
-            continue;
-          }
-
-          const source = sources.get(v._name);
-          if (source) {
-            const key = source;
-            if (!imports.has(key)) {
-              imports.set(key, []);
-              moduleNamesPromises.set(
-                key,
-                Promise.resolve(
-                  findModuleName(key, _moduleMap, { unknown_id: v._name })
-                )
-              );
-            }
-            imports.get(key).push(v);
-          } else if (v._name.startsWith("viewof ")) {
-            cells.set(v, { type: "viewof", lang: ["ojs"] });
-            viewofs.add(v);
-            groups.set(v._name, []);
-          } else if (v._name.startsWith("mutable ")) {
-            cells.set(v, { type: "mutable", lang: ["ojs"] });
-            mutables.add(v);
-            groups.set(v._name, []);
-          } else if (v._name.startsWith("dynamic ")) {
-            continue;
-          } else {
-            cells.set(v, { type: "simple", lang: ["ojs"] });
-            groups.set(v._name, [v]);
-          }
-        } else {
-          cells.set(v, { type: "simple", lang: ["ojs"] });
-          groups.set(anonCounter++, [v]);
-        }
-      }
-
-      for (const [key] of moduleVarsByKey.entries()) {
-        if (imports.has(key)) continue;
-        if (!moduleNamesPromises.has(key)) {
-          if (typeof key === "string")
-            moduleNamesPromises.set(key, Promise.resolve(key));
-          else
-            moduleNamesPromises.set(
-              key,
-              Promise.resolve(
-                findModuleName(key, _moduleMap, { unknown_id: Math.random() })
-              )
-            );
-        }
-      }
-
-      const moduleNames = new Map(
-        await Promise.all(
-          [...moduleNamesPromises.entries()].map(async ([k, p]) => [k, await p])
-        )
-      );
-
-      for (const v of viewofs) {
-        const name = v._name.substring(7);
-        if (groups.has(name)) {
-          groups.get(v._name).push(v, groups.get(name)[0]);
-          groups.delete(name);
-        } else {
-          groups.delete(v._name);
-        }
-      }
-
-      for (const v of mutables) {
-        const name = v._name.substring(8);
-        const initial = "initial " + name;
-        if (groups.has(name) && groups.has(initial)) {
-          groups
-            .get(v._name)
-            .push(groups.get(initial)?.[0], v, groups.get(name)[0]);
-          cells.delete(groups.get(initial)[0]);
-          cells.delete(groups.get(name)[0]);
-          groups.delete(initial);
-          groups.delete(name);
-        } else {
-          const vars = groups.get(v._name);
-          if (vars?.[0]) cells.delete(vars[0]);
-          groups.delete(v._name);
-          groups.delete(initial);
-          groups.delete(name);
-        }
-      }
-
-      for (const [key, importVars] of imports.entries()) {
-        const module_name =
-          moduleNames.get(key) ?? `<unknown ${Math.random()}>`;
-        let importInfo = null;
-        try {
-          importInfo = (await decompileImport(importVars)) ?? null;
-        } catch {
-          importInfo = null;
-        }
-        cells.set(importVars[0], {
-          type: "import",
-          lang: ["ojs"],
-          module_name,
-          importInfo
-        });
-
-        const groupName = `module ${module_name}`;
-        const moduleVarsForKey = moduleVarsByKey.get(key) ?? [];
-        groups.set(groupName, [...importVars, ...moduleVarsForKey]);
-        moduleVarsByKey.delete(key);
-      }
-
-      for (const [key, moduleVarsOnly] of moduleVarsByKey.entries()) {
-        if (!moduleVarsOnly.length) continue;
-        const module_name =
-          moduleNames.get(key) ??
-          (typeof key === "string" ? key : `<unknown ${Math.random()}>`);
-        let importInfo = null;
-        try {
-          importInfo = (await decompileImport(moduleVarsOnly)) ?? null;
-        } catch {
-          importInfo = null;
-        }
-        cells.set(moduleVarsOnly[0], {
-          type: "import",
-          lang: ["ojs"],
-          module_name,
-          importInfo
-        });
-
-        const groupName = `module ${module_name}`;
-        groups.set(groupName, [...moduleVarsOnly]);
-      }
-
-      const orderKey = (name, vars) => {
-        if (!vars?.length) return Infinity;
-        if (typeof name === "string" && name.startsWith("mutable ")) {
-          return order.get(vars[1] ?? vars[0]) ?? Infinity;
-        }
-        return order.get(vars[0]) ?? Infinity;
-      };
-
-      const sortedGroups = [...groups.entries()].sort((a, b) => {
-        const oa = orderKey(a[0], a[1]);
-        const ob = orderKey(b[0], b[1]);
-        if (oa !== ob) return oa - ob;
-        return String(a[0]).localeCompare(String(b[0]));
-      });
-
-      const moduleName =
-        _moduleMap.get(variables[0]._module)?.name ?? "<unknown module>";
-      map.set(
-        m,
-        sortedGroups.map(([name, variables]) => {
-          const head =
-            typeof name === "string" && name.startsWith("mutable")
-              ? variables[1]
-              : variables[0];
-          return {
-            name,
-            module: moduleName,
-            ...(cells.get(head) ?? { type: "simple", lang: ["ojs"] }),
-            variables
-          };
-        })
-      );
-    })
-  );
-
-  return map;
-}
-)};
-const _1clgb7s = async function _test_cellmap_importInfo_on_real_import(cellMap,expect)
-{
-  const mapped = await cellMap();
-  const allCells = [...mapped.values()].flat();
-  const cell = allCells.find(
-    (c) => c?.type === "import" && typeof c?.module_name === "string"
-  );
-  expect(Boolean(cell)).toBe(true);
-
-  expect(cell.type).toBe("import");
-  expect(cell.importInfo != null).toBe(true);
-  expect(cell.importInfo.type).toBe("import");
-  expect((cell.importInfo.specifiers?.length ?? 0) >= 1).toBe(true);
-
-  const vars = cell.importInfo?.meta?.variables ?? [];
-  expect(Array.isArray(vars)).toBe(true);
-  expect(vars.length >= 1).toBe(true);
-
-  return cell.importInfo;
-};
-const _yubgz5 = function _15(md){return(
-md`### \`cellMapCompat\`
-
-Migration helper from old cellMap`
-)};
-const _71n0hz = function _cellMapCompat(cellMap){return(
-async (module, { excludeInbuilt = true } = {}) => {
-  const map = await cellMap(
-    [...module._runtime._variables].filter(
-      (v) => v._module == module && (!excludeInbuilt || v._type == 1)
-    )
-  );
-  const cells = map.get(module) || [];
-  return new Map(cells.map((c) => [c.name, c.variables]));
-}
-)};
-const _x7j8bo = function _17(md){return(
-md`## Visualizations`
-)};
-const _1l7cvxn = function _nodeToSymbol(variableToCell){return(
-(node) =>
-  ({
-    viewof: "triangle",
-    mutable: "cross",
-    import: "square",
-    simple: "circle"
-  }[variableToCell.get(node.data)?.type] || "diamond")
-)};
-const _y7kfs7 = function _focus_variables(cellMapViz,descendants,ascendants){return(
-cellMapViz
-  ? [
-      ...descendants(cellMapViz.variables[0]),
-      ...ascendants(cellMapViz.variables[0])
-    ]
-  : []
-)};
-const _14ty3wh = function _focus_cells(focus_variables,variableToCell){return(
-new Set(focus_variables.map((v) => variableToCell.get(v)))
-)};
-const _12jpxa2 = function _descendents(d3,cellMapViz){return(
-d3.hierarchy(
-  cellMapViz ? cellMapViz.variables[0] : [],
-  (variable) => {
-    return variable._inputs;
-  }
-)
-)};
-const _16z9f8f = function _dedupeHierarchy(){return(
-function dedupeHierarchy(root) {
-  const key = (n) => n.data;
-  const deepest = new Map(); // datum → deepest node
-
-  // pass-1: pick deepest representative
-  root.each((n) => {
-    const k = key(n);
-    if (!deepest.has(k) || n.depth > deepest.get(k).depth) deepest.set(k, n);
-  });
-  deepest.forEach((n) => {
-    n.reused = [];
-  });
-
-  // pass-2: alias shallower nodes → deepest
-  root.each((n) => {
-    const rep = deepest.get(key(n));
-    n.name = n.data._name;
-    const p = n.parent;
-    if (n !== rep) {
-      if (p) {
-        p.children = p.children.map((c) => (c === n ? rep : c));
-        if (!rep.reused.includes(p) && p == deepest.get(key(p)))
-          rep.reused.push(p);
-      }
-    }
-  });
-  return root;
-}
-)};
-const _1j8atwc = function _layout(d3,descendents){return(
-d3.tree()(descendents)
-)};
-const _eb858t = function _clustered(dedupeHierarchy,layout){return(
-dedupeHierarchy(layout)
-)};
-const _17lllwm = function _nodes(clustered){return(
-clustered.descendants().map((n) => ({ name: n.data._name, ...n }))
-)};
-const _ng770d = function _26(md){return(
-md`### visualize the cell ordering`
-)};
-const _xpas1q = function _runtimeMap(runtime_variables,liveCellMap)
-{
-  runtime_variables;
-  return [...liveCellMap.values()].flat();
-};
-const _hishw1 = function _variableToCell(runtimeMap){return(
-new Map(
-  runtimeMap.flatMap((cell) => cell.variables.map((v) => [v, cell]))
-)
-)};
-const _szpnyp = function _filteredMap(runtimeMap,filter){return(
-runtimeMap.filter(filter)
-)};
-const _1jdpo9p = function _filter(showBuiltins,showAnon){return(
-(v) =>
-  (showBuiltins || (v.module !== "builtin" && v.name !== "module builtin")) &&
-  (showAnon || typeof v.name == "string")
-)};
-const _10gdqhm = function _edges(filteredMap,variableToCell,filter){return(
-filteredMap.flatMap((cell) =>
-  cell.variables.flatMap((variable) =>
-    variable._inputs
-      .map((input) => [variableToCell.get(variable), variableToCell.get(input)])
-      .filter(([source, imported]) => imported && filter(imported))
-  )
-)
-)};
-const _qb7351 = function _cellMapModule(thisModule){return(
-thisModule()
-)};
-const _120483s = (G, _) => G.input(_);
-const _2ufyg8 = function _38(md){return(
-md`## testing`
-)};
-const _18tubss = function _39(tests){return(
-tests({
-  filter: (t) =>
-    t.name.includes("@tomlarkworthy/cell-map") || t.name.includes("main")
-})
-)};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
-)};
-const _jrvq7q = function _moduleLookup(modules){return(
-new Map([...modules.values()].map((info) => [info.name, info]))
-)};
-const _rlmpw8 = function _42(md){return(
-md`low-level variables in this module`
-)};
-const _519lii = function _43(Inputs,runtime_variables,cellMapModule,toObject,modules){return(
-Inputs.table(
-  [...runtime_variables]
-    .filter((v) => v._module == cellMapModule)
-    .map(toObject),
-  {
-    columns: [
-      "_name",
-      "_inputs",
-      "_definition",
-      "_type",
-      "_reachable",
-      "_observer",
-      "_module"
-    ],
-    format: {
-      _inputs: (i) => i.map((i) => i._name).join(", "),
-      _observer: (i) => i.toString(),
-      _module: (m) => modules.get(m).name
-    }
-  }
-)
-)};
-const _pyrytd = function _unreached_main_import(toObject,lookupVariable,cellMapModule){return(
-toObject &&
-  lookupVariable("repositionSetElement", cellMapModule)
-)};
-const _12euivr = function _reached_main_import(runtime,lookupVariable,cellMapModule){return(
-runtime && lookupVariable("runtime", cellMapModule)
-)};
-const _1x88m7u = function _main_mutable(){return(
-"OK"
-)};
-const _1c3nv1y = (M, _) => new M(_);
-const _kbdqj3 = _ => _.generator;
-const _1q0qa04 = async function _test_importedModule(expect,modules,importedModule,reached_main_import,unreached_main_import)
-{
-  expect(modules.get(await importedModule(reached_main_import)).name).toBe(
-    "@tomlarkworthy/module-map"
-  );
-
-  expect(modules.get(await importedModule(unreached_main_import)).name).toBe(
-    "@tomlarkworthy/runtime-sdk"
-  );
-
-  return "ok";
-};
-const _1tqu9mu = async function _test_findModuleName(expect,findModuleName,importedModule,reached_main_import,modules,unreached_main_import)
-{
-  expect(
-    findModuleName(await importedModule(reached_main_import), modules)
-  ).toBe("@tomlarkworthy/module-map");
-
-  expect(
-    findModuleName(await importedModule(unreached_main_import), modules)
-  ).toBe("@tomlarkworthy/runtime-sdk");
-
-  return "ok";
-};
-const _1mk5ruc = async function _test_cellmap_mutable(main_mutable,lookupVariable,cellMapModule,cellMap,modules,expect)
-{
-  const initialMutable =
-    main_mutable &&
-    (await lookupVariable("initial main_mutable", cellMapModule));
-  const mutableMutable =
-    main_mutable &&
-    (await lookupVariable("mutable main_mutable", cellMapModule));
-  const mainMutable =
-    main_mutable && (await lookupVariable("main_mutable", cellMapModule));
-  const mapped = await cellMap(
-    [initialMutable, mutableMutable, mainMutable],
-    modules
-  );
-  const module = mapped.get(cellMapModule);
-  expect(module).toHaveLength(1);
-  const mutableCell = module[0];
-
-  expect(mutableCell.type).toBe("mutable");
-  expect(mutableCell.variables).toHaveLength(3);
-  return mutableCell;
-};
-const _rpm6xw = function _50(md){return(
-md`### Notebook 2.0 Compatability`
-)};
-const _1rtpyzk = function _cellMapVizView($0){return(
-$0
-)};
-const _1srzrzc = function _52(md){return(
-md`detailVizView = viewof detailViz`
-)};
-const _1hybsm8 = function _coverage_failures(runtime_variables,liveCellMap,modules)
-{
-  const byModule = new Map();
-  for (const v of runtime_variables) {
-    const m = v._module;
-    let arr = byModule.get(m);
-    if (!arr) byModule.set(m, (arr = []));
-    arr.push(v);
-  }
-
-  const isDynamic = (v) =>
-    typeof v?._name === "string" && v._name.startsWith("dynamic");
-
-  const failures = [];
-  for (const [m, vars] of byModule.entries()) {
-    const cells = liveCellMap.get(m) || [];
-    const covered = new Set(cells.flatMap((c) => c.variables || []));
-    const missing = vars.filter(
-      (v) => v._type == 1 && !isDynamic(v) && !covered.has(v)
-    );
-    if (missing.length) {
-      const moduleName = modules?.get(m)?.name ?? "<unknown module>";
-      failures.push({
-        module: moduleName,
-        missing: missing.map((v, i) => v._name ?? `<anonymous ${i}>`)
-      });
-    }
-  }
-  return failures;
-};
-const _1p0qclg = function _test_cell_map_covers_all_runtime_variables(coverage_failures)
-{
-  if (coverage_failures.length) {
-    throw JSON.stringify(coverage_failures);
-  }
-  return "pass";
-};
-const _1a18z7a = function _test_cell_map_no_variable_in_more_than_one_cell(runtime_variables,liveCellMap,modules)
-{
-  runtime_variables;
-
-  const where = new Map(); // variable -> Set(cellId)
-  const add = (v, cellId) => {
-    let s = where.get(v);
-    if (!s) where.set(v, (s = new Set()));
-    s.add(cellId);
-  };
-
-  for (const [m, cells] of liveCellMap.entries()) {
-    const moduleName = modules?.get(m)?.name ?? "<unknown module>";
-    for (const c of cells ?? []) {
-      const cellId = `${moduleName}#${String(c?.name ?? "<unknown cell>")}`;
-      const vars = c?.variables ?? [];
-      const uniq = new Set(vars);
-      for (const v of uniq) add(v, cellId);
-    }
-  }
-
-  const failures = [];
-  for (const [v, cellIds] of where.entries()) {
-    if (cellIds.size > 1) {
-      const vModuleName = modules?.get(v?._module)?.name ?? "<unknown module>";
-      failures.push({
-        variable_module: vModuleName,
-        variable_name: v?._name ?? "<anonymous>",
-        cells: [...cellIds]
-      });
-    }
-  }
-
-  if (failures.length) throw JSON.stringify(failures);
-  return "pass";
-};
-const _8nkqnx = function _56(md){return(
-md`### Utilities`
-)};
-const _2h3a9s = function _importedModule(){return(
-async (v) => {
-  if (
-    // imported variable is observed
-    v._inputs.length == 1 && // always a single dependancy
-    v._inputs[0]._module !== v._module // bridging across modules
-  )
-    return v._inputs[0]._module;
-
-  // Import from API
-  // 'async () => runtime.module((await import("/@tomlarkworthy/exporter.js?v=4&resolutions=ab5a63c64de95b0d@298")).default)'
-  /*
-  if (
-    v._inputs.length == 0 &&
-    v._definition.toString().includes("runtime.module((await import")
-  ) {
-    debugger;
-    v._value = await v._definition();
-    return v._value;
-  }*/
-  if (
-    // imported variable unobserved and loaded by API
-    v._inputs.length == 2 && // always a single dependancy
-    v._inputs[1]._name == "@variable" // bridging across modules
-  ) {
-    if (v._inputs[0]._value) return v._inputs[0]._value;
-    else {
-      return;
-      //const module = await v._inputs[0]._definition();
-      //debugger;
-      //return module;
-    }
-  }
-
-  // The inline case for live notebook. Two compiler shapes, one probe object:
-  //   legacy    "async t => t.import(e.name, e.alias, await i)"
-  //   notebook-kit (new.observablehq.com)
-  //             "async (__variable) => { ... __variable._module._runtime.module(_.default) ... }"
-  if (
-    v._inputs.length == 1 &&
-    v._inputs[0]._name == "@variable" &&
-    v._definition.toString().includes("import(")
-  ) {
-    const rt = v._module?._runtime;
-    let captured = null;
-    const probe = {
-      import: (...args) => {
-        captured ??= args[2];
-      },
-      _outputs: [],
-      _module: {
-        _runtime: {
-          module: (...args) => {
-            const m = rt.module(...args);
-            captured ??= m;
-            return m;
-          }
-        }
-      }
-    };
-    try {
-      await v._definition(probe);
-      return captured;
-    } catch (err) {
-      if (v._definition.toString().includes("derive")) {
-        console.error("Subbing derrived module for original", v);
-        const derrived = await v._definition(v);
-        return derrived._source;
-      }
-      // never leave the caller hanging — cellMap degrades to "no source module"
-      console.error("Cannot sourceModule for ", v, err);
-      return captured;
-    }
-  }
-
-  return null;
-}
-)};
-const _n7jdgk = function _findModuleName(){return(
-(module, moduleMap, { unknown_id = Math.random() } = {}) => {
-  try {
-    const lookup = moduleMap.get(module);
-    if (lookup) return lookup.name;
-    return `<unknown ${unknown_id}>`;
-  } catch (e) {
-    debugger;
-    return "error";
-  }
-}
-)};
-const _1ii3nc0 = function _extractObservableNotebookNameFromSpecifier(){return(
-(specifier) => {
-  if (specifier == null) return null;
-  const s = String(specifier);
-  try {
-    const u = new URL(s, "https://api.observablehq.com/");
-    const p = u.pathname;
-    let m = p.match(/\/(@[^/]+\/[^/]+)\.js$/);
-    if (m) return m[1];
-    m = p.match(/\/(d\/[0-9a-f]+@\d+)\.js$/);
-    if (m) return m[1];
-    m = p.match(/\/(d\/[0-9a-f]+)\.js$/);
-    if (m) return m[1];
-    return null;
-  } catch {
-    return null;
-  }
-}
-)};
-const _ejsyo1 = function _moduleVarInfo(extractObservableNotebookNameFromSpecifier){return(
-async (v, moduleMapLike) => {
-  const mod = v?._value ?? null;
-  const nameFromMap =
-    mod && moduleMapLike?.get?.(mod)?.name ? moduleMapLike.get(mod).name : null;
-
-  const def = v?._definition;
-  const defSrc = typeof def?.toString === "function" ? def.toString() : "";
-  const m = defSrc.match(/\bimport\(\s*(['"])(.*?)\1\s*\)/);
-  const specifier = m?.[2] ?? null;
-  const nameFromSpecifier =
-    extractObservableNotebookNameFromSpecifier(specifier);
-
-  return {
-    module: mod,
-    name: nameFromMap ?? nameFromSpecifier ?? null,
-    specifier
-  };
-}
-)};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
-  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
-  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  $def("_1t29kxm", null, ["md"], _1t29kxm);  
-  $def("_199r1h0", "viewof showBuiltins", ["Inputs"], _199r1h0);  
-  $def("_v3idap", "showBuiltins", ["Generators","viewof showBuiltins"], _v3idap);  
-  $def("_jqf42f", "viewof showAnon", ["Inputs"], _jqf42f);  
-  $def("_10za42b", "showAnon", ["Generators","viewof showAnon"], _10za42b);  
-  $def("_125g1nt", "viewof cellMapViz", ["hash","Plot","width","d3","filteredMap","edges","linkTo","isOnObservableCom"], _125g1nt);  
-  $def("_cjxin", "cellMapViz", ["Generators","viewof cellMapViz"], _cjxin);  
-  $def("_1nt2irf", "detailVizTitle", ["cellMapViz","linkTo","md"], _1nt2irf);  
-  $def("_1lxiffy", "viewof detailViz", ["Plot","width","nodes","variableToCell","modules","linkTo","isOnObservableCom"], _1lxiffy);  
-  $def("_j5pb2k", "detailViz", ["Generators","viewof detailViz"], _j5pb2k);  
-  $def("_glmq4i", null, ["md"], _glmq4i);  
-  $def("_izhsfx", null, ["Inputs","filteredMap"], _izhsfx);  
-  $def("_7t7pwf", null, ["md"], _7t7pwf);  
-  $def("_1xnzq7y", "viewof liveCellMap", ["keepalive","cellMapModule","Inputs","cellMap"], _1xnzq7y);  
-  $def("_14vvdt2", "liveCellMap", ["Generators","viewof liveCellMap"], _14vvdt2);  
-  $def("_193osz9", "maintain_live_cell_map", ["runtime_variables","viewof liveCellMap","cellMap","Event"], _193osz9);  
-  $def("_1vhxngh", "usage", ["md"], _1vhxngh);  
-  $def("_17c6bac", "cellMap", ["runtime","moduleMap","moduleVarInfo","importedModule","findModuleName","decompileImport"], _17c6bac);  
-  $def("_1clgb7s", "test_cellmap_importInfo_on_real_import", ["cellMap","expect"], _1clgb7s);  
-  $def("_yubgz5", null, ["md"], _yubgz5);  
-  $def("_71n0hz", "cellMapCompat", ["cellMap"], _71n0hz);  
-  $def("_x7j8bo", null, ["md"], _x7j8bo);  
-  $def("_1l7cvxn", "nodeToSymbol", ["variableToCell"], _1l7cvxn);  
-  $def("_y7kfs7", "focus_variables", ["cellMapViz","descendants","ascendants"], _y7kfs7);  
-  $def("_14ty3wh", "focus_cells", ["focus_variables","variableToCell"], _14ty3wh);  
-  $def("_12jpxa2", "descendents", ["d3","cellMapViz"], _12jpxa2);  
-  $def("_16z9f8f", "dedupeHierarchy", [], _16z9f8f);  
-  $def("_1j8atwc", "layout", ["d3","descendents"], _1j8atwc);  
-  $def("_eb858t", "clustered", ["dedupeHierarchy","layout"], _eb858t);  
-  $def("_17lllwm", "nodes", ["clustered"], _17lllwm);  
-  $def("_ng770d", null, ["md"], _ng770d);  
-  $def("_xpas1q", "runtimeMap", ["runtime_variables","liveCellMap"], _xpas1q);  
-  $def("_hishw1", "variableToCell", ["runtimeMap"], _hishw1);  
-  $def("_szpnyp", "filteredMap", ["runtimeMap","filter"], _szpnyp);  
-  $def("_1jdpo9p", "filter", ["showBuiltins","showAnon"], _1jdpo9p);  
-  $def("_10gdqhm", "edges", ["filteredMap","variableToCell","filter"], _10gdqhm);  
-  main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("isOnObservableCom", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
-  main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
-  main.define("runtime", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
-  main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
-  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
-  main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
-  main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
-  main.define("ascendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("ascendants", _));  
-  main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
-  main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
-  $def("_qb7351", "viewof cellMapModule", ["thisModule"], _qb7351);  
-  $def("_120483s", "cellMapModule", ["Generators","viewof cellMapModule"], _120483s);  
-  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
-  $def("_2ufyg8", null, ["md"], _2ufyg8);  
-  $def("_18tubss", null, ["tests"], _18tubss);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
-  $def("_jrvq7q", "moduleLookup", ["modules"], _jrvq7q);  
-  $def("_rlmpw8", null, ["md"], _rlmpw8);  
-  $def("_519lii", null, ["Inputs","runtime_variables","cellMapModule","toObject","modules"], _519lii);  
-  $def("_pyrytd", "unreached_main_import", ["toObject","lookupVariable","cellMapModule"], _pyrytd);  
-  $def("_12euivr", "reached_main_import", ["runtime","lookupVariable","cellMapModule"], _12euivr);  
-  $def("_1x88m7u", "initial main_mutable", [], _1x88m7u);  
-  $def("_1c3nv1y", "mutable main_mutable", ["Mutable","initial main_mutable"], _1c3nv1y);  
-  $def("_kbdqj3", "main_mutable", ["mutable main_mutable"], _kbdqj3);  
-  $def("_1q0qa04", "test_importedModule", ["expect","modules","importedModule","reached_main_import","unreached_main_import"], _1q0qa04);  
-  $def("_1tqu9mu", "test_findModuleName", ["expect","findModuleName","importedModule","reached_main_import","modules","unreached_main_import"], _1tqu9mu);  
-  $def("_1mk5ruc", "test_cellmap_mutable", ["main_mutable","lookupVariable","cellMapModule","cellMap","modules","expect"], _1mk5ruc);  
-  $def("_rpm6xw", null, ["md"], _rpm6xw);  
-  $def("_1rtpyzk", "cellMapVizView", ["viewof cellMapViz"], _1rtpyzk);  
-  $def("_1srzrzc", null, ["md"], _1srzrzc);  
-  $def("_1hybsm8", "coverage_failures", ["runtime_variables","liveCellMap","modules"], _1hybsm8);  
-  $def("_1p0qclg", "test_cell_map_covers_all_runtime_variables", ["coverage_failures"], _1p0qclg);  
-  $def("_1a18z7a", "test_cell_map_no_variable_in_more_than_one_cell", ["runtime_variables","liveCellMap","modules"], _1a18z7a);  
-  $def("_8nkqnx", null, ["md"], _8nkqnx);  
-  $def("_2h3a9s", "importedModule", [], _2h3a9s);  
-  $def("_n7jdgk", "findModuleName", [], _n7jdgk);  
-  $def("_1ii3nc0", "extractObservableNotebookNameFromSpecifier", [], _1ii3nc0);  
-  $def("_ejsyo1", "moduleVarInfo", ["extractObservableNotebookNameFromSpecifier"], _ejsyo1);  
-  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
-  main.define("decompileImport", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompileImport", _));
-  return main;
-}</script>
-
-<script id="@tomlarkworthy/cells-to-clipboard" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _y5656o = function _1(md){return(
-md`# Save source to clipboard
-
-\`\`\`js
-import {cellsToClipboard} from '@tomlarkworthy/cells-to-clipboard'
-\`\`\`
-
-Fork of [@tophtucker/generate-copied-cells](https://observablehq.com/@tophtucker/generate-copied-cells) to expose just the raw function. It won't work unless its executing during event handling
-`
-)};
-const _11ad3zw = function _2(copyCellButton){return(
-copyCellButton(["x = Math.sin(now / 1000)", "y = Math.round(x * 10)"])
-)};
-const _22fbf0 = function _3(copyCellButton){return(
-copyCellButton([{type: "md", value: "# Hello"}, "now"])
-)};
-const _1sqtx83 = function _4(md){return(
-md`Once you click “Copy cells”, press Esc to focus the main page and then Cmd-V.`
-)};
-const _10uloef = function _5(md){return(
-md`---
-## Implementation`
-)};
-const _1seifpc = function _cellsToClipboard(makeCell){return(
-(cells) => {
-  function listener(e) {
-    e.clipboardData.setData("text/plain", cells.join("\n\n"));
-    e.clipboardData.setData(
-      "application/vnd.observablehq+json",
-      JSON.stringify(cells.map(makeCell))
-    );
-    e.preventDefault();
-  }
-  document.addEventListener("copy", listener);
-  document.execCommand("copy");
-  document.removeEventListener("copy", listener);
-}
-)};
-const _1i8jhrq = function _copyCellButton(Inputs,cellsToClipboard){return(
-(cells) =>
-  Inputs.button("Copy cells", { reduce: () => cellsToClipboard(cells) })
-)};
-const _1ud4fa1 = function _makeCell($0,defaultJS,defaultOther){return(
-value => {
-  const id = $0.value++;
-  if (typeof value === 'string') {
-    return {
-      ...defaultJS,
-      id,
-      value
-    };
-  } else if (typeof value === 'object') {
-    if (value.type === 'js')
-      return {
-        ...defaultJS,
-        id,
-        ...value
-      };
-    return {
-      ...defaultOther,
-      id,
-      ...value
-    };
-  } else {
-    throw new Error('Value must be string or object');
-  }
-}
-)};
-const _h1t91h = function _defaultJS(){return(
-{
-  id: 0,
-  value: "",
-  pinned: true,
-  mode: "js",
-  data: null,
-  name: null
-}
-)};
-const _but2s9 = function _defaultOther(){return(
-{
-  id: 0,
-  value: "",
-  pinned: false,
-  mode: "md",
-  data: null,
-  name: ""
-}
-)};
-const _lj7470 = function _id(){return(
-0
-)};
-const _1bwa5dj = (M, _) => new M(_);
-const _mshfha = _ => _.generator;
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  $def("_y5656o", null, ["md"], _y5656o);  
-  $def("_11ad3zw", null, ["copyCellButton"], _11ad3zw);  
-  $def("_22fbf0", null, ["copyCellButton"], _22fbf0);  
-  $def("_1sqtx83", null, ["md"], _1sqtx83);  
-  $def("_10uloef", null, ["md"], _10uloef);  
-  $def("_1seifpc", "cellsToClipboard", ["makeCell"], _1seifpc);  
-  $def("_1i8jhrq", "copyCellButton", ["Inputs","cellsToClipboard"], _1i8jhrq);  
-  $def("_1ud4fa1", "makeCell", ["mutable id","defaultJS","defaultOther"], _1ud4fa1);  
-  $def("_h1t91h", "defaultJS", [], _h1t91h);  
-  $def("_but2s9", "defaultOther", [], _but2s9);  
-  $def("_lj7470", "initial id", [], _lj7470);  
-  $def("_1bwa5dj", "mutable id", ["Mutable","initial id"], _1bwa5dj);  
-  $def("_mshfha", "id", ["mutable id"], _mshfha);
-  return main;
-}</script>
 
 <script id="@tomlarkworthy/claude-code-pairing" 
   type="text/plain"
@@ -3554,9 +2101,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +2113,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +2279,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +2305,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +2775,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -4268,6 +2814,3175 @@ export default function define(runtime, observer) {
   main.define("viewof syncEnabled", ["module @tomlarkworthy/file-sync", "@variable"], (_, v) => v.import("viewof syncEnabled", _));  
   main.define("syncEnabled", ["module @tomlarkworthy/file-sync", "@variable"], (_, v) => v.import("syncEnabled", _));  
   main.define("syncStatus", ["module @tomlarkworthy/file-sync", "@variable"], (_, v) => v.import("syncStatus", _));
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/lopepage" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1xyxga0 = function _page(htl,isOnObservableCom,lopeviz_handle_css,base_css,light_theme_css,commandPaletteStyles,commandPaletteOverlay,linkTo){return(
+htl.html`<div id="lopepage" style="height: ${
+  isOnObservableCom() ? "800px" : "100vh"
+}">
+  ${lopeviz_handle_css}
+  ${base_css}
+  ${light_theme_css}
+  ${commandPaletteStyles}
+${commandPaletteOverlay}
+  <style>
+    html body {
+      max-width: 100vw;
+    }
+    html {
+      padding: 0px !important;
+      margin: 0px !important;
+    }
+    #lopepage:has(.observablehq-root) > .module-explorer {
+      display: none;
+    }
+  </style>
+  <h1 style="display:none;">Lopepage</h1>
+  <div class="module-explorer">
+    <p>Lost? Open the <a href="${linkTo("@tomlarkworthy/module-selection", {
+      onObservable: false
+    })}">module explorer</a> or press CMD + K to open the command palatte.
+  </div>
+</div>`
+)};
+const _1ujnhdh = function _append_to_body(page)
+{
+    // If exported in headless mode, this will attach the page
+    if (!page.isConnected) {
+        document.body.appendChild(page);
+    }
+};
+const _1nv51s8 = function _testNavigation(htl,linkTo){return(
+htl.html`<h2>Manual Testing links</h2>
+<ul>
+<li><a href="https://observablehq.com/@tomlarkworthy/lopepage#testNavigation">refresh page</a></li>
+<li><a href="#testNavigation">reset view</a></li>
+<li><a href="${ linkTo('@tomlarkworthy/stream-operators', { onObservable: false }) }">stream-operators</a> module</li>
+<li><a href="${ linkTo('@tomlarkworthy/stream-operators#combineLatest', { onObservable: false }) }">stream-operators#combineLatest</a> 
+<li><a href="${ linkTo('@tomlarkworthy/runtime-sdk#observe', { onObservable: false }) }">runtime-sdk#observe</a> cell</li>
+</ul>`
+)};
+const _ydvyos = function _reload(Inputs){return(
+Inputs.button('reload')
+)};
+const _1we0ggl = (G, _) => G.input(_);
+const _plefwg = function _onLoadConfig(parseGoldenDSL,URLSearchParams,location)
+{
+    try {
+        return parseGoldenDSL(new URLSearchParams(location.hash.substring(1)).get('view'));
+    } catch (err) {
+        return undefined;
+    }
+};
+const _1nzpnqy = function _visualizer_cache(reload)
+{
+    reload;
+    return new Map();
+};
+const _1ojown8 = function _modulePanel(appendScrollLog,currentModules,file_attachment_cache,renderFileAttachment,visualizer_cache,visualizer,runtime,isOnObservableCom,scrollKeyFor,fix_scroll,scroll_cache)
+{
+  return function (container, component) {
+    appendScrollLog('modulePanel:enter', {
+      title: container?.title ?? null,
+      componentCell: component?.cell ?? null
+    });
+    const moduleInfo = [...currentModules.values()].find(m => m.name == container.title);
+    if (!moduleInfo) {
+      // Fall through to file attachment: titles like @user/notebook/path.ext
+      // resolve via the lopecode bootloader's contentSync DOM lookup.
+      const title = container?.title ?? null;
+      if (title) {
+        let node = file_attachment_cache.get(title);
+        if (!node) {
+          const r = window.lopecode?.contentSync?.(title);
+          if (r && r.status === 200 && r.bytes) {
+            node = renderFileAttachment(r.mime, r.bytes);
+            file_attachment_cache.set(title, node);
+            appendScrollLog('modulePanel:file_attachment_create', {
+              title,
+              mime: r.mime
+            });
+          }
+        }
+        if (node) {
+          const c_element = container.getElement();
+          if (node.parentNode !== c_element)
+            c_element.appendChild(node);
+          appendScrollLog('modulePanel:file_attachment_mount', { title });
+          return;
+        }
+      }
+      appendScrollLog('modulePanel:missing_moduleInfo', { title });
+      return;
+    }
+    const module = moduleInfo.module;
+    let node;
+    if (!visualizer_cache.has(module)) {
+      appendScrollLog('modulePanel:visualizer_create', { title: container?.title ?? null });
+      node = visualizer(runtime, {
+        invalidation: new Promise(r => {
+        }),
+        module,
+        detachNodes: isOnObservableCom(),
+        filter: (cell_name, variables) => {
+          if (variables[0]._type !== 1)
+            return false;
+          if (typeof cell_name == 'string') {
+            if (cell_name.startsWith('dynamic '))
+              return false;
+          }
+          return true;
+        }
+      });
+      visualizer_cache.set(module, node);
+    } else {
+      node = visualizer_cache.get(module);
+      appendScrollLog('modulePanel:visualizer_reuse', { title: container?.title ?? null });
+    }
+    const cell = module._scope.get(component.cell);
+    const scrollKey = scrollKeyFor(container);
+    fix_scroll(container, node, cell, scrollKey);
+    const el = container.getElement();
+    if (!el.__lope_scroll_bound) {
+      el.__lope_scroll_bound = true;
+      appendScrollLog('modulePanel:bind_scroll_listener', { title: container?.title ?? null });
+      const markUserScroll = () => {
+        el.__lope_user_scroll_at = Date.now();
+      };
+      el.addEventListener('wheel', markUserScroll, { passive: true });
+      el.addEventListener('touchmove', markUserScroll, { passive: true });
+      el.addEventListener('keydown', markUserScroll, { passive: true });
+      el.addEventListener('scroll', () => {
+        if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+          appendScrollLog('scroll:skip_reflow', { title: container?.title ?? null });
+          return;
+        }
+        // Only cache scrolls following a genuine user gesture; reflow-induced
+        // scroll events (e.g. closing an adjacent panel) carry stale scrollTops.
+        if (Date.now() - (el.__lope_user_scroll_at || 0) > 400) {
+          appendScrollLog('scroll:skip_nonuser', { title: container?.title ?? null });
+          return;
+        }
+        const k = scrollKeyFor(container);
+        const scrollTop = el.scrollTop;
+        const scrollLeft = el.scrollLeft;
+        if (scrollTop == 0) {
+          appendScrollLog('modulePanel:skip 0 scroll', {
+            title: container?.title ?? null,
+            scrollKey
+          });
+          return;
+        }
+        scroll_cache.set(k, {
+          scrollTop,
+          scrollLeft,
+          t: Date.now()
+        });
+        appendScrollLog('scroll:event', {
+          k,
+          title: container?.title ?? null,
+          scrollTop,
+          scrollLeft
+        });
+      }, { passive: true });
+    }
+    // Capture current scroll before this tab is destroyed/reflowed (e.g. when closing tabs)
+    if (!container.__lope_destroy_bound) {
+      container.__lope_destroy_bound = true;
+      container.on('destroy', () => {
+        try {
+          if (Date.now() < (scroll_cache.__reflowUntil || 0)) {
+            appendScrollLog('scroll:destroy_skip_reflow', { title: container?.title ?? null });
+            return;
+          }
+          const k = scrollKeyFor(container);
+          const scrollTop = el?.scrollTop;
+          const scrollLeft = el?.scrollLeft;
+          if (scrollTop == 0) {
+            appendScrollLog('scroll:skip 0 scroll', {
+              k,
+              key: container?.title ?? null,
+              scrollKey
+            });
+            return;
+          }
+          // do not skip 0 here: if the user is at top, preserve that state
+          scroll_cache.set(k, {
+            scrollTop,
+            scrollLeft,
+            t: Date.now()
+          });
+          appendScrollLog('scroll:destroy_capture', {
+            k,
+            title: container?.title ?? null,
+            scrollTop,
+            scrollLeft
+          });
+        } catch (e) {
+          appendScrollLog('scroll:destroy_capture:error', {
+            title: container?.title ?? null,
+            error: String(e)
+          });
+        }
+      });
+    }
+    // When GoldenLayout resizes this panel (e.g. an adjacent panel is closed) the
+    // browser can shift scrollTop; re-apply the user's cached position after the reflow.
+    if (!container.__lope_resize_bound) {
+      container.__lope_resize_bound = true;
+      container.on('resize', () => {
+        const rk = scrollKeyFor(container);
+        const cached = scroll_cache.get(rk);
+        if (!cached || cached.scrollTop == null)
+          return;
+        const c_el = container.getElement();
+        const at = Date.now();
+        scroll_cache.__reflowUntil = at + 800;
+        // The reflow can shift scrollTop in several passes (content relayout
+        // settles ~300ms later), so re-apply over a window. Bail if the user scrolls.
+        const apply = () => {
+          if ((c_el.__lope_user_scroll_at || 0) > at)
+            return;
+          if (c_el.scrollTop !== cached.scrollTop)
+            c_el.scrollTop = cached.scrollTop;
+          if (cached.scrollLeft != null && c_el.scrollLeft !== cached.scrollLeft)
+            c_el.scrollLeft = cached.scrollLeft;
+        };
+        requestAnimationFrame(apply);
+        for (const d of [
+            60,
+            150,
+            300,
+            450,
+            600
+          ])
+          setTimeout(apply, d);
+        appendScrollLog('scroll:resize_restore', {
+          k: rk,
+          title: container?.title ?? null,
+          scrollTop: cached.scrollTop
+        });
+      });
+    }
+    appendScrollLog('modulePanel:exit', {
+      title: container?.title ?? null,
+      scrollKey
+    });
+  };
+};
+const _1gm4gbf = function _blobPanel(){return(
+function (container, component) {
+    const node = document.createElement('iframe');
+    node.src = component.url;
+    const c_element = container.getElement();
+    const element = c_element.appendChild(node);
+}
+)};
+const _lxv2e2 = function _settings(){return(
+{
+    showMaximiseIcon: false,
+    showPopoutIcon: false,
+    showCloseIcon: true,
+    hasHeaders: true
+}
+)};
+const _lp1ggk = function _is_mobile(width){return(
+width < 800
+)};
+const _qbghwu = function _config(onLoadConfig,settings)
+{
+    if (onLoadConfig) {
+        return {
+            settings: settings,
+            content: [onLoadConfig]
+        };
+    }
+    return { settings: settings };
+};
+const _15lk82w = (M, _) => new M(_);
+const _1bki6eh = _ => _.generator;
+const _14z0bay = function _resize(Generators,addEventListener,invalidation,removeEventListener){return(
+Generators.observe(notify => {
+    notify(undefined);
+    addEventListener('resize', notify);
+    invalidation.then(() => removeEventListener('resize', notify));
+})
+)};
+const _18jv72h = function _layout(resize,gl,$0,page,modulePanel,blobPanel)
+{
+    // Removed resizing re-laying out because it causes problems with components that watch focus
+    // when the the layout is redone, the components are killed and removed, damaging focus state.
+    // mobile keyboards cause a resize, breaking the component that has focus
+    resize;
+    let layout = this;
+    if (!layout) {
+        layout = new gl.GoldenLayout($0.value, page);
+        layout.registerComponent('module', modulePanel);
+        layout.registerComponent('blob', blobPanel);
+        layout.init();
+    } else {
+        layout.updateSize();
+    }
+    // TODO layout destroy is destructive
+    // invalidation.then(() => {
+    //   // avoid layouts stacking up
+    //   layout.destroy();
+    // });
+    return layout;
+};
+const _tsjb2x = function _layout_state(appendScrollLog,layout,gl,$0)
+{
+    appendScrollLog('layout_state:bind', { hasLayout: !!layout });
+    return layout.on('stateChanged', () => {
+        appendScrollLog('layout:stateChanged', {});
+        const state = gl.LayoutConfig.fromResolved(layout.toConfig());
+        $0.value = state;
+        appendScrollLog('layout:stateChanged:config_updated', { rootType: state?.root?.type ?? null });
+    });
+};
+const _11nrwvj = function _lopepageModule(thisModule){return(
+thisModule()
+)};
+const _r97569 = (G, _) => G.input(_);
+const _1sp5wo4 = function _16(md){return(
+md`## Scrolling
+
+Scrolling has been a mess to develop. The thing that finally fixed it was \`scroll_fix_sync_layout\`. I suspect fix_scroll is over-complex.`
+)};
+const _1ts23ma = function _scrollDebug(Inputs){return(
+Inputs.toggle({
+    label: 'enable debug scroll?',
+    value: true
+})
+)};
+const _7jxivy = (G, _) => G.input(_);
+const _1f2wuqm = function _appendScrollLog($0,$1){return(
+(type, detail = {}) => {
+    if (!$0.value)
+        return null;
+    const evt = {
+        t: Date.now(),
+        type: String(type),
+        ...detail
+    };
+    $1.value = ($1.value || []).concat([evt]);
+    return evt;
+}
+)};
+const _1nbnzwx = function _scrollLog(scrollDebug){return(
+scrollDebug ? [] : []
+)};
+const _1f7xtz1 = (M, _) => new M(_);
+const _1dyz4o0 = _ => _.generator;
+const _1d1nkw9 = function _scrollKeyFor(appendScrollLog)
+{
+    return container => {
+        // can return undefined if the container is loading still
+        const key = container?.title;
+        appendScrollLog('scrollKeyFor:', { key });
+        return key;
+    };
+};
+const _tb217h = function _scroll_cache(){return(
+new Map()
+)};
+const _12p8mg7 = function _fix_scroll(scroll_cache,scrollKeyFor,appendScrollLog)
+{
+  return function (container, node, cell_variable, key) {
+    scroll_cache.__reflowUntil = Date.now() + 600;
+    // suppress reflow-induced scroll events that clobber the cache
+    const c_element = container.getElement();
+    let k = scrollKeyFor(container);
+    appendScrollLog('fix_scroll:enter', {
+      title: container?.title ?? null,
+      k,
+      cell: cell_variable?._name ?? null
+    });
+    if (node && node.parentNode !== c_element) {
+      c_element.appendChild(node);
+      appendScrollLog('fix_scroll:append_node', {
+        title: container?.title ?? null,
+        k
+      });
+    }
+    const writeCache = (scrollTop, scrollLeft, why) => {
+      scroll_cache.set(k, {
+        scrollTop,
+        scrollLeft,
+        t: Date.now()
+      });
+      appendScrollLog('scroll_cache:write', {
+        k,
+        scrollTop,
+        scrollLeft,
+        why
+      });
+    };
+    const scrollToCellIfPossible = why => {
+      if (!cell_variable)
+        return false;
+      const dom = cell_variable?._observer?._node ?? c_element.querySelector(`div[cell='${ cell_variable._name }']`);
+      if (!dom) {
+        appendScrollLog('scroll:cell_dom_not_found', {
+          k,
+          why,
+          cell: cell_variable?._name ?? null
+        });
+        return false;
+      }
+      const top = dom.offsetTop - c_element.offsetTop;
+      const left = c_element.scrollLeft;
+      c_element.scrollTop = top;
+      appendScrollLog('scroll:set', {
+        k,
+        why: `${ why }:cell`,
+        scrollTop: top,
+        scrollLeft: left,
+        cell: cell_variable?._name ?? null
+      });
+      writeCache(top, left, `${ why }:cell`);
+      return true;
+    };
+    const restoreFromCache = why => {
+      k = scrollKeyFor(container);
+      const cached = scroll_cache.get(k);
+      appendScrollLog('scroll:restore_attempt', {
+        k,
+        why,
+        cachedScrollTop: cached?.scrollTop ?? null,
+        cachedScrollLeft: cached?.scrollLeft ?? null
+      });
+      if (!cached) {
+        appendScrollLog('scroll:restore_no_scroll', {
+          k,
+          why
+        });
+        return;
+      }
+      if (cached.scrollTop != null)
+        c_element.scrollTop = cached.scrollTop;
+      if (cached.scrollLeft != null)
+        c_element.scrollLeft = cached.scrollLeft;
+      appendScrollLog('scroll:restore_applied', {
+        k,
+        why,
+        scrollTop: cached.scrollTop ?? null,
+        scrollLeft: cached.scrollLeft ?? null,
+        scrollTopFinal: c_element.scrollTop,
+        scrollLeftFinal: c_element.scrollLeft
+      });
+    };
+    const setScroll = (why = 'setScroll') => {
+      if (scrollToCellIfPossible(why))
+        return;
+      restoreFromCache(why);
+    };
+    const retryFrames = 6;
+    for (let i = 0; i < retryFrames; i++) {
+      requestAnimationFrame(() => {
+        k = scrollKeyFor(container);
+        appendScrollLog('fix_scroll:raf_retry', {
+          i,
+          k,
+          title: container?.title ?? null
+        });
+        setScroll(`raf:${ i }`);
+      });
+    }
+    appendScrollLog('fix_scroll:exit', {
+      k,
+      title: container?.title ?? null
+    });
+  };
+};
+const _arfw00 = function _scroll_fix_sync_layout(sync_layout_to_url,layout,appendScrollLog,modulePanel)
+{
+    sync_layout_to_url;
+    let timeout = null;
+    const listComponentItems = () => {
+        const out = [];
+        const walk = item => {
+            if (!item)
+                return;
+            if (item.isComponent || item.type === 'component')
+                out.push(item);
+            const kids = item.contentItems || item.content || [];
+            for (const k of kids)
+                walk(k);
+        };
+        walk(layout.root);
+        return out;
+    };
+    const items = listComponentItems();
+    appendScrollLog('scroll:reapply_all:begin', { count: items.length });
+    for (const it of items) {
+        try {
+            const container = it.container;
+            const title = container?.title ?? it.title ?? null;
+            if (!container || !title)
+                continue;
+            const st = it.componentState ?? it.config?.componentState ?? it._config?.componentState ?? it._state ?? {};
+            modulePanel(container, { cell: st?.cell });
+        } catch (e) {
+            appendScrollLog('scroll:reapply_all:error', { error: String(e) });
+        }
+    }
+    return true;
+};
+const _3nwpp4 = function _URLrouting(md){return(
+md`## URL Sync
+
+### Goals
+1. **Non-destructive navigation:** mutate an existing GoldenLayout (GL) instance (add/remove/reorder items) rather than rebuilding.
+2. **Refresh restores what you see:** the URL eventually contains the full serialized GL tree in **\`view=\`**.
+3. **Links are “intents”:** in-app links should not rewrite \`view=\` at click time.
+
+---
+
+## State model
+
+### Canonical, persistent state
+- **\`view=<DSL>\`** is the canonical serialized GL layout (single source of truth after boot).
+
+### One-shot intent params (cleared after commit)
+- \`open=<moduleOrModule#cell>\`
+- \`close=<...>\` (reserved)
+- \`focus=<...>\` (reserved)
+- \`from=<module>\` (optional placement hint)
+
+---
+
+## Dataflow
+
+### 1) URL → desired layout (intent overlay)
+- Parse \`view\` with \`parseGoldenDSL\` to get the desired root config.
+- If \`open=\` exists, **overlay** it into the parsed config by inserting the target module into the *first stack* (and optional \`componentState.cell\`).
+
+Implemented in: **\`sync_layout_from_url\`**.
+
+### 2) Desired layout → live GL (non-destructive when possible)
+- Try **\`treeSyncGolden(layout, desiredRoot)\`** to:
+  - add missing module tabs
+  - remove extra module tabs
+  - reorder tabs to match the DSL
+  - ensure container shapes (row/column/stack) match where possible
+- If tree sync can’t reconcile safely, **fallback to \`layout.loadLayout(...)\`**.
+
+Implemented in: **\`treeSyncGolden\`** + \`sync_layout_from_url\`.
+
+### 3) Live GL → URL persistence (“commit then clear”)
+- GL emits \`stateChanged\` → update \`mutable config\` from \`layout.toConfig()\`.
+- Serialize \`config.root\` with \`serializeGoldenDSL\` and write it to **\`view=\`**.
+- Clear one-shot intent params (\`open/close/focus/from\`) so they are not re-applied on refresh.
+
+Implemented in: **\`sync_layout_to_url\`** via \`history.replaceState(...)\`.
+
+---
+
+## Unit test gate (safety check)
+Before \`sync_layout_to_url\` is allowed to persist \`view=\`, a **roundtrip invariant** must hold:
+
+- Compute an expected “pre” DSL:
+  - normalize weights (e.g. S100/R100/C100)
+  - apply the same \`open=\` overlay used by \`sync_layout_from_url\`
+- Compare it to the “post” DSL obtained after applying the URL to the live layout and re-serializing.
+
+If **\`test_url_roundtrip\`** throws or returns non-\`true\`, **\`sync_layout_to_url\`** exits early (no canonical \`view=\` writes). This prevents committing a drifting/incorrect \`view=\` during development and makes URL persistence self-checking.
+
+Implemented in: **\`test_url_roundtrip\`** and enforced at the top of **\`sync_layout_to_url\`**.
+`
+)};
+const _14te9pl = function _sync_layout_from_url(reload,resize,URLSearchParams,hash,appendScrollLog,parseGoldenDSL,gl,layout,serializeGoldenDSL,treeSyncGolden,invalidation)
+{
+  reload;
+  resize;
+  const params = new URLSearchParams(String(hash || '').replace(/^#/, ''));
+  const view = params.get('view');
+  const open = params.get('open');
+  appendScrollLog('url:sync_from:begin', {
+    hash: String(hash || ''),
+    view,
+    open
+  });
+  const diag = {
+    preURL: view ?? null,
+    postURL: null,
+    method: null,
+    status: 'skipped',
+    reason: '',
+    error: null,
+    open: null,
+    openApplied: false
+  };
+  let desiredRoot;
+  try {
+    desiredRoot = parseGoldenDSL(view);
+  } catch (e) {
+    diag.method = 'parse';
+    diag.status = 'error';
+    diag.reason = 'parseGoldenDSL failed';
+    diag.error = String(e);
+    appendScrollLog('url:sync_from:error', {
+      where: 'parse',
+      error: diag.error
+    });
+    return diag;
+  }
+  if (!view && open) {
+    try {
+      const resolved = gl.LayoutConfig.fromResolved(layout.toConfig());
+      desiredRoot = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
+      if (desiredRoot) {
+        diag.preURL = serializeGoldenDSL(desiredRoot);
+        appendScrollLog('url:sync_from:fallback_to_current_layout', {
+          preURL: diag.preURL,
+          open
+        });
+      }
+    } catch (e) {
+      appendScrollLog('url:sync_from:fallback_to_current_layout:error', { error: String(e) });
+    }
+    if (!desiredRoot) {
+      // Lazily synthesize an empty stack so the open overlay below can populate it.
+      desiredRoot = {
+        type: 'stack',
+        content: []
+      };
+      try {
+        diag.preURL = serializeGoldenDSL(desiredRoot);
+      } catch {
+        diag.preURL = 'S100()';
+      }
+      appendScrollLog('url:sync_from:synthesize_empty_stack', {
+        preURL: diag.preURL,
+        open
+      });
+    }
+  }
+  if (!desiredRoot) {
+    diag.method = 'parse';
+    diag.status = 'error';
+    diag.reason = 'parseGoldenDSL returned falsy';
+    appendScrollLog('url:sync_from:error', {
+      where: 'parse',
+      error: diag.reason
+    });
+    return diag;
+  }
+  const findFirstStack = node => {
+    if (!node)
+      return null;
+    if (node.type === 'stack')
+      return node;
+    for (const c of node.content || []) {
+      const f = findFirstStack(c);
+      if (f)
+        return f;
+    }
+    return null;
+  };
+  const findExistingModule = (node, title) => {
+    if (!node)
+      return null;
+    if (node.type === 'component' && (node.componentType === 'module' || node.componentName === 'module') && node.title === title) {
+      return node;
+    }
+    for (const c of node.content || []) {
+      const f = findExistingModule(c, title);
+      if (f)
+        return f;
+    }
+    return null;
+  };
+  if (open) {
+    const [moduleTitleRaw, cellRaw] = String(open).split('#');
+    const moduleTitle = (moduleTitleRaw || '').trim();
+    const cell = (cellRaw || '').trim() || null;
+    if (moduleTitle) {
+      diag.open = {
+        moduleTitle,
+        cell
+      };
+      const existingAnywhere = findExistingModule(desiredRoot, moduleTitle);
+      if (existingAnywhere) {
+        existingAnywhere.componentState = existingAnywhere.componentState || {};
+        if (cell)
+          existingAnywhere.componentState.cell = cell;
+        appendScrollLog('url:sync_from:overlay_open:update_existing', {
+          moduleTitle,
+          cell
+        });
+        diag.openApplied = true;
+      } else {
+        const stack = findFirstStack(desiredRoot);
+        if (stack) {
+          stack.content = stack.content || [];
+          stack.content.push({
+            type: 'component',
+            title: moduleTitle,
+            componentType: 'module',
+            componentName: 'module',
+            componentState: cell ? { cell } : {}
+          });
+          appendScrollLog('url:sync_from:overlay_open:add', {
+            moduleTitle,
+            cell
+          });
+          diag.openApplied = true;
+        } else {
+          appendScrollLog('url:sync_from:overlay_open:no_stack_found', {
+            moduleTitle,
+            cell
+          });
+        }
+      }
+    }
+  }
+  const doLoadLayout = () => {
+    if (typeof layout?.loadLayout !== 'function')
+      throw new Error('layout.loadLayout not available');
+    appendScrollLog('layout:loadLayout:call', {
+      desiredType: desiredRoot?.type ?? null,
+      open: diag.open?.moduleTitle ?? null
+    });
+    layout.loadLayout({
+      settings: {},
+      content: [desiredRoot]
+    });
+  };
+  try {
+    const res = treeSyncGolden(layout, desiredRoot);
+    if (res?.status === 'fallback') {
+      diag.method = 'loadLayout';
+      diag.status = 'fallback';
+      diag.reason = res.reason || 'treeSync requested fallback';
+      appendScrollLog('url:sync_from:treesync_fallback', { reason: diag.reason });
+      try {
+        doLoadLayout();
+      } catch (e2) {
+        diag.status = 'error';
+        diag.reason = 'loadLayout failed after treeSync fallback';
+        diag.error = String(e2);
+        appendScrollLog('url:sync_from:error', {
+          where: 'loadLayout_after_fallback',
+          error: diag.error
+        });
+      }
+    } else {
+      diag.method = 'treeSync';
+      diag.status = 'synced';
+      appendScrollLog('url:sync_from:treesync_ok', {});
+    }
+  } catch (e) {
+    diag.method = 'loadLayout';
+    diag.status = 'fallback';
+    diag.reason = 'exception during treeSync';
+    diag.error = String(e);
+    appendScrollLog('url:sync_from:treesync_exception', { error: diag.error });
+    try {
+      doLoadLayout();
+    } catch (e2) {
+      diag.status = 'error';
+      diag.reason = 'loadLayout failed after treeSync exception';
+      diag.error = `${ String(e) }; loadLayout: ${ String(e2) }`;
+      appendScrollLog('url:sync_from:error', {
+        where: 'loadLayout_after_exception',
+        error: diag.error
+      });
+    }
+  }
+  try {
+    const resolved = gl?.LayoutConfig?.fromResolved ? gl.LayoutConfig.fromResolved(layout.toConfig()) : null;
+    const root = resolved?.root ?? layout.toConfig()?.root ?? layout.toConfig()?.content?.[0];
+    diag.postURL = root ? serializeGoldenDSL(root) : null;
+  } catch (e) {
+    diag.postURL = null;
+    if (!diag.error)
+      diag.error = `serialize failed: ${ String(e) }`;
+    appendScrollLog('url:sync_from:serialize_failed', { error: String(e) });
+  }
+  appendScrollLog('url:sync_from:end', {
+    status: diag.status,
+    method: diag.method,
+    reason: diag.reason || null,
+    preURL: diag.preURL,
+    postURL: diag.postURL
+  });
+  invalidation.then(() => {
+  });
+  return diag;
+};
+const _1l50a0d = function _sync_layout_to_url(appendScrollLog,sync_layout_from_url,config,test_url_roundtrip,serializeGoldenDSL,location,setHashURL)
+{
+    appendScrollLog('url:sync_to:tick', {
+        fromStatus: sync_layout_from_url?.status ?? null,
+        hasRoot: !!config?.root
+    });
+    if (test_url_roundtrip !== true) {
+        appendScrollLog('url:sync_to:blocked', { reason: 'test_url_roundtrip != true' });
+        return;
+    }
+    if (sync_layout_from_url?.status === 'error') {
+        appendScrollLog('url:sync_to:blocked', { reason: 'sync_layout_from_url status=error' });
+        return;
+    }
+    if (!config?.root) {
+        appendScrollLog('url:sync_to:blocked', { reason: 'config.root missing' });
+        return;
+    }
+    let dsl;
+    try {
+        dsl = serializeGoldenDSL(config.root);
+    } catch (e) {
+        appendScrollLog('url:sync_to:serialize_failed', { error: String(e) });
+        return;
+    }
+    // Parse hash manually to avoid URLSearchParams percent-encoding view= values
+    // like R100(S50(@tomlarkworthy/lopepage)) → R100%28S50%28%40tomlarkworthy%2Flopepage%29%29
+    const rawHash = String(location.hash || '').replace(/^#/, '');
+    const knownIntents = new Set([
+        'open',
+        'close',
+        'focus',
+        'from'
+    ]);
+    // Split into key=value pairs, preserving original encoding
+    const parts = rawHash.split('&').filter(Boolean);
+    const extra = [];
+    // unknown params to preserve (e.g. cc=TOKEN)
+    let currentView = null;
+    let hasIntent = false;
+    for (const part of parts) {
+        const eq = part.indexOf('=');
+        const key = eq >= 0 ? part.slice(0, eq) : part;
+        const val = eq >= 0 ? part.slice(eq + 1) : '';
+        if (key === 'view') {
+            currentView = decodeURIComponent(val);
+        } else if (knownIntents.has(key)) {
+            hasIntent = true;
+        } else {
+            extra.push(part);    // preserve verbatim
+        }
+    }
+    if (currentView === dsl) {
+        appendScrollLog('url:sync_to:no_change', { hasIntent });
+        if (hasIntent) {
+            // Rebuild without intents, keep view + extras
+            const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
+            const res = setHashURL(newHash);
+            appendScrollLog('url:sync_to:clear_intents', { result: res });
+        }
+        return;
+    }
+    const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
+    appendScrollLog('url:sync_to:write_view', {
+        oldHash: String(location.hash || ''),
+        newHash,
+        dsl
+    });
+    if (newHash !== location.hash) {
+        const res = setHashURL(newHash);
+        appendScrollLog('url:sync_to:setHashURL_result', { result: res });
+    }
+};
+const _jcy1xg = function _test_url_roundtrip(sync_layout_from_url)
+{
+    const d = sync_layout_from_url;
+    if (!d || d.status === 'skipped')
+        return true;
+    if (d.status === 'error')
+        throw new Error(d.error || d.reason || 'sync error');
+    if (d.postURL == null)
+        throw new Error(d.error || 'postURL missing');
+    const normalize = dsl => {
+        if (dsl == null)
+            return dsl;
+        let s = String(dsl);
+        s = s.replace(/S\d+(?=\()/g, 'S100').replace(/R\d+(?=\()/g, 'R100').replace(/C\d+(?=\()/g, 'C100');
+        s = s.replace(/S(?=\()/g, 'S100').replace(/R(?=\()/g, 'R100').replace(/C(?=\()/g, 'C100');
+        return s;
+    };
+    const overlayOpen = (dsl, openTarget) => {
+        if (!openTarget?.moduleTitle)
+            return dsl;
+        const title = String(openTarget.moduleTitle);
+        if (dsl && dsl.includes(title))
+            return dsl;
+        const s = String(dsl ?? '');
+        if (!/S100\(/.test(s)) {
+            return `S100(${ title })`;
+        }
+        return s.replace(/S100\(([^)]*)\)/, (m, inner) => {
+            const trimmed = String(inner || '').trim();
+            const next = trimmed ? `${ trimmed },${ title }` : title;
+            return `S100(${ next })`;
+        });
+    };
+    const preRaw = d.preURL ?? 'S()';
+    const preWithIntent = overlayOpen(normalize(preRaw), d.open);
+    const post = normalize(d.postURL);
+    if (preWithIntent !== post) {
+        throw new Error(`view URL drift: preURL != postURL\n` + `preURL=${ String(preRaw) }\n` + `open=${ d.open?.moduleTitle || '' }\n` + `postURL=${ String(d.postURL) }\n` + `normalizedPreWithIntent=${ String(preWithIntent) }\n` + `normalizedPost=${ String(post) }\n` + `method=${ d.method } status=${ d.status } reason=${ d.reason || '' }`);
+    }
+    return true;
+};
+const _1yxu9kf = function _setHashURL(location,appendScrollLog,history){return(
+function setHashURL(newHash) {
+    const h = String(newHash ?? '');
+    const hash = h.startsWith('#') ? h : `#${ h }`;
+    const url = new URL(location.href);
+    url.hash = hash;
+    const href = url.toString();
+    appendScrollLog('url:setHashURL:attempt', {
+        hash,
+        href
+    });
+    try {
+        history.replaceState(null, '', href);
+        const res = {
+            ok: true,
+            method: 'replaceState',
+            href,
+            hash
+        };
+        appendScrollLog('url:setHashURL:success', res);
+        return res;
+    } catch (e) {
+        const a = document.createElement('a');
+        a.href = href;
+        a.rel = 'noreferrer';
+        a.style.display = 'none';
+        (document.body || document.documentElement).appendChild(a);
+        a.click();
+        a.remove();
+        const res = {
+            ok: false,
+            method: 'synthetic-click',
+            href,
+            hash,
+            error: String(e)
+        };
+        appendScrollLog('url:setHashURL:fallback', res);
+        return res;
+    }
+}
+)};
+const _1zkl8r = function _treeSyncGolden(appendScrollLog,gl){return(
+function treeSyncGoldenFactory(gl) {
+    const isCompCfg = n => n && n.type === 'component';
+    const isContCfg = n => n && (n.type === 'row' || n.type === 'column' || n.type === 'stack');
+    const desiredModuleKey = cfg => isCompCfg(cfg) && (cfg.componentType === 'module' || cfg.componentName === 'module') && cfg.title ? `module:${ cfg.title }` : null;
+    const liveModuleKey = item => {
+        if (!item)
+            return null;
+        if (!(item.isComponent || item.type === 'component'))
+            return null;
+        const t = item.componentType || item.componentName;
+        return t === 'module' && item.title ? `module:${ item.title }` : null;
+    };
+    const cloneCfg = cfg => {
+        const c = JSON.parse(JSON.stringify(cfg));
+        if (c.type === 'component' && (c.componentType === 'module' || c.componentName === 'module')) {
+            c.componentType = 'module';
+            c.componentName = 'module';
+            c.componentState = c.componentState || {};
+        }
+        return c;
+    };
+    function indexLiveModules(stackLive) {
+        const map = new Map();
+        for (const child of stackLive?.contentItems || []) {
+            const k = liveModuleKey(child);
+            if (k)
+                map.set(k, child);
+        }
+        return map;
+    }
+    function setLiveComponentStateCell(liveItem, cell) {
+        if (!liveItem || !cell)
+            return false;
+        let changed = false;
+        liveItem.componentState = liveItem.componentState || {};
+        if (liveItem.componentState.cell !== cell) {
+            liveItem.componentState.cell = cell;
+            changed = true;
+        }
+        const configs = [
+            liveItem.config,
+            liveItem._config,
+            liveItem._state
+        ].filter(Boolean);
+        for (const cfg of configs) {
+            cfg.componentState = cfg.componentState || {};
+            if (cfg.componentState.cell !== cell) {
+                cfg.componentState.cell = cell;
+                changed = true;
+            }
+        }
+        return changed;
+    }
+    function syncStack(stackLive, desiredStackCfg) {
+        appendScrollLog('treeSync:syncStack:enter', {
+            title: stackLive?.parent?.title ?? stackLive?.title ?? null,
+            desiredCount: (desiredStackCfg?.content || []).length,
+            liveCount: (stackLive?.contentItems || []).length
+        });
+        const desiredComps = (desiredStackCfg.content || []).filter(isCompCfg);
+        let liveByKey = indexLiveModules(stackLive);
+        for (let i = 0; i < desiredComps.length; i++) {
+            const d = desiredComps[i];
+            const k = desiredModuleKey(d);
+            if (!k)
+                continue;
+            if (!liveByKey.has(k)) {
+                let before = null;
+                for (let j = i + 1; j < desiredComps.length; j++) {
+                    const k2 = desiredModuleKey(desiredComps[j]);
+                    if (k2 && liveByKey.has(k2)) {
+                        before = liveByKey.get(k2);
+                        break;
+                    }
+                }
+                const idx = before ? (stackLive.contentItems || []).indexOf(before) : (stackLive.contentItems || []).length;
+                appendScrollLog('treeSync:stack:addItem', {
+                    key: k,
+                    title: d?.title ?? null,
+                    idx,
+                    beforeKey: before ? liveModuleKey(before) : null
+                });
+                if (typeof stackLive.addItem !== 'function')
+                    return {
+                        status: 'fallback',
+                        reason: 'stack missing addItem'
+                    };
+                stackLive.addItem(cloneCfg(d), idx);
+                liveByKey = indexLiveModules(stackLive);
+            }
+        }
+        const desiredKeys = new Set(desiredComps.map(desiredModuleKey).filter(Boolean));
+        for (const child of Array.from(stackLive?.contentItems || [])) {
+            const k = liveModuleKey(child);
+            if (k && !desiredKeys.has(k) && typeof child.remove === 'function') {
+                appendScrollLog('treeSync:stack:remove', {
+                    key: k,
+                    title: child?.title ?? null
+                });
+                child.remove();
+            }
+        }
+        const order = desiredComps.map(desiredModuleKey).filter(Boolean);
+        const byKey = indexLiveModules(stackLive);
+        for (let i = 0; i < order.length; i++) {
+            const item = byKey.get(order[i]);
+            if (!item)
+                continue;
+            const curIdx = (stackLive.contentItems || []).indexOf(item);
+            if (curIdx !== i && typeof stackLive.removeChild === 'function' && typeof stackLive.addChild === 'function') {
+                appendScrollLog('treeSync:stack:reorder', {
+                    key: order[i],
+                    from: curIdx,
+                    to: i
+                });
+                stackLive.removeChild(item, true);
+                stackLive.addChild(item, i, false);
+            }
+        }
+        {
+            const byKey2 = indexLiveModules(stackLive);
+            for (const d of desiredComps) {
+                const k = desiredModuleKey(d);
+                const desiredCell = d?.componentState?.cell ?? null;
+                if (!k || !desiredCell)
+                    continue;
+                const liveItem = byKey2.get(k);
+                if (!liveItem)
+                    continue;
+                const changed = setLiveComponentStateCell(liveItem, desiredCell);
+                if (changed) {
+                    appendScrollLog('treeSync:stack:sync_componentState_cell', {
+                        key: k,
+                        title: liveItem?.title ?? null,
+                        cell: desiredCell
+                    });
+                }
+            }
+        }
+        appendScrollLog('treeSync:syncStack:exit', { liveCount: (stackLive?.contentItems || []).length });
+        return { status: 'synced' };
+    }
+    function ensureContainerChild(parentLive, idx, desiredChildCfg) {
+        const liveChild = parentLive?.contentItems?.[idx];
+        if (liveChild && liveChild.type === desiredChildCfg.type)
+            return liveChild;
+        if (liveChild && typeof liveChild.remove === 'function') {
+            appendScrollLog('treeSync:container:remove_child_for_type_mismatch', {
+                idx,
+                liveType: liveChild?.type ?? null,
+                desiredType: desiredChildCfg?.type ?? null
+            });
+            liveChild.remove();
+        }
+        if (typeof parentLive?.addItem !== 'function')
+            return null;
+        appendScrollLog('treeSync:container:addItem', {
+            idx,
+            type: desiredChildCfg?.type ?? null
+        });
+        parentLive.addItem({
+            type: desiredChildCfg.type,
+            content: []
+        }, idx);
+        return parentLive?.contentItems?.[idx] || null;
+    }
+    function isContainerItem(item) {
+        if (!item)
+            return false;
+        if (item.isComponent)
+            return false;
+        return item.type === 'row' || item.type === 'column' || item.type === 'stack';
+    }
+    function syncContainer(containerLive, desiredCfg) {
+        if (!containerLive || !desiredCfg || !Array.isArray(desiredCfg.content))
+            return { status: 'synced' };
+        const desiredChildren = desiredCfg.content.filter(isContCfg);
+        for (let i = 0; i < desiredChildren.length; i++)
+            ensureContainerChild(containerLive, i, desiredChildren[i]);
+        const liveContainers = (containerLive.contentItems || []).filter(isContainerItem);
+        while (liveContainers.length > desiredChildren.length) {
+            const last = (containerLive.contentItems || []).slice().reverse().find(isContainerItem);
+            if (!last)
+                break;
+            appendScrollLog('treeSync:container:remove_extra_container', { type: last?.type ?? null });
+            if (typeof last.remove === 'function')
+                last.remove();
+            liveContainers.pop();
+        }
+        for (let i = 0; i < desiredChildren.length; i++) {
+            const d = desiredChildren[i];
+            const l = containerLive.contentItems?.[i];
+            if (!l)
+                continue;
+            if (l.type !== d.type)
+                return {
+                    status: 'fallback',
+                    reason: `child type mismatch @${ i } live=${ l.type } desired=${ d.type }`
+                };
+            if (d.type === 'stack') {
+                const r = syncStack(l, d);
+                if (r?.status === 'fallback')
+                    return r;
+            } else {
+                const r = syncContainer(l, d);
+                if (r?.status === 'fallback')
+                    return r;
+            }
+        }
+        return { status: 'synced' };
+    }
+    return function treeSync(layout, desiredRootCfg) {
+        appendScrollLog('treeSync:enter', {
+            desiredType: desiredRootCfg?.type ?? null,
+            hasRoot: !!layout?.root
+        });
+        if (!layout?.root || !desiredRootCfg)
+            return { status: 'noop' };
+        const liveTop = layout.root.contentItems?.[0];
+        if (!liveTop)
+            return {
+                status: 'fallback',
+                reason: 'no live top'
+            };
+        if (liveTop.type !== desiredRootCfg.type) {
+            const out = {
+                status: 'fallback',
+                reason: `top type mismatch live=${ liveTop.type } desired=${ desiredRootCfg.type }`
+            };
+            appendScrollLog('treeSync:fallback', out);
+            return out;
+        }
+        const out = desiredRootCfg.type === 'stack' ? syncStack(liveTop, desiredRootCfg) : syncContainer(liveTop, desiredRootCfg);
+        if (out?.status === 'fallback')
+            appendScrollLog('treeSync:fallback', out);
+        else
+            appendScrollLog('treeSync:synced', { status: out?.status ?? 'synced' });
+        return out;
+    };
+}(gl)
+)};
+const _133ahw5 = function _background_jobs(onLoadConfig,layout_state,sync_layout_from_url,test_url_roundtrip,sync_layout_to_url,runtime,navigator_jobs,commandPaletteKeybinding,auto_attach,scroll_fix_sync_layout,commit_history,replay_git,change_listener,cc_chat)
+{
+  onLoadConfig;
+  layout_state;
+  sync_layout_from_url;
+  test_url_roundtrip;
+  sync_layout_to_url;
+  runtime;
+  navigator_jobs;
+  commandPaletteKeybinding;
+  auto_attach;
+  scroll_fix_sync_layout;
+  // history
+  commit_history;
+  replay_git;
+  change_listener;
+  cc_chat;
+};
+const _1n78po6 = function _imports(md){return(
+md`## Imports`
+)};
+const _b2c0kp = function _32(exporter){return(
+exporter()
+)};
+const _1ey5aow = function _dragOutGrips(layout,invalidation)
+{
+    function readModuleSource(name) {
+        const r = window.lopecode?.contentSync?.(name);
+        if (!r || r.status !== 200 || !r.bytes)
+            return null;
+        return new TextDecoder().decode(r.bytes);
+    }
+    function filenameFor(name) {
+        let m = name.match(/^@([A-Za-z0-9-]+)\/([A-Za-z0-9-]+)$/);
+        if (m)
+            return `at_${ m[1] }_${ m[2] }.js`;
+        m = name.match(/^d\/([A-Za-z0-9]+)(@\d+)?$/);
+        if (m)
+            return `d_${ m[1] }${ m[2] ?? '' }.js`;
+        return name.replace(/[/]/g, '_') + '.js';
+    }
+    function flashGrip(grip) {
+        const prev = grip.style.opacity;
+        grip.style.opacity = '1';
+        setTimeout(() => {
+            grip.style.opacity = prev;
+        }, 350);
+    }
+    function hookTab(tabEl) {
+        if (tabEl.__lopepageGripHooked)
+            return;
+        tabEl.__lopepageGripHooked = true;
+        const grip = document.createElement('span');
+        grip.className = 'lm_drag_out_grip';
+        grip.title = 'Click to copy source \xB7 Drag out as .js';
+        grip.setAttribute('draggable', 'true');
+        grip.innerHTML = `<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" style="display:block"><rect x="5.5" y="5.5" width="9" height="9" rx="1.5"/><path d="M2.5 10.5V3a.5.5 0 01.5-.5h7.5"/></svg>`;
+        Object.assign(grip.style, {
+            display: 'inline-block',
+            width: '12px',
+            height: '12px',
+            verticalAlign: '3.5px',
+            marginLeft: '-7px',
+            marginRight: '2px',
+            cursor: 'pointer',
+            opacity: '0.55',
+            userSelect: 'none',
+            lineHeight: '0',
+            color: 'currentColor'
+        });
+        [
+            'pointerdown',
+            'mousedown',
+            'touchstart'
+        ].forEach(ev => {
+            grip.addEventListener(ev, e => e.stopPropagation(), { capture: true });
+        });
+        grip.addEventListener('click', e => {
+            e.stopPropagation();
+            const t = tabEl.querySelector('.lm_title')?.textContent || '';
+            if (!t)
+                return;
+            const source = readModuleSource(t);
+            if (!source) {
+                console.warn('[grip click] no source for:', t);
+                return;
+            }
+            navigator.clipboard?.writeText?.(source).then(() => {
+                console.log('[grip click] copied source for:', t, `(${ source.length } chars)`);
+                flashGrip(grip);
+            }).catch(err => console.warn('[grip click] clipboard failed:', err));
+        });
+        grip.addEventListener('dragstart', e => {
+            e.stopPropagation();
+            const title = tabEl.querySelector('.lm_title')?.textContent || '';
+            const source = readModuleSource(title);
+            if (!source) {
+                e.dataTransfer.setData('text/plain', `// no source for ${ title }`);
+                return;
+            }
+            const filename = filenameFor(title);
+            const dataUrl = 'data:text/javascript;base64,' + btoa(unescape(encodeURIComponent(source)));
+            e.dataTransfer.setData('DownloadURL', `text/javascript:${ filename }:${ dataUrl }`);
+            e.dataTransfer.setData('text/plain', source);
+            e.dataTransfer.effectAllowed = 'copyMove';
+        });
+        const titleEl = tabEl.querySelector('.lm_title');
+        if (titleEl?.parentNode === tabEl)
+            tabEl.insertBefore(grip, titleEl);
+        else
+            tabEl.prepend(grip);
+    }
+    document.querySelectorAll('.lm_drag_out_grip').forEach(g => g.remove());
+    document.querySelectorAll('.lm_tab').forEach(t => {
+        t.__lopepageGripHooked = false;
+    });
+    document.querySelectorAll('.lm_tab').forEach(hookTab);
+    const handler = tab => hookTab(tab.element);
+    layout.on('tabCreated', handler);
+    invalidation.then(() => {
+        try {
+            layout.off?.('tabCreated', handler);
+        } catch (e) {
+        }
+    });
+    return 'drag-out grips installed';
+};
+const _1gkn0mq = function _dropInHandler(location,setHashURL,runtime,page,invalidation)
+{
+    const STYLE_ID = 'lopepage-dropzone-style';
+    const oldStyle = document.getElementById(STYLE_ID);
+    if (oldStyle)
+        oldStyle.remove();
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = `.lm_header.lopepage-drop-target { outline: 2px dashed currentColor; outline-offset: -2px; background: color-mix(in srgb, currentColor 14%, transparent); }`;
+    document.head.appendChild(s);
+    function parseModuleName(filename) {
+        let m = filename.match(/^at_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)_([A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)\.js$/);
+        if (m)
+            return `@${ m[1] }/${ m[2] }`;
+        m = filename.match(/^d_([A-Za-z0-9]+)(@\d+)?\.js$/);
+        if (m)
+            return `d/${ m[1] }${ m[2] ?? '' }`;
+        return null;
+    }
+    function ensureDomScriptTag(name, source) {
+        let el = document.getElementById(name);
+        if (el?.tagName === 'SCRIPT' && el.getAttribute('type') === 'text/plain') {
+            el.textContent = source;
+            return el;
+        }
+        el = document.createElement('script');
+        el.type = 'text/plain';
+        el.id = name;
+        el.setAttribute('data-mime', 'application/javascript');
+        el.textContent = source;
+        document.body.appendChild(el);
+        return el;
+    }
+    function openModuleInHash(name) {
+        let h = location.hash.replace(/^#/, '');
+        if (/(^|&)open=[^&]*/.test(h)) {
+            h = h.replace(/(^|&)open=[^&]*/, `$1open=${ name }`);
+        } else {
+            h = h + (h ? '&' : '') + `open=${ name }`;
+        }
+        setHashURL(h);
+    }
+    function tearDownExistingModule(name) {
+        const existing = runtime.mains.get(name);
+        if (!existing)
+            return false;
+        try {
+            for (const v of Array.from(existing._scope.values())) {
+                try {
+                    v.delete();
+                } catch (e) {
+                }
+            }
+        } catch (e) {
+            console.warn('[lopepage drop-in] teardown scope:', e);
+        }
+        runtime.mains.delete(name);
+        return true;
+    }
+    async function installFromFile(file) {
+        const name = parseModuleName(file.name);
+        if (!name) {
+            console.warn('[lopepage drop-in] bad filename:', file.name);
+            return;
+        }
+        const src = await file.text();
+        const blob = new Blob([src], { type: 'text/javascript' });
+        const url = URL.createObjectURL(blob);
+        let imported;
+        try {
+            imported = await window.importShim(url, `file://${ name }`);
+        } catch (e) {
+            console.error('[lopepage drop-in] import failed:', e);
+            return;
+        }
+        if (typeof imported.default !== 'function') {
+            console.warn('[lopepage drop-in] default export not a function');
+            return;
+        }
+        const replaced = tearDownExistingModule(name);
+        const mod = runtime.module(imported.default);
+        runtime.mains.set(name, mod);
+        ensureDomScriptTag(name, src);
+        openModuleInHash(name);
+        console.log(`[lopepage drop-in] ${ replaced ? 'replaced' : 'installed' } + opened:`, name);
+    }
+    let activeHeader = null;
+    const clearHighlight = () => {
+        if (activeHeader) {
+            activeHeader.classList.remove('lopepage-drop-target');
+            activeHeader = null;
+        }
+    };
+    const isFilesDrag = e => [...e.dataTransfer?.types || []].includes('Files');
+    const onDragOver = e => {
+        if (!isFilesDrag(e))
+            return;
+        const header = e.target?.closest?.('.lm_header');
+        if (!header) {
+            clearHighlight();
+            return;
+        }
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copy';
+        if (activeHeader !== header) {
+            activeHeader?.classList.remove('lopepage-drop-target');
+            header.classList.add('lopepage-drop-target');
+            activeHeader = header;
+        }
+    };
+    const onDragLeave = e => {
+        if (!page.contains(e.relatedTarget))
+            clearHighlight();
+    };
+    const onDrop = e => {
+        if (!isFilesDrag(e))
+            return;
+        const header = e.target?.closest?.('.lm_header');
+        if (!header)
+            return;
+        e.preventDefault();
+        clearHighlight();
+        const f = e.dataTransfer.files[0];
+        if (f)
+            installFromFile(f).catch(err => console.error('[lopepage drop-in] failed:', err));
+    };
+    page.addEventListener('dragover', onDragOver);
+    page.addEventListener('dragleave', onDragLeave);
+    page.addEventListener('drop', onDrop);
+    invalidation.then(() => {
+        page.removeEventListener('dragover', onDragOver);
+        page.removeEventListener('dragleave', onDragLeave);
+        page.removeEventListener('drop', onDrop);
+        clearHighlight();
+        document.getElementById(STYLE_ID)?.remove();
+    });
+    return 'drop-in handler installed';
+};
+const _1v605qi = function _file_attachment_cache(reload)
+{
+    reload;
+    return new Map();
+};
+const _1fgpmzl = function _renderFileAttachment()
+{
+    return function renderFileAttachment(mime, bytes) {
+        const m = String(mime || '').toLowerCase();
+        // HTML: srcdoc keeps the runtime same-origin-ish (opaque) but renders rich content
+        if (m === 'text/html' || m === 'application/xhtml+xml') {
+            const iframe = document.createElement('iframe');
+            iframe.setAttribute('srcdoc', new TextDecoder().decode(bytes));
+            Object.assign(iframe.style, {
+                width: '100%',
+                height: '100%',
+                border: '0',
+                display: 'block'
+            });
+            return iframe;
+        }
+        if (m.startsWith('image/')) {
+            const img = document.createElement('img');
+            img.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
+            Object.assign(img.style, {
+                maxWidth: '100%',
+                maxHeight: '100%',
+                display: 'block',
+                margin: 'auto'
+            });
+            return img;
+        }
+        if (m.startsWith('audio/')) {
+            const audio = document.createElement('audio');
+            audio.controls = true;
+            audio.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
+            Object.assign(audio.style, { width: '100%' });
+            return audio;
+        }
+        if (m.startsWith('video/')) {
+            const video = document.createElement('video');
+            video.controls = true;
+            video.src = URL.createObjectURL(new Blob([bytes], { type: mime }));
+            Object.assign(video.style, {
+                width: '100%',
+                height: '100%'
+            });
+            return video;
+        }
+        if (m === 'text/plain' || m === 'text/markdown' || m === 'application/json' || m.startsWith('text/')) {
+            const pre = document.createElement('pre');
+            pre.textContent = new TextDecoder().decode(bytes);
+            Object.assign(pre.style, {
+                margin: '0',
+                padding: '8px',
+                whiteSpace: 'pre-wrap',
+                overflow: 'auto',
+                width: '100%',
+                height: '100%',
+                boxSizing: 'border-box'
+            });
+            return pre;
+        }
+        // application/pdf and unknown: blob: iframe — browser picks the viewer
+        const iframe = document.createElement('iframe');
+        iframe.src = URL.createObjectURL(new Blob([bytes], { type: mime || 'application/octet-stream' }));
+        Object.assign(iframe.style, {
+            width: '100%',
+            height: '100%',
+            border: '0',
+            display: 'block'
+        });
+        return iframe;
+    };
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/golden-layout-2-6-0", async () => runtime.module((await import("/@tomlarkworthy/golden-layout-2-6-0.js?v=4")).default));  
+  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-selection", async () => runtime.module((await import("/@tomlarkworthy/module-selection.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
+  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
+  main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
+  main.define("module @tomlarkworthy/command-palette", async () => runtime.module((await import("/@tomlarkworthy/command-palette.js?v=4")).default));  
+  $def("_1xyxga0", "page", ["htl","isOnObservableCom","lopeviz_handle_css","base_css","light_theme_css","commandPaletteStyles","commandPaletteOverlay","linkTo"], _1xyxga0);  
+  $def("_1ujnhdh", "append_to_body", ["page"], _1ujnhdh);  
+  $def("_1nv51s8", "testNavigation", ["htl","linkTo"], _1nv51s8);  
+  $def("_ydvyos", "viewof reload", ["Inputs"], _ydvyos);  
+  $def("_1we0ggl", "reload", ["Generators","viewof reload"], _1we0ggl);  
+  $def("_plefwg", "onLoadConfig", ["parseGoldenDSL","URLSearchParams","location"], _plefwg);  
+  $def("_1nzpnqy", "visualizer_cache", ["reload"], _1nzpnqy);  
+  $def("_1ojown8", "modulePanel", ["appendScrollLog","currentModules","file_attachment_cache","renderFileAttachment","visualizer_cache","visualizer","runtime","isOnObservableCom","scrollKeyFor","fix_scroll","scroll_cache"], _1ojown8);  
+  $def("_1gm4gbf", "blobPanel", [], _1gm4gbf);  
+  $def("_lxv2e2", "settings", [], _lxv2e2);  
+  $def("_lp1ggk", "is_mobile", ["width"], _lp1ggk);  
+  $def("_qbghwu", "initial config", ["onLoadConfig","settings"], _qbghwu);  
+  $def("_15lk82w", "mutable config", ["Mutable","initial config"], _15lk82w);  
+  $def("_1bki6eh", "config", ["mutable config"], _1bki6eh);  
+  $def("_14z0bay", "resize", ["Generators","addEventListener","invalidation","removeEventListener"], _14z0bay);  
+  $def("_18jv72h", "layout", ["resize","gl","mutable config","page","modulePanel","blobPanel"], _18jv72h);  
+  $def("_tsjb2x", "layout_state", ["appendScrollLog","layout","gl","mutable config"], _tsjb2x);  
+  $def("_11nrwvj", "viewof lopepageModule", ["thisModule"], _11nrwvj);  
+  $def("_r97569", "lopepageModule", ["Generators","viewof lopepageModule"], _r97569);  
+  $def("_1sp5wo4", null, ["md"], _1sp5wo4);  
+  $def("_1ts23ma", "viewof scrollDebug", ["Inputs"], _1ts23ma);  
+  $def("_7jxivy", "scrollDebug", ["Generators","viewof scrollDebug"], _7jxivy);  
+  $def("_1f2wuqm", "appendScrollLog", ["viewof scrollDebug","mutable scrollLog"], _1f2wuqm);  
+  $def("_1nbnzwx", "initial scrollLog", ["scrollDebug"], _1nbnzwx);  
+  $def("_1f7xtz1", "mutable scrollLog", ["Mutable","initial scrollLog"], _1f7xtz1);  
+  $def("_1dyz4o0", "scrollLog", ["mutable scrollLog"], _1dyz4o0);  
+  $def("_1d1nkw9", "scrollKeyFor", ["appendScrollLog"], _1d1nkw9);  
+  $def("_tb217h", "scroll_cache", [], _tb217h);  
+  $def("_12p8mg7", "fix_scroll", ["scroll_cache","scrollKeyFor","appendScrollLog"], _12p8mg7);  
+  $def("_arfw00", "scroll_fix_sync_layout", ["sync_layout_to_url","layout","appendScrollLog","modulePanel"], _arfw00);  
+  $def("_3nwpp4", "URLrouting", ["md"], _3nwpp4);  
+  $def("_14te9pl", "sync_layout_from_url", ["reload","resize","URLSearchParams","hash","appendScrollLog","parseGoldenDSL","gl","layout","serializeGoldenDSL","treeSyncGolden","invalidation"], _14te9pl);  
+  $def("_1l50a0d", "sync_layout_to_url", ["appendScrollLog","sync_layout_from_url","config","test_url_roundtrip","serializeGoldenDSL","location","setHashURL"], _1l50a0d);  
+  $def("_jcy1xg", "test_url_roundtrip", ["sync_layout_from_url"], _jcy1xg);  
+  $def("_1yxu9kf", "setHashURL", ["location","appendScrollLog","history"], _1yxu9kf);  
+  $def("_1zkl8r", "treeSyncGolden", ["appendScrollLog","gl"], _1zkl8r);  
+  $def("_133ahw5", "background_jobs", ["onLoadConfig","layout_state","sync_layout_from_url","test_url_roundtrip","sync_layout_to_url","runtime","navigator_jobs","commandPaletteKeybinding","auto_attach","scroll_fix_sync_layout","commit_history","replay_git","change_listener","cc_chat"], _133ahw5);  
+  $def("_1n78po6", "imports", ["md"], _1n78po6);  
+  $def("_b2c0kp", null, ["exporter"], _b2c0kp);  
+  $def("_1ey5aow", "dragOutGrips", ["layout","invalidation"], _1ey5aow);  
+  $def("_1gkn0mq", "dropInHandler", ["location","setHashURL","runtime","page","invalidation"], _1gkn0mq);  
+  main.define("gl", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("gl", _));  
+  main.define("base_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("base_css", _));  
+  main.define("light_theme_css", ["module @tomlarkworthy/golden-layout-2-6-0", "@variable"], (_, v) => v.import("light_theme_css", _));  
+  main.define("unorderedSync", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("unorderedSync", _));  
+  main.define("runtime", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
+  main.define("Inspector", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("Inspector", _));  
+  main.define("lopeviz_handle_css", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("lopeviz_handle_css", _));  
+  main.define("viewof notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof notebookModule", _));  
+  main.define("notebookModule", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("notebookModule", _));  
+  main.define("currentModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("viewof selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("viewof selected_modules", _));  
+  main.define("selected_modules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("selected_modules", _));  
+  main.define("navigator_jobs", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("navigator_jobs", _));  
+  main.define("serializeGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("serializeGoldenDSL", _));  
+  main.define("parseGoldenDSL", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("parseGoldenDSL", _));  
+  main.define("linkTo", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("linkTo", _));  
+  main.define("persistedAttachments", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("persistedAttachments", _));  
+  main.define("getHashModules", ["module @tomlarkworthy/module-selection", "@variable"], (_, v) => v.import("getHashModules", _));  
+  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("getPromiseState", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("getPromiseState", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  main.define("ascendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("ascendants", _));  
+  main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
+  main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
+  main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
+  main.define("exporter", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exporter", _));  
+  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
+  main.define("commit_history", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("commit_history", _));  
+  main.define("change_listener", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("change_listener", _));  
+  main.define("replay_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("replay_git", _));  
+  main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  
+  main.define("commandPaletteStyles", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteStyles", _));  
+  main.define("commandPaletteKeybinding", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteKeybinding", _));  
+  main.define("commandPaletteOverlay", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteOverlay", _));  
+  $def("_1v605qi", "file_attachment_cache", ["reload"], _1v605qi);  
+  $def("_1fgpmzl", "renderFileAttachment", [], _1fgpmzl);
+  return main;
+}</script>
+
+<script id="@mbostock/safe-local-storage" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _gi5bv7 = function _1(md){return(
+md`# Safe Local Storage
+
+If a reader has localStorage disabled, simply referencing it will throw an error and prevent any downstream cells from running. This can break your notebook!
+
+If you import from this notebook instead, you’ll be able to use localStorage safely: if the reader has disabled local storage, you’ll get an in-memory storage instance that evaporates when the page is unloaded.
+
+\`\`\`js
+import {localStorage} from "@mbostock/safe-local-storage"
+\`\`\`
+
+Please note that this implementation does not support direct-setting of properties on localStorage; use the [Storage interface methods](https://html.spec.whatwg.org/multipage/webstorage.html#webstorage) instead.
+`
+)};
+const _x8ty32 = function _localStorage(MemoryStorage)
+{
+  try {
+    const storage = window.localStorage;
+    const key = "__storage_test__";
+    storage.setItem(key, key);
+    storage.removeItem(key);
+    return storage;
+  } catch (error) {
+    return new MemoryStorage;
+  }
+};
+const _jodvzd = function _MemoryStorage(){return(
+class MemoryStorage {
+  constructor() {
+    Object.defineProperties(this, {_: {value: new Map}});
+  }
+  get length() {
+    return this._.size;
+  }
+  key(index) {
+    return Array.from(this._.keys())[index | 0];
+  }
+  getItem(key) {
+    return this._.has(key += "") ? this._.get(key) : null;
+  }
+  setItem(key, value) {
+    this._.set(key + "", value + "");
+  }
+  removeItem(key) {
+    this._.delete(key + "");
+  }
+  clear() {
+    this._.clear();
+  }
+}
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  $def("_gi5bv7", null, ["md"], _gi5bv7);  
+  $def("_x8ty32", "localStorage", ["MemoryStorage"], _x8ty32);  
+  $def("_jodvzd", "MemoryStorage", [], _jodvzd);
+  return main;
+}</script>
+
+<script id="@mootari/access-runtime" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _xuj1uh = function _1(md){return(
+md`# Accessing a Notebook's Runtime
+
+Based on an idea by Bryan Gin-ge Chen (which he explores in his notebook [Dirty tricks](https://observablehq.com/d/4e5230c1d38f7c0f)), this notebook demonstrates a hack that exposes a notebook's underlying [Runtime](https://github.com/observablehq/runtime) instance.
+
+*Related discussion: [Check if a cell is defined](https://talk.observablehq.com/t/check-if-a-cell-is-defined/4351/3)*
+
+Suggested imports:
+~~~js
+import {runtime, main, observed} from '@mootari/access-runtime'
+~~~
+  
+
+
+<style>
+  a[href^="#"]:before {
+    content: "→ ";
+  }
+  a[href], a[href]:hover {
+    text-decoration: underline dotted 2px;
+    text-underline-offset: 2px;
+  }
+  a[href]:hover {
+    text-decoration: underline solid 2px;
+  }
+  a[href]:visited {
+    color: inherit;
+  }
+  p > code, li > code {
+    color: var(--syntax-keyword)
+  }
+</style>`
+)};
+const _1k2rjj6 = function _2(md){return(
+md`---`
+)};
+const _1qopri0 = function _3(md){return(
+md`## API`
+)};
+const _1hkk18y = function _4(md){return(
+md`### Instances`
+)};
+const _1xud60i = function _runtime(recomputeTrigger,captureRuntime){return(
+recomputeTrigger, captureRuntime
+)};
+const _1w8wxmk = function _main(modules){return(
+Array.from(modules).find(d => d[1] === 'main')[0]
+)};
+const _1uwo3kn = function _modules(runtime)
+{
+  // Builtins are stored in a separate module.
+  const builtin = runtime._builtin;
+  // Imported modules are keyed by their define() functions, which we don't need here.
+  const imports = new Set(runtime._modules.values());
+  // Find all modules by retrieving them directly from the variables.
+  // Derived modules are "anonymous" but keep a reference to their source module.
+  const source = m => !m._source ? m : source(m._source);
+  const modules = new Set(Array.from(runtime._variables, v => source(v._module)));
+  // When you edit a notebook on observablehq.com, Observable defines the
+  // variables dynamically on main instead of creating a separate module.
+  // When embedded however the entry notebook also becomes a Runtime module.
+  const main = [...modules].find(m => m !== builtin && !imports.has(m));
+  
+  const _imports = [...imports];
+  const labels = [
+    [builtin, 'builtin'],
+    [main || _imports.shift(), 'main'],
+    ..._imports.map((m, i) => [m, `child${i+1}`]),
+  ];
+  
+  return new Map(labels);
+};
+const _1whqobe = function _8(md){return(
+md`### Utilities`
+)};
+const _1d8v4pl = function _observed(no_observer,runtime){return(
+function observed(variable = null) {
+  const _observed = v => v._observer !== no_observer;
+  if(variable !== null) return _observed(variable);
+  const vars = new Set();
+  for(const v of runtime._variables) _observed(v) && vars.add(v);
+  return vars;
+}
+)};
+const _mgd7ct = function _no_observer(main)
+{
+  const v = main.variable();
+  const o = v._observer;
+  v.delete();
+  return o;
+};
+const _ga2084 = function _11(md){return(
+md`### Internals`
+)};
+const _1kceec5 = function _captureRuntime(mutable_recomputeTrigger){return(
+new Promise(resolve => {
+  const forEach = Set.prototype.forEach;
+  Set.prototype.forEach = function(...args) {
+    const thisArg = args[1];
+    forEach.apply(this, args);
+    if(thisArg && thisArg._modules) {
+      Set.prototype.forEach = forEach;
+      resolve(thisArg);
+    }
+  };
+  mutable_recomputeTrigger.value = mutable_recomputeTrigger.value + 1;
+})
+)};
+const _mp53no = function _mutable_recomputeTrigger(Mutable){return(
+(m => m.generator ? m : Object.defineProperties({}, {
+  [Symbol.toStringTag]: {value: "Mutable"},
+  generator: {value: m},
+  value: Object.getOwnPropertyDescriptor(m, "value"),
+}))(new Mutable(0))
+)};
+const _1trrrv5 = function _recomputeTrigger(mutable_recomputeTrigger){return(
+mutable_recomputeTrigger.generator
+)};
+const _1l3masu = function _15(md){return(
+md`---
+## Examples
+
+*Hit Refresh to update the lists below.*`
+)};
+const _qzbmro = function _ex_refresh(Inputs){return(
+Inputs.button('Refresh')
+)};
+const _1taed3h = (G, _) => G.input(_);
+const _1sbpgcs = function _17(md){return(
+md`### Defined variables`
+)};
+const _mcd64l = function _ex_vars(ex_refresh,runtime,modules,no_observer){return(
+ex_refresh, Array.from(runtime._variables).map(v => ({
+  name : v._name,
+  module: modules.get(v._module),
+  type: [, 'normal', 'implicit', 'duplicate'][v._type],
+  observed: v._observer !== no_observer,
+  inputs: v._inputs.length,
+  outputs: v._outputs.size,
+}))
+)};
+const _2couch = function _ex_vars_filters(ex_vars,Inputs)
+{
+  const unique = (arr, acc) => Array.from(new Set(arr.map(acc))).sort((a, b) => a?.localCompare?.(b));
+  const modules = unique(ex_vars, v => v.module);
+  const types = unique(ex_vars, v => v.type);
+  const value = this?.value ?? {};
+  
+  return Inputs.form({
+    modules: Inputs.checkbox(modules, {
+      label: 'Modules',
+      value: value.modules ?? modules,
+    }),
+    types: Inputs.checkbox(types, {
+      label: 'Types',
+      value: value.types ?? types,
+    }),
+    features: Inputs.checkbox(['named', 'observed', 'inputs', 'outputs'], {
+      label: 'Features',
+      value: value.features ?? [],
+    })
+  });
+};
+const _350we = (G, _) => G.input(_);
+const _1ij3t3 = function _ex_vars_table(ex_vars_filters,ex_vars,Inputs)
+{
+  const flags = (arr) => Object.fromEntries(arr.map(v => [v, true]));
+  const modules = flags(ex_vars_filters.modules);
+  const types = flags(ex_vars_filters.types);
+  const {named, observed, inputs, outputs} = flags(ex_vars_filters.features);
+
+  const data = ex_vars.filter(d => true
+    && modules[d.module]
+    && types[d.type]
+    && (!named || d.name != null)
+    && (!observed || d.observed)
+    && (!inputs || d.inputs)
+    && (!outputs || d.outputs)
+  );
+  return Inputs.table(data);
+};
+const _8awat = function _21(md){return(
+md`### Dependency matrix`
+)};
+const _1tb2c5q = function _ex_deps(ex_refresh,observed,Inputs,htl)
+{
+  ex_refresh;
+  
+  const vars = Array.from(observed(), d => ({
+    name: d._name,
+    inputs: Array.from(d._inputs, d => d._name)
+  }));
+  const inputs = new Set();
+  for(const {inputs: i} of vars) for(const n of i) inputs.add(n);
+
+  return Inputs.table(
+    vars.map(d => ({
+      '': d.name,
+      ...Object.fromEntries(d.inputs.map(n => [n, '✔️'])),
+    })),
+    {
+      columns: ['', ...Array.from(inputs).sort((a, b) => a.localeCompare(b))],
+      header: {
+        '': htl.html`<em>_name`
+      }
+    }
+  );
+  
+};
+const _kmu6ss = function _23(md){return(
+md`---
+## Explainer
+
+Presumably, our best shot at fetching the runtime is to receive the instance as \`thisArg\` to [\`Set.prototype.forEach()\`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/forEach) in [\`runtime_computeNow()\`](https://github.com/observablehq/runtime/blob/v4.23.0/src/runtime.js#L110-L119):
+
+1. In [\`captureRuntime\`](#captureRuntime) we apply a temporary [monkey patch](https://en.wikipedia.org/wiki/Monkey_patch) to \`Set.prototype.forEach\` in order to gain access to any passed-in parameters.
+2. In [\`runtime\`](#runtime) we define a dependency on \`recomputeTrigger\` to ensure that the \`Mutable\`'s generator value is observed.
+3. To trigger a recomputation we reassign [\`mutable recomputeTrigger\`](#recomputeTrigger).
+4. In our overridden \`Set.forEach\` callback we then use [duck typing](https://en.wikipedia.org/wiki/Duck_typing) to match the Runtime instance.
+5. Once we've encountered the instance we restore \`Set.forEach\` and resolve \`captureRuntime\`, and in turn \`runtime\`.
+
+
+`
+)};
+const _icntqt = function _24(md){return(
+md`---
+## Updates
+
+- 2025-09-28 Added a FOSS license, per request.
+- 2025-08-01: Replace \`mutable\` with a notebook-kit compatible solution, per request (though you probably want \`__ojs_runtime\` instead).
+- 2022-08-28: Rewrite and simplification, documentation updates.
+- 2022-08-27: Added \`main\`, \`no_observer\`, \`observed\`. Added example for \`observed\`.`
+)};
+const _g7meyf = function _25(md){return(
+md`---
+*Thumbnail image: [Austrian National Library](https://unsplash.com/photos/ciMJn3mD5u8)*
+`
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  $def("_xuj1uh", null, ["md"], _xuj1uh);  
+  $def("_1k2rjj6", null, ["md"], _1k2rjj6);  
+  $def("_1qopri0", null, ["md"], _1qopri0);  
+  $def("_1hkk18y", null, ["md"], _1hkk18y);  
+  $def("_1xud60i", "runtime", ["recomputeTrigger","captureRuntime"], _1xud60i);  
+  $def("_1w8wxmk", "main", ["modules"], _1w8wxmk);  
+  $def("_1uwo3kn", "modules", ["runtime"], _1uwo3kn);  
+  $def("_1whqobe", null, ["md"], _1whqobe);  
+  $def("_1d8v4pl", "observed", ["no_observer","runtime"], _1d8v4pl);  
+  $def("_mgd7ct", "no_observer", ["main"], _mgd7ct);  
+  $def("_ga2084", null, ["md"], _ga2084);  
+  $def("_1kceec5", "captureRuntime", ["mutable_recomputeTrigger"], _1kceec5);  
+  $def("_mp53no", "mutable_recomputeTrigger", ["Mutable"], _mp53no);  
+  $def("_1trrrv5", "recomputeTrigger", ["mutable_recomputeTrigger"], _1trrrv5);  
+  $def("_1l3masu", null, ["md"], _1l3masu);  
+  $def("_qzbmro", "viewof ex_refresh", ["Inputs"], _qzbmro);  
+  $def("_1taed3h", "ex_refresh", ["Generators","viewof ex_refresh"], _1taed3h);  
+  $def("_1sbpgcs", null, ["md"], _1sbpgcs);  
+  $def("_mcd64l", "ex_vars", ["ex_refresh","runtime","modules","no_observer"], _mcd64l);  
+  $def("_2couch", "viewof ex_vars_filters", ["ex_vars","Inputs"], _2couch);  
+  $def("_350we", "ex_vars_filters", ["Generators","viewof ex_vars_filters"], _350we);  
+  $def("_1ij3t3", "ex_vars_table", ["ex_vars_filters","ex_vars","Inputs"], _1ij3t3);  
+  $def("_8awat", null, ["md"], _8awat);  
+  $def("_1tb2c5q", "ex_deps", ["ex_refresh","observed","Inputs","htl"], _1tb2c5q);  
+  $def("_kmu6ss", null, ["md"], _kmu6ss);  
+  $def("_icntqt", null, ["md"], _icntqt);  
+  $def("_g7meyf", null, ["md"], _g7meyf);
+  return main;
+}</script>
+<script id="@tomlarkworthy/acorn-8-11-3/acorn-8.11.3.js.gz" 
+  type="text/plain"
+  data-encoding="base64"
+  data-mime="application/gzip"
+>
+H4sICP8iLWcCA2Fjb3JuQDguMTEuMy5qcwDMvflzHMeRKPz7+ysas37gjNgDzuAiMdBoHg8dXJEiTVCS1xSMbcw0MC0OukfdPSRhAl/w0i1Ksr2SRUkUKd4Eb4KHSPGI2P3Rn/0iNt6u16F96x7o/TQRG/gXvsysqu7qCwBp74svSEx3111ZWVmZWVlZa5555r8pzygbWmatodeU8WnlTWeT3jD22ErLMcxJZYfVaLSayp7enrVDPUVFM2vKTt12dFvZM9BTHOrp7cH822xj0jC1hjJhNPSSssZsTq3RqpZt/o91PcViT9+amuG4LKRn6k0HsmCuTZbyyradUJGujOzYrOw13LpSmza1KaOqNRrTyqRu6rbmQruwWKdL2WrZumKYE5Y9pbmGZZaUuus2ndKaNXv37u1506lRy3uq1tQaan3esY08FpvnxeapIKh7zX/bo9mKW941UBhSC2pv71r4LQ4U1H61d6hfHVKLfYPr1F74V1QH1T61vwivA5hmcBCCBtb2Q+AQ/OtbC2HqOoxeW1SLBRXK6FOLvX2Yvl8tQrpeDIYwtVjEkgbxcx0UBW9D6lpI17cWqoPnkIpl91M1+N2PzcA6sBlQSR/+YkP7qLHr8JOV0acOYNZeamuRZShgoiJ9DUK3oC1DELcWI4aoK+sgEa+hF9qJWaHL61RW0yD+H6JEvdTTddSbAUzd34evCIoh7PUAgamPqi3QOxVa7C1QoVg7BGMZ/djgXgJdARsC//uhRQNqf2GQQLEWWwjNg3fsTpGBcoCVwHuIlVBhQzhaFNjPxqKP4FygoALG845j9EDfQBEC11LL+9b1YUfWYV19WMwgNrUX+1MsFFllMHrrECRYVJE6NTRI0OlfC42FUYLuYqo+qmOAjwN0GEFRhMohT39xHTZjAPoxgGn6h1jPEfy9faz52JxBBpciA5foEzSFMA4jadT6BnD0Bwku/UNs7NZhjmIR24/N7187gHWsXbd2LQxub9/QqKqXdxEmADbTSK3jFSBuYhEAiiL0BBB5AJIMEg5Al9bhf+hMEacE9mstFYLoCDkGaLggGRQBrSoOsUD2gy0YICwoFlhFvX63oiGDWAlhQm+R4XfvAGEUTbl11CxC+F6sC3P00wzopTnRyyYX9H5QdAxD2e8AISe2FKphk5dwlP6to+Kwp/DTx7APqAB8DPQFZUCZOEDYdWhaL04zmOA4D+gXutvXT2iNdawdoulTJPyE/P003wDBYSJARC+NG8AYZy6bwwA/KATa0Y91Y2kFPr0Bnv3UUxxqmiLU5QJhNjS3SO3tx6Khc/18WvSyqd9PxGQdUpg+hpZEE4rSMPDCh3gNUMEQNq04JBL2FanlRT6ZiusGsLh+rKFvLY8q4LzppwoLCB2YQH3rEB3XDVLnoZGDfUgA11Kf+gjIhIhEYFhnhgYoGjIW1/Kg3iFGu/qGiFD28ikIc663wFpNleEE7SVgYKoBylcsBjMI2slANshJFPWKJl8fDtQ60YgiYkQf0hqii9Am7Hehj+YVJoM29g5CcUNEFYuFtYQZSLawbCAR6wZhuAYAl9fhEELcWiofGzRE40dd7FWJJELE4LohBE0REqzFwYPgtdgMQNOiAMFgkYgUEMC1CE0oe6iPIbDoYO9QgXWhjw19geEJ0jRocF8BqRmSBYQd5sdpOTRURFJO872X42GfT76LvHaqYrCfSmXDNsjnByXrZwSWEfM+wpl+jo+sLSt4g/6u6yeMX4vDA1RtEInNWpwStLAROvT19gooApoCEkIb1gLBGRS4LvAdqDNR8bWEMrD2DLC5LmBV4ERkiGdkmIZVDAiso7/eSPron4gT49AnlTfEaDiBihF3mAf9SAl6kRr3IR8xQODsRYAPrB0kdFzbv5blw4nXDz0Y6MfwAoBiiOZTf3GoOKoa5cw/zv3j7X+8/08H8v/0+T99kf+nO//0Xf53B3/3Tv53v/rdyfzvzvzu8u+u/v56/ve3fn/n93d/fz//+4e/f/yHd/7wXv4PH/zhoz98nP/Dt384nf+ft//n3fw/H/znD/L/69r/upH/l8//5di/nMz/63t//DT/x7k/Xsv/8ea/ncz/6YM/Xf3TtT/dyP/wmx8+++HsD+d+uPrDtR/u53948MPjf//033+d//dr//to/j/O/seNP3+Q//Pcn2/9+faf73snD+S9k595J7/0Tp7xTl7wvoXvb7/wvj0Jjznv2+t579S73qn34fGxdwoCT7/vnTmS987c88489M5+6p39Iu+d/dY7eyPvnTvgnXsbHh955z7xzn3qnfsNfFzwzs3B47p37qZ37g683fPOPfTOf+yd/9o7f9w7fyLvnf/WO3/dO3/DO//AuwAFXPjAu/CJd+FT7wIUcOGCdwEKuHDdu3DTuzDvXbjtXbjjXfjOu3DPu3gs71382rv4jXfxJrzd8uYg99xRb+4TePzKm4Pscxe8Ocg+d92bu+nNzXtzt+Hjnjf30Lv0qXfppHfpW+/SPe8y5Lv8kXf5E+/yp95lyHb5gncZsl2+7l2+6V2e9y5DtsuQ7qF35WvvynHvCjT7yrfelRve1cPeVch99QPv6sfw+NS7+mt4fOZdPeZd/dK7+rV39Rvv6gnv6mnv6hnv6gWIm/OuXoXHPe/ap951yHr9I+86ZL0OX5D1+gXvOtR8/Z53/aF3A4B740vvxnHvxknvxrfezQPeTchx8yPvJuS4+al3E3LcvODdhBw3572b0Mqb97ybD7354978N978SW/+W2/+hjd/07sFg3brI+8W5Lv1qXcL8t2679166N3+2Lv9D3nv9ufebejT7W+92/fh8di7A/Xc+dy78yU8bnh35uHxvXfnoXcX8OPuO953B/Ped9e9725638179yDs3jve/YPe/UPe/SPe/Xfy3v0PvPsfweO0d/+sd/88vF337t/07s979x9630OG749437/jff81vJ3wHhzwHkLYw3e9h4BqDy97j97Le48+ah84kG8fmGsfeNw++Gm+ffCz9sEv4XG8ffDb9sGz7YPn2gevwvf19sHb+fahg+1DH7cPncy3D7/dPvxu+/DR9mHIdPh++/CDfPv999rvfwCPo+33IfD9z9vvf9F+Hwp7/3j7fcjywXvtDyD6g6PtDyD6g+vtD27C43b7g+/g8aj94YH2h4fy7Q/fbn/4Hjw+b3/4Rb790aftj34Nj8/aH8HX0S/bH0NrP/6k/TGU98nt9ieQ9ZOH7U8P5tvHLrePXYPH4/aX8PXll+0vIclXc+2voPVffdf+GvJ9/av21yfgcaN9HL6O/6p9HJIcv9w+DkmOX29/A4HfzLdP/LZ94uv2SYj69rv2KQg7daF9aq596nq+ffp2+wwEnPmmfRZ6cPZK+ywEnr3VPgeB5y61z8HX+ffbF+DrwuftC1DCxX9oz51vA+q3L8+3r8Djykftq4fz7asn21evtq9ea1+9n29fO9u+Dlmun27fOJpv3/ikfQNgduNh+yYE3nyvfROqunm/ffMhPB635y/m2/OX2/PQ5Pn59vzt9vyd9vz99i1Ie+dx+zt4PPis/QBg9eB4+wG04OHb7YcAzodH2w+hnIe/bT881n74Vfvh8fZDAMXDh+1HkOXRrfajO/B40H70qP0YBuHxkfbjd+DxUfsx5Hr8m/bjz+HxVfsxlPj4cvsxDNzjW+3HkOfxg4WDNxYOPl449Gl+4dDXC0cOLRx5d+HIB/mFI79ZOPLZwpEv4O34wpEzC0fOLRy5sHBkDr7vLRx5AI/HC2+/nV94+/2Ftz9eePtkfuGd9xYAEAvzZxbmL8Hj6sL8zYX5+QXo28Ktswu3zi/curJw63p+4fb5hdvXFu5A8J3PF+5AxjvnFu5cgMfVhTsQfefOwp3v4PFoASbSwt13Fu6+B4+PF+5CC+9+vnAXWnT3mx8PvJ3/8cC7Px74Fh4XfzxwAx63fzzwHTwe/HjwYP7HQ5//eOgreJz48RAkOXz/R8DwHw8//vEI5Dty7ccjkOGdj3985yQ8Hv/47vX8j+8+/vHTA/n/c+fx/4FR6Pz6o85vPs13fvOw8w/w9cVHnS/g64sTnS/mOl9c6hyDsGNXO8ce5ztfHu8Apna+utb5+rf5ztcnOl+fyne+ea/zzYf5zokPOic+7Zz4VefEbzonPoPvY50TN/Odkwc7Jw/D4+3OyXfh8UHn5EfwONWBdaXz7Xzn1KF859R85zSkPH23c/r7zumHndOPOmc+yHfOnO2cuZ7vnH2ncxbqPPugc+5IvnPuZuf8J53zEHD+TOf8OXhc65y/D49HHUDlzoULnYvwuHiocxESX/ywcxFSXrzTuXi/c/FRvjN3rTN3ozN3uzN3pzN3D74fdi4d6Fw61Ln0Vb5z6XjnEqS+NNe5BK25dKtz+WC+c/mdzuX34fFx5/Kv4PF55zIkuXyuc/kCPK52LkMDr3zZufI1PC52rsDXtVMdwIv//Ob0f35zPf+fJ975zxMfwuP7RZiLixevLF68nl+8dGzxMnxdfmcRlpbFy79dvHx88fIJeLuwCIvM4uU7i5e/g8eDxcuPFq8cWLxycPHK4cUrRxavvJNfvHpj8RpkuvVw8fan+cU7nyze+XV+8e67i3eh3LvfL96Dx71bi/fu5Be/f7D44Nv84oP7iw8P5hcffrn48Fx+8dGjRZgyi4/fXXz8ATw+WXwM2R//dvHxl/D4OqM65f19pYw27ri2VnWVcctq6JqpjE+7ulKta7ZSbWiOo9Ss1nhDV3SzNaXo+5qW7cLD1c2ao0wwHVLD0lxl0nItxZhqNvQp3XQdfMWkhkl/uj2hVXWlYZmTiqm5xh5daWrV3dokPG1jj+bi03L1KmqPmlChUVWcOhbguJAcPlpN3VacabNaty3T+CUkc+Ftr6NA603HgDqVPVYD0jb0jDpQyrDG81az5rIyqpbpuKInrJUZdbCUwaQAFNc2qm4pI/ckaL7urqDZrMHTht6oifI2GGYNatgD0NLsyRaVm5lV7XJm3Na13UpVcwDmmlutY/Ncw2zpSk0fb01OQoNr+oTWargwEIregHQE9ca0MmHZykTLrKJmTTEmFFt3W7apOHsNLIegA8CZVlBztrcOcGEaO7PVaEA41DChYXEGgEMzq7o1objTTXzssYwa1Aq91RVT3wspoDTDyahaef9AyVYzA1NWrQVwLtmrM3FIYiADMh8DDv5QQjYYAAOzvOYXhpkVbchVfrJGtcpY7Q598vl9zWxmV2a1sTozmsmp9YTwhQMfLRw4+o93/98D+d9f+8O7/3w4/8/v/uuv8v/68F8f//HgHw/98cgf3/7ju//2af7fvvzTh/k/XfzT9R8+z//w9Q8n8j+c+eH8Dxd+mMv/cOWH6/kf7v37r/79ev5/f/Af5/L/cf3PB/J/fv/Pl/J/nv/zQ+/k58AlH/NOfgWP097Js/A47528CI8r3rfAhX77lXcKeLVTJ7zTHwCP/K13+jTwyIe9M8BMnXngnXkETPIn3tlfweO33tlT3tnT3tlz8HHNOweM1LnD3rkH3jlIdP6Id/5d7/x73vkP4eOod/633vlT3vnTHpA+7/w17/wj7wJkuHDYuwC8MmS4eMi7+K538T3vImS4eNS7+CvvIiS9eMO7eNubg6Rzh725B94cJL30tnfpXXi8712CtJeOepdOeZdOe5cg+aVr3iVo6aXHHtBA7/Jh7/ID7zJkuXLEu/Kud+U97wrkuHLUu/IZPH7rXTnlXTntXYGMV655Vw95VyHptUPeNWD7rr3nXQMIXDvqXfutdw1SXLvmAX30rh/xrj/wrkPCG0e8G5DwxnveDUh446h34zPvxufejVPejdPeDchx45p3E1px87B384F3E3LMH/HmIcf8e9485Jg/6s1/5s1/7s2f8uZPe/OQY/6aNz/vwVLs3Trs3freu/XAuwX5bh/xbkO+2+95tyHf7aPe7d96t095t097tyHT7WveHajmzmHv7gfeXZAY7v6Dd/dzD1Zg7+4J7y6kuHvNu3vTuzvvfXfD++4W8Lv3vXsAwHsfe/c+hccx7/4N7z6E33/gfQ/s6vcfe99D+PfHvAdfeA/gF6SlBxe9B7e9B3e9B/e8B4+8B4+9hyAoPTriPXrHe/Su9+gofPzWewQY9OiB9/id9oFLwO8+ah8Evufg++2DwNgcPNY++A08TrYPnoLHmfbB8/C40j54Ax632oeAITp0tH3oE3gcbx89DnzoifZR4MOO3mh/Dczp15+1vwaG6Otb7eO/bh//Tfv4zfbx+fY3t/LtE79pnzjePgFM04mL7ZMf5tsnj7ZPQjEnj7VPXWyfgfAzl9qwILfPfN8+C/zW2U/a54HfOv9l+8JvgYf8qn3xM+Ahv2lfRFbyQfvi43x77v32HCSZO9aeg3xzD9tzEHjp4zasfu3LR9qXodYrR9pXIMmVY+0r0NUr8+2rEHf1UPvqt/C40r4K+a7eawPitK/Nt6+fAc7zbvsGJLnxfvsG5LtxrD0Pj/lft+f/AR4X2vNX2vO32vN34eNeG1iq9t3HjBosHHi8cPDAwsF/WAAhYOHw1wuHv104fBberi/MXwMG7sbC7ccLd4E/u/v4xwNzwFld+/HQsR8Pffnj4e87X8Ca/8XFzrFrnWO3gBd62Pnym86XJzpfXe98daNz8lDn5Dudkx92Tp4GxuZ85+TlzqkDnVMHO6cg7em3O6eBlzp9rHMayjh9o3MauKgz73fOAOdy5krnLLBEZ3/TAZa8c+5w59w88DEHOgDVzvljnfNnO+eBnzh/r3PhIjA2wMMc7lz8qHPxaOciJLh4rHPxe3g87Mxd78wBvzJ3qzN3tzP3XWfuUWfucefSwc6lS8DFXOtcut25dKdzDRp3ba5z7XLn2pXONeRT7i1e/mYRuL/F7z5Z/O4kPK4tfje/+B0wD0eBh/hk8QHwFw+OLT54vPjwLBDaYX9ZaWZdVc/th6Umi8uIUR4cGOgbBNahMOw8q/c0dHPSrQ87q8u9uf3GRDZrrC7ru5zR3HNuji1HXcXhIHx1EWLKflRhVqSZ9SusQoVGbj9fy9xnBwcqfYPlctktuc8OFWdmsvBYWxka4EHF3j4Ko3YNVNznysW1he5uq8fVHTc7AouvOdkzYVtTG4Gh2WjV9Kyby5W6il3lstHdzXqXywXVN7KG6vjVG8/2r2PVGyXj2YF1MzNdWQOalOvuhic1x/Cbg0lYcwzRHIM3p57eHEM0x4Eym1C7npuZwSe0E1uGUG+VRfvYaND6XIAqdcijl/fP5lRcn3sa2rjeKLvsY7c+vdeya2VdvLHgcR3GUof10y53denSJ4uGZdh2HT86+GTRhrPFspoUxV5F8HrHMSZNHsE+WFTT1ieMfRTBXnmw5bh+OHvn7TNMqEBnz5kZZFZYRKtZA3ZrI3BHwE+UMXw2QNMaAwwfNmQSWhCyP+hdqaugUpElfZYBdaIcjp5Vp8r7g/5SyD6AbVDJZKiShEHwQQ1jsG+XO1oWDdFZlXvK+4HHLLHQDLGbUznV1ieBMxKh7IsiHEIXEcG+KMLUpnS/FHinQM6Pbq6JGD+AooG1EhHwCrzUODD9u3V3iwjdlYnCKwwMP8cOkWOUl6L7ZexfURm6X8IslNDUbN30S8guWwKl90vIQQlVa2pKEwFqRp0A0OlThggZppCqBbKHCCpRUM1yRUAPFPNWC+aoESSqUCIRuilIXMHUmg3stQgpP0dpXR2EBgC5CBbfkNwwgfc3ajsjKSLBkFBvNIymYzh+y3p6qOxxgP1PW1aQ9e9pWGtWo6HZG0Kj8JPlh0F/y296LK2Yvyylxt556rHlkhtmdZNeFclXr16Tz0MONvMxNZ/riQPLEvGsXWv+n1hVQTHRvA1rEm0Qtu0o1bKZmZmMWvTD1r+yCQO7uzNqL4DRcPcajs4TZtQ+P+hnLOwXGbXfDxN5QaBEmLVgrNxpDCmX13SV15TpASAZxFncIBMHrYHxz655bs2z5TXPQdxaKm2kbky4FANRz8F/wJh10OdGy9lq+OAFcGWSqdbQEp0nYczCwv87dLyQowT4+Qz/BCmsjt9rgmhKwmt95plopbM4X7SG7lR1zFepEEDHSFYtTWaZ0ArIOoZyKwbgk9B0jIRYFgQvlIYLtBTI3zFcyLcYLt5ZOIm7LJheWck1i4IsaCxbewg6kWaPoYSM6fDJ8nFxGQP5K9YC2SjEsuXysARB7ymav9NcGzMmMMxA6jnGVgH8Zm+sLiZ7Yyh7w5QkiGMQvbB0IJZTiE1tgbUBv+DB4eW4HFiOiyEkvGMIvUTbi0I9RcITU8Oo4ic8liUDY7iysqaheI99JLGcOkDyOYWRGE8twhcWxoV6AjV7ZT1jQj4LJoUAwm1KhAklAZaASzg1FJ4sBJUSDCwttqaNkYaCBkKj8aRRIKgbZspMWTtLaYQ+gaUVX0vlYcoPqp/enoD8jCEzQEMIzyfJx5QsDNXxbeV5Z9Xp8po37DfMyswb5swbrd5C7zr2GFqjjst6kukex2rZVV3NTMqc/RhwwoKXKSIf487MFPvYc11vX6//RmEBh7wb+Rlk0X0GyEBuuOxyYQCq4MKCU9ZBSDBAOlgNqSHAhkRVzviud7NODkWDsaydywnV1bNGvtjdTc2w4UnNCmVZXcxVnNW9JXjhwkO+SLzVSHnNrjdaxcF1BQRCoZCnh0YQmcDfAfjtg4g3WhP6xMToGnVjeU22UnrDmXljzRtrep7BxzO7fjH6TOWNZ95Yk3tmzaS6t7xt/E296vagjs9CrFCfL+/tqWvOtr3mdtuCCeJOq5shyLUYb6+uF1lYopmZMOfO+/l8DxrMMcZQ3V5eb9vaNPLN+JSziAyZXRaVqlCKUVh+ypt5EVDAK6LOKpBlV8/ihJIG+jVpoF8BrhQElFcEcypUab8ASGRWuz22DnxIVc+uUaD7sD7mVmdyP8nIAtJOqTRf7EqWs0pZN8/lxaQEAwO9Q4Ors+5zz+GiNDDY11tYnS0Wevu6XSH4bKEhgnHdtI5GdNOGF14YzVa6MGQjC3kBQnIzmOoX4WQzv8hFk61Rd0QkKSY2GaYupCZgE1tTZlmfHd4RjHqPNTHh6G45PjAkauzI+sXIhayGsRnGXmwKVYpTJxC1yjwLENCyoeLIdSHKsxn7AlB7mFssNYWEonKSbLItKqcXSUYfFhMPZ60DKXDG2c8WcqHmg9CZh8m4ejXIvmV7lkC/obxfr05pr+m2QzwxymGs6p0AkVLGqdpGEyi5ZW42HZgHem0EeG7OZWNiy9xpawYAZXIj488xEFDW2rtDhwx79FooCJuzreU6Rk1/QSzAXUUWu5lWjedpPXl+j25P763rtu5Hr9+rGW40b1D2CC5kPHqr7tYtueKXgDXaoIGUBYVV63p193YmNb2A2nsH6W7DqhJj52AS6JS1W/d7iD3TTZd92lCMTqkAcSZtbUoGGo4X+64ZNszVkUgo0HkCynaUbrCQWXVruasYDPALiHQ4MDrJpGKcUTe/IafvMkbLbnf3elKeVFz4LG2AHxztDAoWwEegpNojDWkl9FUu6uuoJdFU2a6twDoz8gNl8B0CZE0sRE7+0rNXs01AVWhzQZXDspkREAl0ZT2aEivrego9BVWxmgRQuR7FcBQbOGwATq3nDXMTY/zQoNm1FCDhkGu85dI2hLLXaDQUx7WaCsjauzENbVDoykQLsEgH6QxF8VDnirlSKOS5cm+hOICCuxyah9DCUE4VcAhhKyUOhYQh9SyICDAEbAq7PSHsApKrh0PKkeYUQejYDok4guXYWMMKKkKG/bckMuT0NFtOHVcDvioqrDCOoDlqvP9ZTlyU/ECgAqqtaqqpWqwZ9fJ+HPeSUclsgOmwG+TnLUDsMioIr8CxOYw3KdkqULGSNjsMrICYNFBxHb9otdlEpIzKBVj1sAlDKei1vAtqHcWxo87UoTNZXZW7AXFEnF4t9w4MBnPjrVA/emeybqW/VIBVQa+sgydleTOZCHNULLtlnGCqRGpxbobIbUit5pRfy2q73PAgDlYGSxm+NVYOyDgSzEqwZzYwmhtmRDmTGe4qEL2PYppddpIKJ61naHoOlPpG1ZQ6sZzV5YyiIX3ESUEd4ISm9jrvhc1aY5azdgV37mBwYdnH5Qk3LofjeUYoAnKaSSWO+PudmALL88vCQJ7FMJstt8y4gqyeE8um6WrAqz/vVIH0qUYlK1SFsDT6S+wILZtBKT0gk7ibzZq+bxsQuzdALAAeMre6yMts2VtoeQ/SOw0DOJxCpMRcj9ME6T47nRN8bCmoPlJ5IVx2kbcf50h5Tw/QR/ZNs6McaDCdoOW43IvSpcgtMFFEvP8O1Wy3HINQ11f0Oi7QguelVDxoRBQTVCvHlCPZI42ocu0qhxbUqTW4xlVUDVKdvR6xFehfV0GM5lZCwHIKIooeEt6EcszMSFGbaGU09ug+4HNCWQwCJrZlPSrd1rvlfDEpYrP5gmUTM4DoQwloE367GEGaCOGvzTUoAIMKkgrdKe8a5UpnwKsJGOMaYz6cJE5bJSmFt7i7O0L6YfH8m66MSBHGwF6gy6z/u40mohKnc9leQYmqIGPAwFV3+y3S0RhhBMOzRX/+ocoYkrkytnH17yvalF/CrPpieb9h+jzSfhjvCWOyZWvjwIegwtswX2RneCw7MXY9GmAkxFQ1kwCfEBXwYGmRbNzTkrgIatFkZ73zmpZa0Cv63k2Wu1OzJ3U3sfkbUX8xQvYZtJDFE80Ovynx/U3NdvRg4WCrIUdhwcRwZs/HZJhlr6B4kxsWUhKGmzCFaPUW84iK3mk1t+h7dCbGvdgTDE3PpCxuiKUt29stKAJwiS5AgiFCrmeioU06uecKrBR/DFOKWbdcMd3dXSkpOAyJPd4MBIJVSGiRUln/X7cygWnR2gRHzEcnmDmcnOeLw+5zIBG5+bzgoyMJQSZGflmPVTszo7PGdr8a2tTs7ebhOb+rejAS8ugLcsenewL/CxxgH0chEZsq2yAYglkVBYQEBA7RnfDOQaoiS0NNVFFjE+0pR9nsIPQE+jAzYyS1KS5Q+S2SpnIKOhR7w9gnNS6ExQnTPrlEBuGE5JtNVq5cG68p5zdYJhn/FZDsHVgnQMmmSpQEpYBpqTkDaIgwerOHKV6TZ8EuPEfm25qJjXo9nx/Oubv00SAKPgJxknrLd/fdYHd/dQ5idjmjWcOnagY2IEIfo3uwWBhw8MBbUcJszs+DakzdQcRf78YYcyb5+AUA74eKC1/SkUmpEy2O1eFitPFL3V5B22ZVvqazlZ6r9QzdyUorgfoi45JfKsuBr5fXoOJsVRb1iG/0zOz6xao33hjNPVPJrZrJBIEZHpjJrRl+KcrrhKQ5ICppBALES5/24HChamdjwPui/mp1eSOghF7NBqxGbldhVAwjI3qvR5NwbgSEK6RpXXqIxGXwrC9rMfIwWX1XcRTI4a7e0Vyk+tV6pCojoTWAWQa8QobVRpBctWXmCLW9TDnMdZ/DWLM9M5OZ5S/TzJoCSwAGqiu7Zlf273t2rX4jv+aZ//7sc2W18ovu0TUsjZ2DfMR+2cCIlSN8mKhqdREogosWKkGbngi2KmtkEAdrCdD61atnZ9WXeoAyJcnsgcxQRt1N1ucTAK+7QGqFnIbDue+W1liuiD09aArAVxgmelC5XVHZijdpyZK7urhdR5AqS1qEhEYC7wmonFIc41nl2iCULyotk2XVa1kqCJZ2pkv0NYmp1F50GWQtXpgfxCwMfCyJI3pYApKkrxyDeXoTxPSMNzTrb2GE5m+CcjTCAiSkSG5hSORD2GNbnaRWCpBn91C8gLYRbXHKKGgTIGCEVLcRIiqgIFA3peehImK9DsVmY3KqmiTTwprL2+wjYIB/iViXjmvBdzwjNM1hsl1X2a24pQBD1Myrfj6FFpkM1/H/MjYCZL1e18waN43ibIoMVyEIwDJc1x20aZfThiJIoULBzBx/Oy5CIAfPworC9NaaC+NmPg+CsO0kjBi0Klz7c7jTFvR3h1619ugkB2UjKdUMPVBFa1quAsvjlOEiBAhVSPMKq6+r6MxgPpPj9F+vuEm9K7nxrg0bSzTHUPVKhuXlCmGb6FumlNkuF6Q0GQxgTIicIFgCziANMl2SpSLngaJjB8uWK8M9tFAqBogVMzMOChf4KvcCmp4ZEWXhSQHaMVSYTQ07XAAdUMgGSLHMxjRqsmsAS7tVhbKxt7xPTgYWz0jpMowcNbNDJw6GFEWKNaGMjRGnMjbmV5zJ+XD5O2RUSbjYLJTtAEttyonhsVChAPHvCmlR+MwS8c+GInMhMIQSqhmqHI8D8KFRgKAiZo3riuafdmBDzKVlUWy8VBGjZqg3KyyVLa4jdMiDjTETARKWwjCOBfjElFxIBCt8rYwXBzMpaE+ulCFtkzFh6HaQGxiUrfrUuG4nFc2Iy09lrnP4p2HdQajJjMdL3A4GntHtGbdq02gvSy8gI+SGfVLexddTvmVolAM1BamWSDFF6qWuAvLjrAymqjdys2JVEKJuLrACKACDx5u0W592somatRxIHLZkT1xkzdDKNsgdwyl0KqmgXdqoINYsRFmVWa2tzqwS9IsnBySQFy6tpjUDrhymecOabOkcUhwL+bIjqzbDuqCoyhOno1MndRA0ZzvTFIkl4+Xy/t10LKhhWc3MrPp34pubDs3CSBvOlghSLiUiDM7MJPBtmYaO2n+fyIU4W6625MJBAsdu+GlkDl91onw0N9AwSIoYKgIGA4EYQisSxzf3HqaFSJYvir19LKXzHJoDDHR3O8+SJUAoTxXIGzCbgXhrl43VxeFGNq0VNjGnw7nVq21qTu9ylTBUi/GKhmozqchkzKSWSzBdV39KJs/TZlXoH5J4xqTxWpc8XhqWtaIRgzVs5WPG5amu7JKcMe4FGDkUm3zbt65yEmSM1esgFfyGo1ldsFgAo5+GI5AT+TIxGi4fjRyCMkxwknUDQmAkIZwPm6x4ZRMoKyzWkQ7naFNtTw/a2gHysjkBo7ufTt5BOLNtFF++zaJMIqhpGzDdRh4dEEZNtcXWYG5YlOJbOMZK2cRjpAKkbFZCBisxKVoxxtK+YCWX6xs2ihy+bQkJ+DDkxgQNNojKtA9CH7mllJaDPFJmryX9tpgQMpy6iiqwXH6jmG1h0KKliiPdGRZRCPIbE3EAbJ5I7D832YwlZ8YniVm4PWcsywiFJ2Zh5p6xHDsxODmDPZ2Q3J5OTMyMQ8UXGo4KvVhZMGTE4qApAhmUspMlS0EV1YvS+DhBZczuNNa21zE4sXVkihpPD6FJyfnZgfgUQ71oFriMICnZ88cSPj/VdJPBxK1QfSRhBqhL0OLnisBa26RA4Kkj+i2Z7JpJRNcKiK4pLZT1FCJo0cLSj3uH9ZmZfjxjVM/Fe+jzhPIQJcWjUjtJEF/CgAqtUjjOSAw1551WMSisIg+Cqxg8VylT2jSTU7RmU8c10yXxD21xGsiMZnJq0v7ukxTPS6Za6LzyKsnsTGEbzKvQmiE0WhVp9lMAYEMpBCcKgyVkWNiX+xxrePGWVDmp88aUNsTTCV2BCB0iTLMszcxqOXn8hIbblpR5EYmhSksebxZT8ZAyJyd1fwtSbr0mt6SpVlU3Ao4EtKqi3PzTpZa56Dk0khP4aQC0LxuOQWcFeqiKyw+ukUF4WB5BKFRig1DKiizSqCOgRK2OpJeTzJFpVyPY5Rd80erVjm+fHMSi2AEowmzBeH0zMzY1qeyH0CdxeUxfBFwA8PBoEA3LKTH2qHumwFyOAEVMMMvc3W2wMN9qyxFa5FALw1JvoIoCtHW1KjobyKwWRjQhkQMNtrB8fwAzpUxsUDMB3xVjS1KVzvIYS9BOEntihcoVWk9WFQcLCZ0voyRGcmySpIoHRSKZrKZkxAKolBVLHBaELLFUEAn98uxUl2CCKlFUL60ILlZ4IZXAInNwcf0kA8iwtImd2KwhjjZixzwgGyFhgxmHVWIK11KeJLREsEcMUQpRsLIzfbJZFE5mAg0fWT3Q90kzWw/RVNRYqEx7IWkkGEOfG46ooRk3FN0MYPwSiCliVzEqK8AqApMEpYFSQKKH09BP8Eskj4L0EBtWR81AtIHaiU06sLY2WUECIkbbapiRnfVEtjosF+KxTeDGSbbuqQXFCzJRyS6JDPEmVNJGoeQyvVoZE0TGZDMSfycHRHjFY+hwc34hYce1E6qJJlvM7ccvBc8UXSG7qEYUTRnSqlbYxiYM3axZfioA/5dBUevuNkOUvC4o+c46upaZcPOkJkazCtTfaujgJQ8vuIwQa4TaK8rCGSMA3aoeQeVci2keSTNWRzHLEnaVqPDd8prW4HsE2XrSkNZzwuIxUXGetVDsUlc85nVJnI9xRzGxfskJ90KQ+OczWaNSKP0kh/3TgxokiW/ZdWQFpB63Sx39rRYWl7i40BlAtPRDeKLdnbQC0BFEmSOL5CsFNnrhBUHqhLQWRKTT1O4FxmNJNjuJByzSuXNW8CrFYhkQHX11UAIPvDIuT5icMEYvKwUkM8RxXi4JahH4SJCLCOlxRXmYXe2pGXioZcowNXNZ/ADBMrAS9dc9JtEm8Cp/l7RoSmY3XcWIIp7tYg/n4qscVh1b5rhME1rlwlmGhdggQU9XMwxGG/H4rt8v1mQ9tlaiZb40MUTvOfycih6dWTLQSlkjdbsxtvub2YqHP5oN3d+3gcWuBU3Dk/RodsyrYva34TFgAtEsecrSE3Z/Q53gxyZSdjpy4fVF32e4vvXXCqCZxrwGfGgYkyP4KmFyWHm0HIV7GsuH+MaalDCzudHQJ7UGGk6hFby/8YvnmYkOPuFETup9uI9ik+RngGZix2sjnijfSIhAe5UptnpMfgWByzAn17vWFNnqJW69hUc3mJp6pa+3VEhbPWHJqvSXehN53h0QGoyapMNL3MPxKc84arzKUQ0YxiBH0NBtya5bntYAj7Axq6QETyHSnDWvkHEzwFDSrkbAmxX8QNLWRbGQpBwRhQatDRE8TBAR2Liur+hDM5hiQecTZprUWGkjr4cO+JPhn7wg82P/8prMIczXYlETkIugiPDqKJbGrYZD92wwZ33ogY9746vyxiTitoQJ0rSWNa9PxhKhDOISDwRJVzS9EsUSvyVhSfSvwUI9obTOPBuskFCmys0hTXNqL9h2R5ziCeYHmetVaInBEqLOMUbPe9iJyGXYhCX6y5w1JHVO7oPUt7Cye0XaknDB4QKkkqMawwgqoj+sYOO1IDbc2CAN289q/v4i7dpru+xRoSTTw8YwAsJUIW7L63xbXmvYulabVphQS3vzokYzYGa4y6kK06uVItSQbdVUxO45P6KboE3LF4ctNNaxxEmAekjtZ5Haj2QzBg5iSdipbFormRYvmkAiwGqd9H1lM6SQlyfDfvLgpKu032+q4ZIke7PZJZHIqeSZLsAQp9/Yrh16SOCvJackApOmFteiGknoEsUKGRXj6uNkQ2vZ/EWcdF+GTiWULdVMZDtGKglXhDcK2tUso6wa8dCVxM5yM5g0Nl6ozEJcezKjLnPeSazksC7Zyzj+kmWE92DL/koo5rFogrwwxpdDgkuKJjFtaNBUzHc/ILpOMlyIwIfUd5VAR5/C5cVKYn7bImUxZukJSvO5qyVoKvrySeIjVrKkyBrXMPg2m4m7HjE1UJLSMHHVpYP4bB+H7RnoIWUe7h3i0KC9nZGuJETjkfDmPd/t1Yn4wLfE8VJwrJIatSLM+nOXf2rWqCA884aZKWWYHgqdgTBd1B7eK0Uq0ldQ1bU9ICAAZrPjo8hJkYyACi5Etx7bmKy7ZaOSIicGwVu16XFuTvd/Gx+g9zT08sYJBGybSGHjUpZMNwR0IjRsaTACzxwxxl1IB6LszbWs7XN5jKPV38pVbDaBk8Gl50oOoADzIIW+LmMag6dVQFecMGrR9hZHpZkZPUlBKlRCCbpW3omADqQIoBstNK3cp4wzsc63ihU+I0IIx/CRW3qWErZww8rzQAUgoYAdn7uITTm1K7T3OjWl8W09f62X0WJzLepvBkCVKqWmiJuQRaXJjYSjUiz1At/PpeOfl4vqT8q9gSeEv5VJFLmjJFYMzfV2GaPob5x8a4mjNez03ibfbJgRCm6VOqm7AT3p7s448vfMTNYuM2rhGlXgumCCGEAhWCxQPgOzl8n4JGM47B0P8Yh3Cp8Mwh0pvSOld6T0Io1dyWJ3eGcQHKWuLgftWjHUJvj4IHHdENnGQWu2ABHIqBsAJMzicCWOILbDybTj87PQoC0GDIvWCMeL8zZ6bjai845RBjQ688/XB6ptsUWUvO+wzFztcnKxiYckpbtb7/5JohVDz6Q4IyxLypgnt9RW5zqspocMFMsActSD/ZyCAK37uwW7H96+jyzyYqO+CzMhxfgJ75yP+cyOmiF+aImTWo0f1IxK2vFPnCmlvlxOtu30TdDNsEMAISeEXAKEFnTfkUAhbJAe+o46E5D4xrcE2GTQ5wh+ZI8tyELoMFclBrWSpPEMoRkz3vddmITiNsAKiWsa6gvEnqXfHy3SHzOpP1bCEgkth0WSVyHzNyU/VLJoj28GRY8b+Md2YpvITKnkxOnmFsMJeAFV+HxIRlyZvKYefsgGzSRbwyRvYdLuu1GW0HM4xMYXomaLm5mL4mgwHZXOcjMhpxygDcXSyOXUOJMAQjg/B2ovLcMsJa2Y5Uhjnm8EAgsTeLF1FJUbRvdOtiTDmEDkY+sHoK7JiSJjPvAgi2WzcFwZKlktbRvAFOqBTa1mw6ji3RpSEcLHkwPzgt0rkSEoFGBOIBmHCrcLh8cyDadI3qS/zcLMz6XXjyl5G4JClFV/k1lt+kspaizqWqCyGNd1U9JbhI3wODYYEd1RwLKGOQ5/zGW2VUaEhFlYYbnCE5CNZtLsk8c5USctbeX5TuIAHZaxNlGNOIo65UwGUBe9tOGPWc5MEbpkgNp2BbYlEXsUxlAAILFFOrpFCJm7cbSOW0pGz9VngWM2hgXjKfWaO0SxXf8EZGjJrEDjCiVoO28IHmwxOJsDdLAL+BCd1sFEYxpmue8flUqtObpQYs1iGUw4XFqB9rCyS4Ty1AyEDjAGXVouBCFaw8naXSTsginXZYd0XczMJXEAkMcSkImODR0kEZxGaucqZrkOEKzToSCnAuATPBe5dcKpFMGW9e6Kj4Aa/kwsO7H5QJHy5IXmlpKJHLYXcUR/1ne8EdZObAFejyMsDBEIMTBAGgNis9wlUAJA7+IpP5nY5dRquQkRw/AjFxFRhkrUZqNE52D8V3EpGoZiDcAcFdC8N9h9lB+blVCNJTO6rjDKjAdYVDLspO3QSBpyVhF26fDTtFFd9iQ2jkgMjoIgRyPM1lR87uFxx6TD3OikXgoXxywSSRq2N85SxBtUyUaXp2BapG4MUEW6I48QiJ381KuCAKjBYiGVu4rtqUvI7wbIzzYNpCUrG8JV4V6W8NSNEHA2uglKB+FlF+WaWA/5AhzuoJ2Og3Rw0mdWEfmeJKepEMVS+ATAzslzBvL5RxozuZSCOcDDqiVxwZZ/nJZBXipNsPxcLJNUJGxWMGAJIZgLlS6Xc9Ehn8ZZzgT7W5lj0ERDoQjcEHfqVqtRY800LYWVAXDLOOEqik9RhROvQt+nVd0GGuTrrK6EqjI7dMflkwPDRbWoAJRsyRPqDdLxFoywFvBTtegYhE59+71M0KrG+MMIHhMFirEhhBwhgloJ7cTKhDNhSioTdLyYz8fwdFwxDi5fC8fCUGV+aasyUX1daJ8+wZ0QqmtiToTiQSRZxPE6pClNyGXwBUDySRgSb5fZlBHEKH0kJc4rTH+FeCIzkHzrkDSkCU73JLEZjwUuJcIYS2y4RA4op22SpqiGy4lHeKVuRiEQ1/XF5flsRP8ndCFiGiaqQEjflytluwrSjmpEmwOlUqcjg4LiW2Q4ApEubLPIfPjnIlr5kdY4c/Ts8KPfRaaCwHrCYmrcGGe/kIpKSU4TgX7USrtGZ0NoGPVZKLza+ipbnZb9kFiUZgUUK4pU/ei1SxRFjruwHcPRg2FxT9DScfbk4n1XRjhKjqz0iqTc5eSLoyASFYa1Z43gCIomZHJjlzY6vB7WKJOdLUFNa8WmdgrBu7SMAM1bzmkTk1+F7DrVcmh9FkBAuRq5GLPasJhhC5OtpbNA7PDU+kZDEjJTNhXTvdsVhdgQE5kyaHLdw46A6fLsYEfIWO3EBsk6HH6iCzeURNa4xEBMh19yzFpQbge6ps9IJxa6AqY0ecoJh+yh+SJr8pff6I5BNbzHbtluiuudBNtb0twmnR+MVUJFDYflfd+ANFREGNDBbSxxOIf3VMrRBnAlm9yIJWAST50J2ssYoO1B2QHZz+WWa4UEg/TN2VAhkoMPgobII6GfnFreWOLTNIqtcnJUcEcCuJEJIhggG4l9fOOQIxyt3biaEzaEOsyN2aSMURCM+FG+zX5kPrJ5kPurzAPWzMDKuUB7LkHzho1n/UN4hu/yA31fG9zlBwHvVVN4mAbRAD2LN0J7ZRjA4etHy7s0PDDG7orUgmquV1g3lQbLK/mPQeKroNLPVAQ18bci0ZLLarnK3yPk/r4HpnBoqGajtCDEiCShP5K62lJEIZkMh4lwEkcUKyY6zWJLacIhqwn/7IDv3yF2fjbVJjWJB+NDkn7qQ1f7Z35O2v3Ay4xkBEva6f0hdXxyhZILAUOlW4dwIm/elGGHk5w0fjqVUXYQoNL0jnuYxy1Ffm9fl7g6gRkjRXYa2aZrRe9hhmGMTc+p64lWp/vFklTluu/rBpd5XMnQyye56Ptp2ENY0sIiNozJKhr9PoabZ+RipAy7yI1F2DxXMBvj9HhNLGfYDxDeAikcbC7v8SfebqhX49osrI/uw0mszoTqLLxlgd/iPWw+a4nKTL+yetnaZY4O12X+O1pfndXnC0FUTyU9vRi9EvdZhtXLTVwyK1rJQM6I1G4s1T7dN78Pxjq8TCW5gwtTZX2FpDhaN5p+ME4xfV2Oqw6FNUNMp+ebrKRFEm+aEukfUEqOlw+P+l8RyhWhkP5qmeBjK43U6GxRWZqN1SPsbhJPvFQBJV6LmjQtA344ePW5irjpYKSrmVQgOAlQAMYEz+MEonxs/7ErunmzIzdMKGjk6NiTmMrRQzxoWcO3omMOKYOiuDGuHj3HE2k6ercV664eHBqcikyOdEvqiJoaBRaJy/rZ0mwQ+StIZMpYCySmbFnxJFRPtFVJlcftn1YmnrCmJbMhkWanSOBJ63AP89axIjEvcVLEZpcwjMgm8otBhWSCyPLKYclaFza5epcATNJ8ESAjtuqpoJPSuadvZrQxsdYiwJ0mzKWnaW9clRZFW83JSID/6/Ur3ux09HTiPSLn6NwfXYIL5WzsXGAyNLPJ9oC+DB0vn8R0f7gTK4l3jabs05BYPaf/1UhsSmvlRsZNIKNTe4WO8aRd/wiJix/044JeNti/8/FzCz8HyYOTvaisFyId6fCFzGeY1Uarhmr+Bu6uOC3btiaBn6HT9rNxh2OEz5zZTvYkGVpmBPOllwvD+rNueA/IcPzMGzWQMdF8PovcPN7Qp5P3/p6a7z6ePoNTFtC9vfy4Z1HNF3NsSzdeYOqqlzgcA93diQcz/JOUEC9J3PKxDxHNxSD/BrlQGr7vml2VWRVxo86GaRTYu1WZ5ChuCqu7ISepuhtyiBATzZbEPrR+zgkngsxInvwEylJRiTeFOEjoH3NJQZ2X/LBHkG1jsHe2ijKsQq2CEdgaGSYdt/c3T4ND98NsGlIzwlIWeTkLS0I8KCZ+sHBZuCjFipXMhkqs8+VIhWqiOMK8RBjknC8s87lPJPOF/FhoaDIXajBtnXIL5VCfKUJIQgLrwg2PJwmd8ZTi0r19S/DyBcJSBnfFyFsi33ZN20lk7RHm63xDkfvmV/gusgVwo7dEzx6cmqEKV2oKQSJp5EIgWnbg4vWRiaXrS9GRakeaaATn45KoVB6vxC4IONPoJkrJbnQoQxCNjtMOyf24I2g436eNeH4OQc2vWQZdpsxGEgcXDR8idaOEjvezwWCii7pV5VWKSIk1++rCCRxHWh2nUU0YagYtI2KEYt1X2V3QStCERCBiQyLjkeaqupSUP6C/RBLlcjbWAR9j+RP8xAu0JiqKKlPMyI5H0xhwZ36A3GH/NuFxiPm/LjEH6yyJ8NeXuHoneIUX6qHliFTArUQWC8T5iMpEuiAn8IBciN1ujURM4EsI2jY6qyGhl9M7d5eRL44OD4o1LWEdQuP9bi3JhIMTt/ABLy1xxkiCX5S8yfya7nKNMU3oJ1B3yDKAnuQHQlalkg43SQcRpiO5oD3YdW7s/XRyydIAjp9WSN7jSOhXwtGdqF+aYNSkHkn5VswND+Zkj8YBP6IEBnKlJxDVfGqealHPS91BPiwLid0LLSzLunSFdY/Y4xTOOQ6f2ByMnkPfNUrW35Lw4+bIXY5WQXPjUqKwo0elChZu8411dk6Xb60J+pEgG7myK8fwfTSNhtF0DCduYC9hsnDOEe3vZuCq0aze9g3sExq7pBMd3yDvia7rCJ0ccDllnrWjAl+YQFJjnUDos4MhjCdMIygBheCitdyN0LWoCVs5UcjpeDtwEh7FWhCne3IbkmQFwz9BmTb5l/THH1iBCVPb4SR3hOvZUbXgqjM6MwuIz8/MLnk0NuyFMM5VsDkWUbbE/auHz8wXxMEUtIrUh1ckE4XdayTfDSwkc7JwSb+Ghp9FdioZDnG8nTi05mdyq11u2xL32IFG8r2sL+RmMFE6S2RoIDXOn5rhaOyuW9r9BSZmn1Elby/jVstkZn/MLja7Hu+pW1l/gHay5YSrHBqag75AjF0sP+3aqQNdgbEXt9VhpsDsQCdaEnDXTf+/YtycZTsvRnKK8kr3tWRWxsqKybHiikKXDYXqS9M/RjnjJThQCTcjqEnH5X2WNDz5+JyMzT4+v2KTUA3NuIj4/5cI236LNpumbosjxxq1ZjYqX8ZqZHus7lPsscaqrMtVhuAdGx6WMgxQuaynhGogzS/RTF/6jghMCaqWtNPcTGyL5A+pZNJyBlJzkDsZVJKrMoIVO63opp9FJu1Gma+5Bh0dK3d16eImaUbER1ArDcH8OBvOOBtIgjiHE5wo7uoCbgD4t/3jY2glXUKvroabzeyns9rqOLrnt0OhBQx1YXz90J/wxM1wEVkRGioiy4p4K1zE32cY/6pmkxb/Htee3gFSx04d8miuzq8Unc3l1Ilwnb4SjqqeCFctRRZE5BiAIjEBWrHwK5QwbUqyopxsVrXDmk3bjdzMHt9f3+W4PQz0o5gdzc1T0yryxe+75A/fXRIrhFj7zU7cxDts1+5fF+9viKM9rNvDIDMz439i89CIqIuxtg00KUI5zG87yL/iE7NWXGbww4oFbix656V0M33laVwglngFKACI4nGTVLyzuyYl9zXiS8PL58keyrdP31Lh/eQzgPUSPVRDY7sCz9Tii3WjK9qPXKlL59OREEG+2zthRCN3YEfHES/ALsYuwPaHnvxehawodEYXfJ/dwRSXbj+yhYufWIMEbqiSt5xhQ1hkQNcJXjWLX94g9RsFOCDRRrhkdFqI3BeNon+hgZzN6BnXAQi0/U0tEzQqqW0xjO2S7mFdekKU0dRGoEGk+2LjLA0qJE8UxaVJ4aLDd07zKDJcH3bLoakRt3aRe8LGjRxhxYsK5L0A3C7HMumcYCi+gN1lmL3EaIfr8qVHmXJAskowLfzJndQmqrNmNYD13bBkzUkVU8m4GqSWzA55Loe7ZU4UDH/u451L/jsafwYf6JZwON4WHXvc9HvcXLrHhlndpFfT+4ppfCvMGO4xe8glegVDHcwRv+lRmtfdnTQ7/G74+RgZ6O5+GnrrU0xO/GXymUtogDwBKokjzhYVYXcdi0wDexFBSo1Ih/rK5lt8sqWN8rhW3f3TluXqyyF1DACMyanEq0ru9lups4C6jWOxBLaggits95u0dkgrjEw7QZKVlv5KNM6PIT4oMRYiZlMAiCvmspNXuNVO3eXt4isQGupaE9FzwLH1eGYmQ45TEg8Mx9fmLB2W18tdhQT487s9tTB357stMl3pCtL0C0LT3F74YuC02CyNqgakIszIRaWzmiuOQFlNtJiuJ+nEupa+KCGi1JfuO11ySLLBgWn08cNOD+ObfyevsC+nawDppDMX8Ow0tZRTZtf2yBKXMFeAyBEyTYDs3HwkLFmxIRD3V9D+7vAy2vqMf/Wu7+nKZMYBGuIDG268I6hiyNcKP1vAsNAFz/wodNqJLzvYAF3+7l9yz0yl4u4XqbmZEK/vcsqZn2RW8wuPctmguZWQRs8kyWNmxgRGkB6ODlKSCNyljaaqvlIbGjSPmSlRa0bL+zFJCcQgqAgfDj1mh7ESJAAg/mtu1Hlgup9GVrmsbt1iVYVbnZhCNXQ+KrJVsF/yJiXrbelAOfLfmjSRnPIumytaZAOx4VwoUVTPHm1KWPUtqXk1PJONbuyresjXS6CR19xYkamWMGH3fIzM5aTogLrFj5mRQyXcOkhaZZhuCn1PlfPoCyaPvmBgrdArWToPEL8hHBLpkSvITXRgGUwMNTFfNBfUgtfU8FtlHMJ7bI0VctYbxorIaWPGJSbtFCL7wi78c5HSaI31KAauDzkCTkiw2XzBssn3VFmyGQpdExcMGYxIzWAaWh8rUdncBEknkISaqoXXraiyo2QGEIau1Ti6YgaBVlXfzEC+pS6yr/UW1Rrf2G6yi1hyKrrfW9mg6JEr7JEuRS5cf67cZM0lchmJLPtXEknNqyQrwJq5ZCViM6dW2e5KM+SbqbrkToubU026/yYb7oMZ34KpqsnWJf7sdGR1aOyyHZ00RLaoLAmswMpqIj4MYC2nNiNzX0Kkv4RKYju3NZ0whUzpgb/XZUfOmgLFcoiTXJqY8twac0Vsq1rypTxLOYllV4FAzsg9PUkDm0BcJaAtQ185XP7iBehVU7OncfCL7LzbcNJp3Cic8VJCKpIdFMoQmUlwwUdHIemYmV2KDil6mFUdNU+H7CLdStQaSyNHFGfcMK3msH8NIvI5XfJtbF3cFyxwCNpz4e1xfxY3rEncXdu2I+oFiEesf2WTcNQorcpaQ3eq+jDyU1ooLWsTo6wht1dRN35NeYyqkTFqxNA/mzho3D0C97GIN25q+NJi2cdbRqO2weDDa6iu2lDrKgi9/hVmWTNum8C6Bolizj1XAKpcbiWmAltYemlbzKErWUXloYjgQOyUsU+v9Siv21pT0Q2gTLYyPh3stOm+PxgZbi0ffSTLI8A1CTgJuKYC05Us4zhx00An6gJBsq1F4zy6VXac3bbmX7Q2TlWHdyIl/EzbnjfF9rwZLKA2fLAVJO6cDNiaioB3yN6QdT3sri9EvV9NBA23OgtdgK6aEW4mmbvjlz5GLojMyfSIQrLo4RWtbEJHCGjCQ2MnjH2sDVbc+V89Mk+ZVmvYSuQ1LF6a7zaTr8ZWqkGZPOcKMJOciGuIMI10aTWtVxJZgaCSXNh+IcPMMBHTLMkYNHI01gqb3VWSp5zl+7bEMumQOZ5xCTypR20XSim1g6guNXi52kKOQGj+KnwCs9KBwy/h+KrxO3aAQ6xkXiX9SghZX43hqsANPUrufW9rJEVE+QjJtYy73PhJvATKWMMSGlqOC5gjdDVJzhOHhdO+2GwGsSI33ExEyaaPkkV499HQTjYZsMOXNsSh2VTjsMzNEuiywDkXhD4pxa2MmKnp/mmS7BbtVEdzamxdTsjvuwUMWzEhAOkYE7AReoU21aNZ4/5BSrFVEGCv2upySyngReaZZ2jjNcyWBNjzl/KzZMQlGNrlmScgALlMl3wSJUHVHXdg+TzqrXwklrgnZnYbzAXGiJFQNRzcQ56oARSGwFk3SUB4rqz5MlRiAiZHhWPQlGWJjBjNs4VEjnCWmAwOLHgweikjJxhLsYeplZf0Qp54nxsewyEvqVFDr2AQ2OkkPKKRTjAgEybJu4KtHuDFxER9/1Igur9W3OlgJY2s30dCfEI2i/dOawDYTNISW1gkO9mShoYW13KSqk726SpTNrIQqcu371iCdZaoUl2NaYV91syadcsWU7NJR/vptBM1Lm5JsCRAA/pBu+W5BHxIKttndWIqJ0ooXRySyKqhz/MCZE+oLZHTVM3QCKZ4sgLmxgp1SUi0mywQ2YAU11NvUxxZsdkdmumiikcnFhU1WBInngkJLsHJT7QEJ9RqzszUo0qrZFWWvxEVuPzN0pZILlV5RMhV9W9AU5uVbNXfbiiv6DofYWAuXJ7GPbTiBgK6qmNncYi1SqwkvLCVEtOwyIyp7+HlJVyPy8xUUQMU+GvtaqooelX9eVrGm5PLCbqeGHkO2KIuJ4Qr3Ks9A26DqyZbkesJapHrCSaSrid4mnsJCG2mImMUdqO/BNnFZalB+AWcaJdAsETykE3wJBY+hEPOBFfmlD+hK88V4nMslOAvOmwZuSOhFYFtLQm2E2oC1ZcAgkRmChnOJRjdRnDaIqicT0wfOSJt4dE+riQ1TU7j4w+iwr6U2b2vh9EemN37fO7XKU/RfNi3zHzYh7BvNBJnQ8S9syA+uf3ZOrrXTvW9vEKK6WqTSC7hMYlnNrlpXwLpnEzp+GQP5IVeTwJR1xzZvaiwE8zuN5ydVH6pqzCb1P9JNcMSiCxJ66sb5mfD54GE/6jwCXjciPXN6rXaDn0S+sV1WI7P1ybwKH5Ph1PPEY2RX9DQwR0ijESD0+8Jp1yrFG7S5V8Xrvlen1UnrhtI9K7SJTteD+pnJ9fjrfCbQC3I5mit9OuX740AdNAUpzUu7owI10h7/3EHs7iQLrl+hg+Ixc9fsLXLPxc1hkl80/UVgCRcGjoKlpFIFEvewqJK9KgOSDB+/Jix87xTFeoZ2XlBMbf0tjYw3V2WzGHXQ1aLy/J9gQVJaGWIWOjFLHXCvuASRXiV7GrxVnB/bUptUvSiC8aN5p6cvaSKd9VHuai2HOjiYEtyPIIA5ldHpO0agnBgTfhMDCkrxMURwfj6HUocZ/WJOPWkK9SfCk44PoL61QUG20TEShI3y3T0XCnuJHj6aHI7jRzLXN7PT9OXmj38TZ1oaJMOfNNzVnX8+dKaKvFX5o8iflIxyZ+ImMTk1Nef0XZL9z8mNFjfSuFGy1eNyh67A9+FWJ7kKTiIwLLx1Je2N+7JbDlaIQxb/GYzulWKMvOhnQ06bbPerG0CVhDA0oLypEG1w8qIZHUCWq+IW0+YWoyF7wT2QXezjVyqHqKaqIYga5gk/QNgt9oYjp5/XRltdZLOvko8cPjga9JpZUeNOVtY6vRrAnkbj5E3Oh1L+30+PnGC9yRLRphSOmohKI7WvlKKM8xYybgU+Civ743ne0UH/t7vtODh4ul8likoj7neKq3AX3TEmxlzN5Q1EhyaRUy1lLh+T5wuzc3Gua7YqU/Od8k1hHMl+I1LOSTvb5EHpHklm3KQTGvqisONe5C5FRwWg18mhYkqy3xKlxtf1jZNw0JjVDkwk8ycUPJP9KaKHDJvIHkf7O6mh3ABKpTF7GqeDG8nJAVOUIuxyEb4kh416lZqK2SC5s0uMRKhriReZeWfd4/55gsbDXRFxfMdCR5s42ZccbF+R9qGjA4sHFeKKlX5cLY4XQojzCCWzSVcWaov5TSYASB59zAAZtxOX9oA12MMYuCSLlWdgpIq3m6kMQ2Nb2669PlaPxlH9Z0gtNGmLCyQRg3FBi242AVdqDCwILxWsVdCKHRwu/wp3lAO5vkegS787eg0zWooUgLhhlWT7mqZIp9lmajfCIZDO+MGrDSE/iDgL7Rjem9dt0PehRIbKKsoQm2VBCnWnLTrVTT/2KI07JwFeCKvpZxBgQnrcx2x3Q3JqE3HS16LRTpOST7HEIgbBZnAAGETTibQPePGpGG6PC0rsoD+yYCHgyUCvtaMrQG5OZNbWhbSJf4m6C9xL0l2oClXSg5HncjJmsqQzU38vumYRjyisF5eGx5pdxrXlbSvFZKmQ9dCopy35JbJcjbLMaJgqkuZSapN9MBRxb3jBu6RtrgmsxbRZE6ENZmBF8N0xWWSBeYO5tCwWqmm+vbQ0v11BFeEFoCyN9Cggfm4WMJ/hyxE425w2EaXRo68TqR4+Mj933LewXvSXMqKGMdHTWh8jnk+nypHj+nsi4bIpiTxOZGgCCaVZzNJnlxOL9x6Ur2wj0m1CCZNRPtMrSJOH3d7mijVNH3fi12NuKSbcNFFwk65uaTxQitBp1tbWqc7EdXpilY+V6xks0ayOW8uZHjejJJOMqtMshdXp9R9uVzJKDd3FUa5njYqGYboY5SQiOPhlJJbJSWoV3F3V9DWSXln0lATFKhp7h98TsiIkNElnLyEya3Agb/qJiNaKrDzPBZ6lx0WVYKklHhO8a8jDADJzYQWsyTZQ15JU89BJYsAeoIBnGACmAjgyiKAznl/bJbqJjP+ehLjH79S+SlYUZf0DP+1zCgd1gdOFJ49rL5V0WsRkxlRKcMK+dBABQ44tMlymRplWY4yVJNs8Ug+CaEygY3czBM1AOIqu3F2rdkKOM2o86IoKxKMmdhGSjJ1SbDD8U1/YESRRpPLhNBFR5yFq7jSttTTb2fi/VBBOZab1HeAf7J05W/vJFynzKdPj9grUpe5nEQylCTkE2VXsulShEQkNmg1jkYhQtEyozthDcE9qwZn+fcDR16SLN+qlrVbr7Fb3mBZiKVaTioIOPo37DfMCnL1b+CWKi83qGk2xOkbgLVGo5yyP6gmKBAi4E8amfCQCP8vpMIs75/1hV9/lIYjPmJQE5Zys0y47aEzX6PD0ftkIk2VthD1WXZszGD7jZDbGR3ucggYw7kIc2pNxPdHm7jV/SpexTdl4AmHxLEO823ymfpI4xPuUfAX/iQbDn0HFsCazo8cr7Tb6W7kk4c5LPfxqzuQJiUKX74VR4KpWHAhvGwuJq6VjtnaJ91s/Ne4wHipg7BDcffndKt319MctA/mxbbxN5cxl/Tvbiej4P2zHDkDn1L+LZ180U51Pu/knJU5n0/zOL5Sz/RRY0qxTjGjTrFkhs8zZzXVJtZN6hnDXy1V1wZ8aiXqeyvuM1sW7wW/kijJM3uzdL5tSbzgDgWFtOrLVJWsmWQzH2z9/d/0KBk6+xD2h5orJTc0IrXqKQ3WUfkcMjOl3aLoQThpEiS1KOJ1Nre0rwBoMDNqQHWHGRxKxM8sYBn6/cvKfFDoYAbdXY/+joxy7NbG0KHUJM43+VJwEzXXbM946V17w79YwKeZkLmSpUlulFeKbdRYNbUxuRId8o3Hv4aLPcDb9a0sddVKHJAkXeaL5Aqd3T0ducoWj+JLhFtNvTxdTb0JXCzwILWErgGvFEpFmoksY/iubvTM6FNOnoDtEUQKSb22ben7wkup+VZ2CTi7rmyZi8DDPVvuOvB46pVdCh4nhoQNKca3gBb7s8bMjJOLn4VrWGaq6Y3YlcHTnhXR1rJeeVIfs6VUQoQqHoZvzDcCT7oyeZqJLMDJJzuXlopVXZ/GFNKRFnUVuRKeC5yZWcoJxwDabkjeNCIOwwNGCKJ80TlggwiDQmFR5oaocRLHo8fOJYoT2mkQWxnHhtovCT3imBC//wmy5lR+4C2pMyGbSHGmP2w+aUdHCTAr+Qp2gWGIzZyaN6eZHEkNiVo747F6E9fsyBF3Ws1ioeH17ClbgBKvlDMSrbrywlZI2GwvLTcEMaqdDbGgMmlO3LVN258I22351u7BbUqB3TbOHejNCk+J+7boLNewXFLRZwaDApcXApa4iO1J7dGZsANYJww7Imsgv/hdXc6nTuCcU/b0U/ZZwjTmAd2OItNQDp3AYoQo7jw6wad1cA7NV3ZrEet2M8m6XeZ95P5nnWV0mVnZE6m7XPcc0b0uPaqkX5lFvVB8ILrDZNKzg/0zb2XRestvRQ64vkqxd12pEJOhuTZLdfjKmuqRX2xgFZfqzxNtm4TMhTZYtemsw80ofaTwQWFHQKElgcJMspVKOMMk4VFEv552xPkvxR9pdIqDMDqosBdDEcItd8Wzoct4WnQJjXTsqh092C2KD5DLXcg6f6XxYdc4JB40kwZJbkLqCOlJVtT6lkAGwrPN7JQcmujm3J5xLC6ZQjt0SYVEpQqqvFtIWOySmZrvxWqpE1tro4aJVAS/2YiNRm5YQ0kK1n9TbrB/b1rWV2/Cwmctq+/f3Gjok1pDWYUMMStqleLf2Sar4en6cGD+zbxDTWOcs448dQMamAm5r2ho49DhYekdtTGm0FixigJvcxFwYQ8hbZceEglTISKuCRXe/GGpiXrw9h2mGzV1AMcsMqbM4ycgLFOrYku7tOjYcoqWfGtelpVJPzlV7nhdOAY0XDazhV4w0qG0e/dQ8B3WnzWEv3Kd/JVHrr4GTDbwfj06KuG7vOUvBapQAnLqnUFMSdRTtXU0hqRrRlTfWztlfXpP7UXgRsmE2IgaNz7lFSoIAy2nLau701dwPwrzosFGf9hIvHylYpYTLKCFZquSle9QYQobJA9OYlnd3U6CVshJ1wrlSma68smRbmIJ+/yJSBmJGz+MEhjstDHa7TAPhDFnaiDt+C4lU+800MOmYpQh7TSb4vMdGX+Ji11SuNKanurcXLVl4+Y9HlrhUxOaQLbG5KtgM6y42Bax7fZE7RGZViERZbuX5NxC4T7RjV/StjKn96zWEdreJGIEkm5QbxfzzejLhk7ohFG45sxqh90wEtox9SulG5LDG6hcy+8whb0TPtqmh+4WFPv5q6iWVZmlrpTp7s4Xk9wPIAMOATV93zagYW+8kWEOdgMSXkm7j6UUj8gFjc7KKITgS4RW+pD5feOo5Fs2pmFPovFsXY8CCZXRos0ZWcAk8r3khUOUIu1+rK6u5CvKwlYLArRRfYMu6xr0J9Qz6IIq4T1Goe5gI57w/rPQ9lWFUR/pgE0pth1VycqJQidOMuzsXFfgVSFwh+wH8n6GXS1E7adWF7u7+wdDF7nKlqNxeyvpbFPEpzJ1kHUvQU2hynY/0hHxp4Wify49DZRxRUjKlmbgliduCLOUf5fsck5iKkkXJIY8ACmr/ibjX5fEDVHIFxBdL0TmITAtdbPasBwyVWdHJkuJte5aqi354mgPWpzw/eRcaDxINI0bpAtpRkwOX7qRFuzhld9GGFHMsIsc0mxyo66LsGwhNdBUoMroDGYFnT/qyN+7aCAg33pInF1Jjo9tnyx7R6KbSyQ/BLMUIZqcicbAKYTBEK15enDqK/TFlXrHIzUz1AMm2oT9X9ddhsGJ29TbpH1vPC0FPHtGyWZWAxNvmIDSJXyFEW1NmaszuQw3w0CjrZFp09X2kUUmnnpx6yD1KmQ8UXZVB43Y2DVrWHVN+HBF0wpnVhVNktaksgjDSGB3AKyGG7E8j+oz0eEXvQmNJbZrR1ZwTFugB8JfrJNnhBCCGBVkoGqGQKVWEwadDjyKe3wgj79bz28u8799MzA/JMqiofJzuOlKypN4dQ4Gs3nPGGXoEt0hCOiJWYVwFrOBlDMiSafkLspHQtvgrHde0+zNZrxmDr5eEEmpu8I9lWGy6+a7u4siioqVbk9L0VgypQTdFBfSOHFGljOxw+hGnMPR57Tc3HP5Inrg9AEaj4ISw4FqUA6nj2qsBzbrQXe3uAyYLTLkPZssYi2gR7vcUd+zQj9rfkLDo5X5WfqCHmspPWYUMD4wFS0ZFCUtDURaAhw0CWyhxgU3jEXRxb9qwHyuXBjO58Mee4KEeOUY+VhKbA7Q9mxfb7clgOwn21UYJX/MAqnScTJroSoobdxz+53QMQOLep862tYKR1vtHRgSiZmMPZsqOoXO2CHb7OKiX8eLDBsoR6NZqG76q3+GTUKmZ7CYj8roybp80XcnEQC6MBqHsbgIMS1DCBVE4mxKr/mtiC5voISiaddZSZWl4c+oXBiMaqy8yGVKSSgYu0tJrpfQD4dL58MljlrNyjX7QvJ/ZdWI7cVBvyFSS2hdSbjyNGCeMhlpk7ys+3aepMqOrW1iEHFBxcVgExRoIEfjJ2Va0BE6TfeC0fDN7Rw/pJyeWC7I1sxJ3a+Qvsq7dLUwCmjSSrlUo+bGjf1ZN/E+TeyVoSYv2qT7R1t3TBTdggqawl53FUfLuD8w23IDtioBVxFC3B5BTTVKwN7IJvgRziipKHS0gLkCBiw5U82V79NSdTXRijB0Ciha8PolzlHEijfIFRuKfHzXOUFMD3Uk+SZgX7FKXn9y+i5jFO9TH/UPMzK0nnDLmfUjGzdvVuh37CV939gmY9JwlfXwqqxvNOvauI5qHHpV1pvTCmPCQRTaYNSMMTy0b1sN/sEeWw1kIkWKrcpGzdHHNk+aFhFdZeNmCqkpG+uEFGOv13VzDIMmrEYNw1/f+EI8cgrdGFHk1nDkFmuvbldZia9vCce98sLLG8NFvxwte6fhNnSRfWc47lWo0i/6VWWT5tQVvlMYdGgMJfOx7ZZhusqmzRAP/HuVzIzhVdlkaFXbQBDCm/L8lPWmwX4h21TTMvGOW/YNSx1bh8KfYxvQLwAL245aFNNlqrTn97kw0zD9Pld50daadX1KZ6lftMWTh7K0GI6Jg2HGUd68aWSMeRwd28bdvGLYBorYacdjdsIPDbxhtnR434jfxIVjrAIrqjWJFUOf8V35WwCNjyjsQ+FOnse22dADaFRVJ0KhbNn2vOIPKHtTtmpuXXnFMv3DHzLEX4EBsxWu7B9jQgx+4qsf/HrdcPUxupyT4l4fUdBmnuA4tlWzdys/pd8dWo1cfe/QJ8mV1thmEwOw3zs2KyPI55tVfWwnsyRvKCP4poxYE+7YJovMPUc2KSJ2bDvO3BYbLEr4qokjWhvzIaS8SgDy0Yy9Ka+hy2Nq2wjwOuSi6bURRe6EQ78/k8fhZzgQP/NHAt5GMuoU0B7gaQSu1Ma2G1AcH52Mus8tT1E0wzHESOV5QDzlecQ0zIXpM+qkW94/VJpw1WKhNAW/RfrtLe2D3z767YffWXUPpYP1ENLhb5F+e+m3j377Sxmoy6iOyTPhZX26qjXHxMk7ZceLm8cikyAh7gVYqZPCdyYH//z1v00Izsyq00AEiSCNbWGWels2KhsbFtAseQC3A+GyTJNGIxxRVQRub6wqVXiDF+JcqtOAhFPjEDFSJdoRzof0oWpMAaK80qJ7nl+pKTWalc8L9RLDza268kIMobZPKC9Y9pTmKhsnlM1MyR5OYCiiP/zFr6ehoCgN0MCdNcSunzeCSedDoaGw2qF7U+PkUI43B6aj37EpxR8ikU8KEql24/RFnA0KMRXRGgVoixluuqNsI4f5G9nTL9ri3yKr+A5lFoGickvBvUfCebnLTYUr/sZedXBslVAhShO/FCm9QjNPLsGhoKBLVWUExt1CrZayESJ5/Yq/wvj9cIEUaGId3WgGBMBP0cqo47g41xralAK/8FO34MeEqhuGZo69BPC1JhvTzbqjvNRo7VXWw2KECzU84GdKNyEVvsDPHh04A3w6rrJBQ50J9Bhf4GeqNUW/8OM42thrWp3e4MfVduMv/ABHTYnhqWyoa8Zup7UbPuu7IZnVtKasCYtelA22Vp8y6IE/RgOWe3wqG1qTvFZ4gZ+6UcNf6LxmAs2F/qwft2x0gABUFcIc+LGxA/iAnxYAh1I1xjXWscn6OK7Vu6c0iN49he/+D0Bmt67TCyLvFAzoz6enp+G9iQsxPpSfahq8tUzdAF5pSvmZ09qnbJxu2oYFM6oJBHTjtA3tx+TTMKM34faFDgu8A1Gb9D3Q7ElsGr4qm1rNhjUNrcIX5fnJaagmMkQYqDwPrXcgGT6V54Fls5pQPr4oL+qWPYkdwxflRSBtMMzYWHxVXrRcXE3xgWu66QIvhk/40fXd+As/rTcRMQ18gRJa9lRrNxbcslvKS5AU/gz8mWw16IE/LdOy8Ik/rk2JXBuYAhCb99JDecmAqQOdpRdl8xTgKRIawLIpjbANhnuzCYA2cPX7uWHWEbIYxo4wsmV0u1ZvaHsMZXu9EY+yoW9Q9XYb2v63GkAW8QRflJc1A2HzMv1oJmAKhJn4g8iJrXqZ/Uxr9bEtmAaKfxn4AcupUx5kDV6uT+n0iz/Wm7sNesBPq6btBdxTRkDKVrZoFv7hDyyn+As/ehNYDnoAwZwab9Ev0U7NHluPL5r42oAvGOe0+M90FXuFD/ipsXeobatW197EoYCXN+GnAY3HOb61MQ0/GvQOwIpP/DGgfh1ybmUZ7CowpfSEHwetIsZexAt4ADFMyKzrrg5LpjYN2LAVXiEE1vyxl43d2u4W+4If20K8GoMlykFDGwioBqEyymKgstUAwGxv2DUi6vBjThL9oTdlK6awAWpbgSOmNsJT2QpTYQogv3UaYP6KNg6DhZ14BV6UV/S9sEAbY1uAY9mpNVoYoPGf3Rb+wU/LqUME/mybxBm9bRJ/GmMb6wYM37ZGdTf81MZeapmTjErgGwVtdjWcsvig71fQUHeMSCO2QLPHKXg7smhVBR/iG8mL8rMmcGMYAPK0lG9E5NvZsndDvm327jr8GNMa/OKPo03q8Es/U5pJQUCYAO21vfWxl6YQVi9Nwc92rTE1DayBTm/w0xrbCPzwS1oL36FFdW3SgTlBL/BjARknPNpeN4GtdeiWJnk6NYFXfRNn84438acFyfHXhjbDEBgutX4KP1s2cCAwyelVGUFeGmbSSB2GFj72UD+huTAdajUEOj7hZ9J8HcUXKHxk0sRYsw74Sk9YWm0NQAVEAaMtLNuaBmbBoieshoDNNJvxDdbDhuUaY6/AUmzQB/zA6FXxUQVkgDXGmlR2TjYm8QPoPOAEviiEL4QuOr3vxOZtwZmPX68ZQJZ3anvwZzeUjL/wM2U08Bd/gOS59AAuvNGabNFDgVKoCHjgj8F/DJB3ARTwhDzAxQCdrys7JzCzYddbrkZP5VXEPKTP+AIMu4F/hvK6htoNGFOXvSt/Z8B/iPg51DWu/RIoxchbLc3WMWA8o4655XFkwDchT06/QLDNNwHCwcwmSg0tGdth1WEcALngBeYeUEAHZxk8Ya6igzejBtIavk9wJJ4kugNPHBH/o5ZRd7vlMWL8geogwcEnTA80p2XrGr4rr0wb2m4YW+CvtGq9pQeY3ITegTxmKa/DT0Ydccu7sbiNdUACZ4oW7rrtoMi7G36A/xhbvxsXopfriJJjI8D1NsZGaBlQXjZcR/k7/ZcG/dSMjLrRLY9QcbAeW2NbDdPCApvAymC3Xp2erAMGb2tN2jSqDgyJiT+WaymvwYqxu/WWQS8ZdS8JJOMkuIyR4LKbBJcRElw2kuCyEat6yd7t+ssKSKVj/sL3srYXwQFMHqIzgWYSRbndprUX+Ipf/vKXIEM879JBUKFE2+wG2prn8d748n52g1LptewkfkONmdXTbk5lwdsm2AWrDsTvwficalomE8pL+5khFJA/YCwnLSoEszLwwcdeyjE7i94lRK4eFssEf3boOh6rykGT1VCKaKWhtE51udKc6r7yks2ZFSqq9W65oG53y7uGYJBghGB4YGxgYEaH17vPbhc3J8MHGf0BaLe7u9ZjhzH3K+ENv9cSNvxoG9YOdvwaRu0F2gPMTBpTmdVZN8VOvpJpTWdAaM2lJhmqZJylUxT7KpnaMkkGKpk9lETlyn2jatXEIRA8TowYlJK3vwIInBjJtyy5Xz+homabn2GFNbccZn6vX/WtTdn3a5HvV4IDjIEBN6o/N+MWAZ6ZkcIYUrNgUSeGr3fQtgAaudn5aUuj7RfaMhZFm62pjVrTbWFu5jJHlDql7dugVXfv0Cd0FLD92iZtq9XE7ctgs3ZcTieipDm6U7o9WukbZLeKuM+V+9Ft/v9X3bM2t20k+f1+Bcm70xIhZBEACZGgKFVsJ45rnTiR7ezWOT4dTY5tODQpg/BrTf73ne55P/CQkr26c5VLJDiY6enp6enXdJ/NR8l+P+JP00T+Oo3w1+kIv0Vxgl+jeHyQHT/SO6aN0jF7Zcg6OOVvxIdfS0W5GFxWVjhfMZwtV6FrH3sBVoo1n37o8eu5fFn3pUECZGASQS4jRNkGqaTOvkkeQ4s8hhZ5DIPMfKNoMUxaT3NtupgGh9DEqBUkYbCD+rvcD1mGkU5BqLYEXFzGZGSdk95AQ+ugd5JRVl7agy9sJ0RD2gzsLKSrItgdxEacz4VL7DiaMad7bsSC4VX4rkwwzjG+3xdn8/E4no7pp/P5+DQZAbkOItWfLLBk9jeIVFFR+mKaxHQzLM6wi+SiX5ydRcNgsDgep2mUTCaTrLCmDZEwD4Eg/9TZd1glBqjjZ8+fB5q7KFhIFCwsFOz3/cKdd3CG0wWMsdnSh1k5iK0Jcp+kL9rCSp4irwgtSpWGxKGT9Xb7++INWaxu06PEtj6AO8ZiRZXqZW2mF9n1tYh+8vZtdUwWFa42d7mNsOc+CcTI7F4DwgeRoZR7uGOAhX/XTFDqMoEKTWI3COquDsirUZD8jWX7RY/8Zr/fUP66kHcaZrmNmDy0ss4C8qCc0iH8qWSCBhWeLsnr7z5fM4nDf9Gi1IQSDIdHBh3yguBdKAg+nC3UPYzFYCCqwzIyhhzywQzBJvI82FiVQpp5WwfGxbRHso9wQbcGBoP4ugJzF7hHSE1n9FgCbMIlA7x2Qw8v/r2A74ea/Nb03KRHVHHLaXgWgbuD3DOBpdi/4rnxIfykW4rDpy51BGR/0GQPkYKQpWVXJ2LoH4SBaD627q5yIcuRsLziVaNsVSFYeaUqd1r41JWqtF+1Wa7y3Vv9yiDMBOOgGa+XKSUpniD2cxRhSTm2xr1nm3cLijqy6vwlgFB/3mia4G19+EgFrkB/4xHkdnjP5wuVdtmF5R0my3Xmd+7DhNaboC2WLqynWAu/FOXBgntPiolucDeK7UwDo2KD7QLPsBDLs+osETzYWnwcCD/SKUZDscNY9KUQlb3xjh4VETkCRwFPnlXRTPuJvvCLxC0rFauB/RMYpzevO1T7Lsg1bdvD+2s4SNJukfRpaXA405ohHZ05VGQBC85WvKg10zvmP3gzYJrvyz1Em0DMf82+csbWEYWT5xKJZ50VKnp48mXdrmQbzy5smLAGp0h8Ih8Lxy7/WYaIVQDEDlgDJ3Ji3jtaFN0syUsjb8EdOpI7NElFEFV3yHrABjEvL4Pf0lQ2n0605ozvkYNsOGIEh+8kgYh1ZjGptdy5j7fL4DW8WM4+RgrIxMy1W8W8OIuC1ySL0tLJ4cZGqq/FEooGKlUnTDHsRtZyqOVqLVp1u5VL/jNW6MUOJK+lGPSQgf2Of3SOilhicKR4cpqIOwKqV8ygtzKYB7FHttv4068pShScRbDYIerCkhRUx9y9jpEuO9yNkHrPOEvF2o4CZyN73i6stxWfo6eR1NToMUdlluJsxy4SS5LZoNN6B9e7oOLWFiJfIDzr68HmBDONaxhdPNxA3g0MfzVeYdSUH+T9W2uLm5XTqtgeF4/uyRyr/VKtc+ou7iUk59iRJ1vKzD7sYBCWiLdfum1lp7ygitvi2WYpDuQHsJ+8vdgtrIlWQVTP2gzG5HJdOSmXQVXg255K8/CjocEXE8nuxhMXrir2pMNXw6YODdDfq4bdhbea+RoHGA795JpuKX4QZcymJjVCnxwk2Wr7uXd8kh0Vx8JGpFQgQz9fvVvo//LucFpwzLpc2W0qJm4zBXfTVXTaguF4Todm0dJZIhbzJwH0bjZJZsJg1H0KVggWsqzrVnAiCHuE75h0eGSlTg/2hxzuX8CBgHKIBAKylD6FQk1UAlejzXTRAO7GVpCiDUK7CTOrBtnv0dRN/xJm6iaaqZtwUzf9O+WtpyP2l+oLeBOGJXipQpC5zf2sAwU4l9M+EMqRYrTsFrdPbXL0X51olFVCqFDYA6pVlH5QgDJ6ZVdOnC5nVQzpYC2MBN2dsFdNF/KoBwvMTqHupHCESOE39jF5AZ5vulV8zTdQO/DrAcbgU1hCpobaPQzmT60d52iado8/sw5hq7ToTCYeaTlvhLfqfK7N/BlFmLJCbLRc279if+RBOI311A0WGM+Yq4+dCyI2Fa+DeETVIPQw1CVjmXxXl3S/juHvob+TiqtkbbuQ+Wak5hE04Obn/9eoWftRs99P4uFIfvoD6KoQL8UBY29twwLVLAS0EBb0Jpa1UrX+q8FY4aaz0i3602mjEMbd0dIWFlZayQIPjkyzYp0Y7FW+lOgt1UB9jZj8zKcjJMD83DX44anlWDlz1LVoH/nZ3Cc3tpb3/1pzAqB+ODxte+Z1vCbWihMq9J0CzHoorYbVR4BFRy3kNR7nXkOavMUjkdXSafFfpNj6nv9APtt73SdS17GGboRXUjWDm/n2I/J6sfzyeFkKuqobinHB8oucq408Y6Yt9MuplwJsfLUmOcCjb8VGE3tHdx+XeC+P+xn7gUfqHTZIvcbCt5I3O1GEEqXDVqf2UBkvkee0jIaephN/08htOoz9TWNPryNuT7PbJu3wUkMEruLxqELx+M8kbhithvxbutvxWIbTuwCZXm4Vza4W+TnV9/lnsqJ7VFjDwlEgL8U7LLk4OgKf+ziepix6IE2iqfBYunYXIdzC2M6mrRx46xl4K2MWtjxmQXFVi7Ti0Tf9xTHCGAz622N8Lxik43GSgpmWbb+N7XpbqMx2bKKGo8NhaZrxUFkK6ZL07ZMsOJ9TqOk5FFFipP81RlC0O5QB3F0VtzC5mXtImUeoY0+2NGzkl7QRM32ceoh5dArkO6tWRlHwIIbcQg9JpWHeSCc3hAXLgWqyOQ9EdP6gCU9REx6fBl9X268OtXxjPhn0yfEIUskqsA6f3uRr0u8bndNVHU1Exx7VRAWjXeoxYxhAJkV52ea+3uaStQHeHqgmj63QMxi9hNFVk7tVTTA6jceqnZqxasNYvf+jP7rtdHhRHqfjQTTMjBfp0+kpPqUYU718XwHF+OAXUTSRuIHN0vX0HIvRcMhD+SbsbxQJbSARD6b8wSlTCUhQwTyOzcMmmhneKEv8qHRMURYwQQ4dwNgssQr3aCiHW9WYOtcR5YR0W6EeQcrKCegV+gKDHUm5+ehIKGQ2u5EF3rgJZTdraiLcXEPHMl4H2g0UBKsj204SWRqDJjU3d8aqcZTSweR24RGPRaSJB7BvNyveJV7vD6MD82wyxdKWUrcbXx+PCxOq4g9DJXsMC/9ytZiRE6/6LZ2WE8CswsBDovtQq8irtgvMNQuZF/ParjDtnBlY0IyLKp+nCw4L22eAkOAiysS+/xVIsKq9DPOXL8YZN0c2bKfaXeQonjxUZeY1wc17vRk9PcyDqsK6RowzjhNYjyU0tJq32Og3g/H+vxzG+q3WQh+u4BtVejYeYn4LwVQwLDKXkRTCxMZ7wkyDoHBAYlYV+toxYqN8Hi6ZNkEkK4S8xMDqc93Tgsn4nMadd4svsggnq9ywQxe1V9I0QPThb2o5/fSNc+FM9gkpjWMrM/g25QjfvbsuvyBWLzFpB3gETROUp5EnqMjSyaEtj6eZqVVxDU8o/o5dwV/voMJwpcwU+z26OQhPWpt7mJq7gOYrVMI819cS5+mEGTi9HGw/hoT71u5y03Jpxf8IJUNiRAltTB+gc/8e+LrPDMmosdkIKZ3b4uh2DBPThCU1du29Dbp+gwhq4mdSJT1OQgsfQmYZjateGY35O13npSqzktiIbWxLnT/NDu3wAmMHu1ijHM4Xt3OPv4p0DIDLLOtkXtEU09NsVrjhYm73yOexitzkhg8W/YgB5f3nySRMJi/oHk8mXcto1mqki7grRsIquZXb1rf7YN4sIpaCJWXwGY9yVEDSxR+NX1ixml54ajlHexBYdsGbdoVwzwIk0obVBHrttkKwQou+pl62JQa4gQoh3tPtGnV+hlp27+3H9lPNNL92zrk35UT5+e7m3FsZqaoDeUyMtjHwe6YCZ7SvFQoD941wHIdF/ETFXLISQS0WeNqPLRiqrtEJAWlXLyCpl5M6Lfdmos/OjU7Fw1DLidrISll9F3kTy2LHWFbat5I2xhuxxlnINA6jKHmhR5ip+EmPkOkM5EWqYTuoYBoygL5hivXDVoXY+OG2Y9xjkV7T2xRZfRyovHh+qKpKpMxabKBZQAYD6RZBp0SUxRV7tT6qx5HBhD2123g2iwtyHr7JM/OL/EfbQnqKuSjjOFEmjm9c3ufzGHvzs+F+n6Pkr7mhjo48/ChRN20TZlhMJuxWbsxu5Y7UrVz6dMzMhumIByqBl5//GsUps+OhPNnv+nxl3CY4ivhfbhIcnTrXfRPnum8/t2OhLBxBtHcQVJ1VDs5beo9qcJZw8BMOfsJNnaOROT0Nb/F+n1bh7TaWeFfubBmcBk5KGHA67lb4AJrdY44LuXkLRfGwnbvLjLuqvtJhOWQqj2YjuLwmxka3j2huDIqt3GsbqfNZ5LbPoingUCLg5gDebQYwtQH8EXS/m8BX6dD3Fs1U7+EbODMpqXkV/Ma3HDmRUH7lyIfGixcWGtLRN2Qw+SYfmM8zm+HSVvKQNTdGY8ibGr+d5/57tEw6G5BSj+M5d+MI3BAgcy/VXO5wiEjpbsPZ7ozMBgNV7dD0+HQpvRWa+swv4kazNkRXmI48iU480Z55EopgNmSWFDlUNU5EuWg9tYaRnZdgKW4oddUyK3QpE/qyzMuQ2bcxvbMcEt6ARM/vKxI9v9VccHqtGmhFNY+7+WuKJFY3jX2G1M3ker2gWDq5Onkd9qCm0PsSL0QbSIKS606FHFEYT9VurywRqCViYPu6sxN5O6koLooc8TQM+hhWzunt5un2d7KxPHH8KRZieMYu0geBncZ5LlYsdOrtzO001EbyZ/kirpr9rmygFlZcKWdA4XrdeU3Y16rc7bzeiD6DQ9iTWeHVIrIUlJRC3pfP2ec7eckS+b7wl/nhTOArDJFZLYDEBWiSXXxdbTckI1pduu2rkBX9IQf6Lwg5iTgz0tK30818j5Uv0rg+HK/XvGwU5t7k6uXu9/wav/cDY6/JNAWV2cl1zMuBRWGSfqBSIJzrxZf00kEsqzfDAE4V7D5AuUW+ghJS4iNbFO7cYcfBYsVe47VF1ut7MgEFBaEfsKWX7eYV0b51BaCpFIfazoUcEkqVibrKYum+L7bv7mGZJTakA0vFIvlLUYHpCE9LmW+j5FE4kh3rJXQqO9FSjxAeMoR3FDB1x0VJjxqWfITI5CMIPBADlq2DPJ/VxavU5uftBDvS1z8kiohyHVyZYuebk56kkQGojSJbRG4mKRA1auLQcsWwwXtaso18EFdQbKDOP14ctKCnfX83/12v8VPIrgJI1DALBgOjXg63SchCOXNeHLUKI87zvshfYJTSo1BTYU2V4wnL0LOh5BIBKM4Kudq8J7C8fsV2TVQ1F1fZ8d64vampUnzVp/QbVPXDkYlEflO0RT60lWq5dOzltdhDbmcUCMqU48o7sVnbnctUGVgKzD+exBn+jdJhpubOarTM2C9JFg3rq9Ox3Xx0pHXAXh2yziexGIZ+SrRxqlm3RdQWSavpaICOTjMxuSZQ+eRHcSYPGJ2n9O1+ZSuNrPuxaLViBQIy/NYpD+ZTNH6X56iARyyL2Pg0HR4dPWFBAczedOcVMGkOLJrCA97dTKELHHjvS/1MsqRrJXa2OxuJJsKYpKhna0IxUhOEdRmYL82Hawi0EEd6bh1tV6ttedMzBo4HlhRKBqxZN/cXK5YVvK9FHtZ3GZtV3PyHqijGyP+SC423JKFPKOB1eQOqHtmkbbakaLBP/asdFRff3AY5RjH3z9fFt+v19hNZXTgwwFiXqJ3Rdc3SSAkMDLrH1xQ0lpw8jLnooP2CAKKX3YD7HZTEeAfFmrZXtOuq4qJ1UwBvIGXoIybCsGqA2cc7rNPmlTqlKxTzlRLuosEAQp5ZV/A/bEETQZgyI20FTvJBZGOF8m8bH9f5NblavLsVIjAmFUts1V+xjmLwt6VRMzeOzTQX7qQSk4BkA3btE1ZjzQp2PL7M5Odvf7pPKUTY9Oux5lCS6vllXn6iUhP2zD9Dzw6JLRcFKT0qURsERMENSJwD8ffHly4Q1+sPuysqzt1qXYV8ixMfoamT6zSi0Nl+n8bdFsu53w+7Zu1Yqn5SaYaHpDmCh7dqEcqMDl7yzfI+WQJe+t5zLhFal62GaVos5yvkBkgHxP6Yb1yMU77yurwtPzFR3s/nKWcRadxm11wkWRy2oa88uAG7QAp78iZ/hYW/siRhhJDikjoEgXTSgiDatEuCC8YvhC89tCEryHrBMvMjbH4SGLUhAWsZyXt6LizXf2TfVNAUef9hsc7LL2E7TghrKs49TgekLlg71U/82HeOL4pi+ymwV5mfrABfBsWRIamOS93vP9D9apVF9eitGkRcDIqiG50nTHgxXL61ghHeihxN9vv83JK0NMwL4O9vwUMCDvGU18vkMP7rD6iPd5bbxZrslgQgODQA6uKfJeWBNPfuCiTj+vxSUaI0ExCvln2+ah7rDruKzMwzvrkKWpJFtEPDhhOBDO6xMIB9QRTV1gIY/tIbPKUbbND7S8+0KArbj7ENLR1wlGa2ZC3FdqoKsTZD3qZewr2Ge7SPxDtR+3cu+Tvjaat3oHS1GGXU6g2wxCz4K9N2gPF0dWI60+Qmb4kJRXH718gj+dK4/UsSdZOWiFhvN2JKaVZD8Gcp00FnrUChs4YSa0QsyyS7AbeK4iG7HzbB+56Opgd12j5zdS9Kg/ptmiI7iiKe0eR02tjlBHucTnhKlLTxBcp62CynzK4x5paOccT/cnvHOOF/R/zvmP9N+d/TrEqpjTgiE/5qMnWaqvgXYajw72NU4cROTk4zYfzwt7Y0O9k9FeA5JJOKN4UOJF+ZjipaomgveQtH0mhc1S+XwWW/KUd3WjUHlCFVc74qSVLRnMsq6oWqhuJc6UucmLxTl2+FAMDRXjU5dSD1eXLc23F8MbTf4erVD+RWho1IzAMXpR/i7vRSV32ZWcFbpheuB0kz1GwmcrF7XS2GLT23TOhuvt9ewKvYW6zF9lBw3WgX3Lj/sAwgRTaGIQMv6T2HHMa7gED9ahGb3HvRY4GFBJ5H6vkJf94lnH+W895vv+HDg2bM0wII9ZXJla6mmf5mWkFyWLbN3BYXZhXu1g+SeiBntFYXnHnsn5QUCxD7ZT1Cp/Svwl0627J6BRS6ItwEWmUNM+F1f+v9jWewor8iAG/m4GWelcWXr29wHNaqD11Tvsplk0O10MTgDL/yHMpZEWIG7WzDHZFvDopGH27cKgtakHiNseXoSF2rDwtw+bBkC/UW9tBYpWG4pf8hWfI1ThqDAU+GGZm9Obum6/sm1DwOuFmXjQOsuXsIw7khhIoCtQyKWvc6MhJ6tJAiX3Z2sqRhvutstmVnwWyH4G1fY4xNZwsxJJ0Nf2GNTuQ1hMPiaNvbjPXuw67svCR0o1EOtqZDbEgHXNjFbrktIIQKEP3mT5jFoqQ0Qzqv8mKHMdVYYxNg386Xckv31/Ml3Fu+WPL7yku42ky/sTvNS2Z3XoLdmT6k0gxdtYDyLr6laVd0dTfflIO1VELEWjRi5zhqPwuw4RiTkI7E+Xyx3wNNdaU+C30vwLjAwjg2ilEr2aVKIceIHKX3zoxYYdxG2h00RsoeJyh62wdx2PtOHFnsfAPSKgAIrJ0R1qWSOjqKWjicAjDuvPVYvohm69I3V7as9sR7nblhT2XG6rCq65RqF6/g9GWT6gU+SZj+pp+RLbAultHEdjQMuRsYVUkNQqKy4QtAZmYhhGNyPo9r+RVUPuDThlj3ZWngoGqEXZvIgG4Oscd1Jha1yDLAq2kpXSXkf3M9i+BAJ3XyfDJ9cVJhcdWBRWMbZGoepXDjY7/P6Qnr88uwdW52a4OTYsouj0TDSPU5AlNiv4Uzm4KE9kL6ngYH28Y22QVNpBD8S3DPRBzKVfuLeR12w/wCS/oAsItwEmT47fv1dkG/uxFrPjuSvrQbtVVhGlhk3DENMR01aeZKXM71atOuQCb8lpqcV6rV+IFgCpa+LzDloOJSgmOFGp3GznlqGT5szhaR6YwMAXRpAf7ONRZW5zeQXm7poQy3RVnwqQvOSGFUYq720kSvR1UBbYo3UAb00EBDamf3c+C6DlQ6Lm/CnnZokmPHOEtJeNEng1pBPBS/w1xZiOIKcdGNAk3NCTKIdJjjLoNIB9Z3JUFEw1vONWwTQaHHTwwGlREUQda/slWkW0Ei/YL1uBwMvEyW9Qy54nEhH2B5RUpcVEe4BFWZvKPbuiROTCEfSfz+3ZpgyBFE7VPtQqna9GcRcCkVDDAiUZb4gCp7b4rtJ7rLNUaIm8UYVqjnntEi3AjuDrN0cWG1cnqozR3DoXtQGvZgTKsvLNtidl5NHPYfmf+pu6/k4JtyR/22w/smOc/OSQ/TNux0EJmmc15TRoLFpSIIS+lCKKqASwtHxue5uZx0Tw7qjxgPhYq+wxJceDiJRkfRarteL4q7zLTbGB6iTKgMYZiyIWgEtYo1DfX4RmmduIL7UdID0NC3Bm/OnQXtwsH8wWB0uN5vm54VNkWf+mKgcqtU1C2iw7T542mmR1Ip84C70+1tVBd3p/E1J/rsufjxBUMeWIH8UXa9/+iBJb73tWf4dJ+rjfAi0Fr/Ty+rFmosYg/9tj8tnh2PgcPN9r3En0ZyrV29epAlR5pGaURQWiR8Tkg0/NlIPivEs1i063hj6Wz5JQ6E8TaSBvOnqpkUAvuqXSoHLfmg04l89FLCpp59FM+GsXz2qjf7wzvIFxTlXilxdkJobpiACsYz2w8hDidDG/QIjboRw7wFJ29toAH1q6WRRrOqHvPKjsBqIGiOCx+U9LTISqIS7o3lFXyN3j+8pG/pICfBHSw11j/57+fD49MXg5Pg+fBFWMylSrGjKoUQcIvzeDzGjGs7vneG4XEU2M0DLUZclEejY5FGS15vyE3F45RllhifstCQrrEUXRUkUrMcx2LosLzo4R0wYbfzoTFzm7DhOu8olHQFfXtJJQ67gitjvV7ma0UCxV75pqsxf4SWkSlKQ9vOJA1Nfh3m7kJ3jLi0mEto0FTuiI+azRzs+Jbg1B2GRoHJGr9jc3x2URkvACf+ul+ElBUrYirO5pCgdAz3x6XlcgoBY4VwLTgTGIZlvTJjuRJmlA1WBhJpnLqZIwijH6gIz4yEpWpD//bbh7/Tf4bmMOOJYj0ceNYnF8tsHfQ3FDHVm2ChOMgzJ1Mq5Azb6GraAdw10rswqMOVQTkVITuaD4aSy8c7kMHNsDnwy2o8CRxPQfAZi747xzeIl0wF+oHS3+ROFN1JeuoO399KI1PdW1bcmGkDstE/SuHnMJupzDzfihbqpV/snkuAJ/+HKOH19s5iuS02868/Yznl7G34kdF99kMZco78mO2K7G4oIsmzy/AJVu57xA+p7H74mpRwCD3cvNpmj8Of6GJl6zLE6T+lAnv2IaRDw6dd9jHkuGNfP0MrHmSe5SW049922a4M850yMsHuytbGIzwSsyUbKXsG7X8inwCU7CqEM/Mu7Kjsi/r8IHsZbii2ntx7+PDTG8oodxD7lj05zMjn621Rfl2XncWuA1MI38InhpvwEj9zFIT34ZuJhTDHF9VswmfiAdmEH+RHmHZ4F76aGA4fwzMNkeEaHtgICJf2U8RBeMUe89mHn+GrjujwCzyRaAhfGl8fhE/gu4uY8G84CaS18B/qs0534Q6faysXfuQP2NC/iN8Z8YU/4HdOawLxAh14Psz+7eTk3zusQOSPi+tryhWeXT6an+zenSRLQl5NVvHo1YqM09ViGJHJOCLD0+VoHMfjl6eLKVlN0tWrBYnSl9EqSuNXKRlNpi8nJBkvp1RWuP4nZ6Cvw16yAQA=
+</script>
+<script id="@tomlarkworthy/acorn-8-11-3/acorn-walk-8.3.2.js.gz" 
+  type="text/plain"
+  data-encoding="base64"
+  data-mime="application/gzip"
+>
+H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC5mydonhQbDnRjC17JRkmh+S/n5bkm2zHITsvjNWt7v76olYrM3779o311rrMaRjj0JourG/8GsfkiVk5J3Rm3aZxnGfW06H7/sQ9sBANrXvMOGbW06/uwYl76Er5z4zMCEWxFZEYn1pjmiVjFKSM7j+j+Pu/f3OP3MNxSLgYy7WbfOMgJQWvU+vT53uwha272xvrmYi5FS4oSkiA4nhhzTDFDAmAJjXzHetjyrBFaJSyBAmS0lNrLkTGT8fj5+dn9xsPFXg3SJOxcmCfM7Iv1e4XaveVIrA9fhPlNJA6LGELBzvUYU46eqHLpU39ZOQ02MBwyOjlCTEL+WS5ZK5YZNijD+hR8cTIwfC9t4cLymgFKtW/lRbcNCI1Ef/h0VtnDek93EelNSfz2Y7vkwfixpjOwKODRy/b2yNulvO5zUYOfeANOFzB0ZTlkgB+R+9OM7sHHu3Co+eRDYTl8ikloTUZnTJvpwFT7R69kAfYgRXER0UTSjs2tDNbjF4YFjmju1wwSMyu70uRNLLEebnNxuUmC/vAX52K5bJilrydyWolAaZ+xQJzoxcxJ9ylaYh94ahvLqByfLzyKhik4+QWCfCa8SWQCra3Z2NF4EDwWU9UUWmwritPYXdU9ncMowj0KKOZz6usBz1ZD8ysZ49KGFClDVRIJd3JgArQnMDMfQMjLzASDQDkbCQDAh7ZZOQJtngxcXJQqnAGflYFh0S2TfM49n0saRB7Js58PAI0mkwlGdPwd58CET0Ej0oVoO7IQe57BIEqJYkdAPyRmLP02aL42UqlHuUV/A2QCOay2ACPgEYB+mggqywdFZUlPC0qVnUIsjoEkCjwm4L7EAci89UNQF+iZAB27MKB33GB+Uz5QRoponYm4bfwI4Uf/VP8wT/AX+DVIHvdKZ3x8d5eAbuN2mu4tvopF/KmC+rkecXulj9Oy5WscqUI/ahbnNpN6Ye9Ay7qNqFoijOS/smqAj73a+/AqC7ThnsOrzFHuvFIa9T/PP2GA+EGDEPXsaEAIPRwTdmSC40G4I7oA3v0BfypXKt1xdp/SJ9SWjN+lAzV9BL/ZeUl7heWzhhK/MS9jNPg+53sdAmmAgjymwSKbDRIqaLC40+gKwh3moYLj52lRW/x2C/+gUSQAkaQ2K307oL7jtat7cSw+iPJxKIm/ZCkHxnDnIPJJqQviMHHHHPyPxzWW4BzNUeENihtwGWcbOHiapdEVssANDB8E9UG20qktMBctOUcyQhSyvHfOci1HHaEi2KBGQWKrI/Gsh0asP8BTTFMUOtBNDyRUe9RcQmVY2TyKqWC0BybIf4LhplhX1NVib3erjF9BxNSsEErjG8BIwmMebSj22sXVoA45t3K0nOFrC6PqJTIwJLe5FQqEajkPmkkykNnvNSLiorlMHh1KrZ27QrwdLwSFQQxDKHyqoawxaG5VZlvJva/BMfmObh4RkQMnAMoPjbLpXhRisWq7yjcy95qdATgo/CPeGNhDmpli+H6mMqO0z1DcySfFkzDLhbQ34ATyRcDdISCVy176vNKXilXMcp7s5ghaIVaifqUCr4gIQ/rcNn/NYe3QDNS12mLtFUrWWPlz5StVyhcQkmRVPkl5UHgBj5V+IYrFDbkWVg1KP29JbYbozSB8HlDK41x1IIpqfACnIutTZOuid3/IEbQNMbXOIghnZK3K18D6io/19fjqd7eqdJrPM1nM8zMlvlnYaKhceAYKN8Krtbag2jj1RrWe/n6bqE7RFt/ynoDT0Kzsvtqpx2Q0pG+wgsLUVNtp+upM8WHOl4lu2rku3ljnzdxnbYroRDvVsJNCHtIRDBrF4BTVUll+3T3I06mmDUsdYT0jlqkmLUaKSixyLIxdquJ5xbO4JZ9tI4NyF8whhbr3G3HHWtDG65RdYOahqQlPY2+1lTG0gwzQTbc2btf9L6FjCzRkbXlzZxkucChvsy/40VPGyDuE4pzbACFlDUCWuvUevqDuDKGTJWUe3jrG5fpXQ4gfZk/gUrEKqEq/AO37E9mwDh7dRK2MDiUB7NllOfanCIY3Py9nJ4OKGcjNcwEeJuQVFsHO0InFPc4yWI49R8IJBLFG+38nSNOBqNQShCQQC1k5AyVYqQQQw9kGFl5rmWhfKWILYwAflVX60CgNs1Pl6Sj80M6kz9zblBaXrede7X3xlVdBr5nVAIxq6Mir2sLTXPmALXWFrxRQiJ1bPTjlS+wDtt4dbXNf8LP5nsSxUM4SGQri7AL455hqkwgH7XrseJsVfXtG2mb55ow+mrVGxZ9YYB1ysQnlOCwOaOUjGscoTwWQ+OLMbBogw1CYbPHRn3HLpeGCIwV542L/rTtHE9zFhRzq/5e79hFHA9jx2pbGalyJZ8Zw+pvEh2e1491PMOBmkgGe9NrrG6oik3idyUQv3ZDZbnLkDnjGQqwwapmK/kDDSNPkCmDVnZq2Q/vEQzVYdUpNxx0NOs9yKql9/aQGHFu1q0ivep3IalQ7W7oev2wKwtRTgtKrCjGaj3wmqltXcL6J39nK3uFmKdwtCI5yusolMNLL7HHSbNh9A1iQo9hekM1kRkJ8fTxecEW4pb85ZbDe8RJ5GqKOHYC+QV4wk9piC8iiKOTGSSW5jR0uEETTt5cX2KIEHaIouVx7KDy66I0GElKgr6Da/KL4SBnnDzBu0IuOYFSxCVWK9Slb8n/MPDejMf/svTx+YiyjNDZ19sP/pgn42gSTN4fTw7fhYfRydFheHz07t0xOkYBmh5hdDJ5Nwl/C8LjSXR4go6O8WSCDkHz++gwPJkERweBm6Ds/8t9I8syHQAA
+</script>
+<script id="@tomlarkworthy/acorn-8-11-3" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1emgxs3 = function _1(md){return(
+md`# [Acorn@8.11.3](https://github.com/acornjs/acorn) & acorn-walk@8.2.2
+
+\`\`\`\`js
+import { acorn } from "@tomlarkworthy/acorn-8-11-3"
+\`\`\``
+)};
+const _1xdqqxo = function _acorn(acorn_url){return(
+import(acorn_url)
+)};
+const _vctqpi = function _acorn_walk(acorn_walk_url){return(
+import(acorn_walk_url)
+)};
+const _1c0mco9 = async function _acorn_walk_url(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("acorn-walk-8.3.2.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  return objectURL;
+};
+const _jdtsxp = async function _acorn_url(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("acorn-8.11.3.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  return objectURL;
+};
+const _17n6uge = function _unzip(Response,DecompressionStream){return(
+async (attachment) =>
+  await new Response(
+    (await attachment.stream()).pipeThrough(new DecompressionStream("gzip"))
+  ).blob()
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+  const fileAttachments = new Map(["acorn-8.11.3.js.gz","acorn-walk-8.3.2.js.gz"].map((name) => {
+    const module_name = "@tomlarkworthy/acorn-8-11-3";
+    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
+    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
+    return [name, {url: blob_url, mimeType: mime}]
+  }));
+  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+
+  $def("_1emgxs3", null, ["md"], _1emgxs3);  
+  $def("_1xdqqxo", "acorn", ["acorn_url"], _1xdqqxo);  
+  $def("_vctqpi", "acorn_walk", ["acorn_walk_url"], _vctqpi);  
+  $def("_1c0mco9", "acorn_walk_url", ["unzip","FileAttachment"], _1c0mco9);  
+  $def("_jdtsxp", "acorn_url", ["unzip","FileAttachment"], _jdtsxp);  
+  $def("_17n6uge", "unzip", ["Response","DecompressionStream"], _17n6uge);
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/cell-map" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1t29kxm = function _1(md){return(
+md`# \`cellMap\`
+## computes the mapping of reactive variables to higher level notebook cells, grouped by module`
+)};
+const _199r1h0 = function _showBuiltins(Inputs){return(
+Inputs.toggle({ label: "builtins?", value: false })
+)};
+const _v3idap = (G, _) => G.input(_);
+const _jqf42f = function _showAnon(Inputs){return(
+Inputs.toggle({ label: "anonymous?", value: false })
+)};
+const _10za42b = (G, _) => G.input(_);
+const _125g1nt = function _cellMapViz(hash,Plot,width,d3,filteredMap,edges,linkTo,isOnObservableCom)
+{
+  hash; // update links on hash change
+  return Plot.plot({
+    width,
+    axis: null,
+    y: {
+      reverse: true
+    },
+    marks: [
+      Plot.dot(
+        [
+          [-1, d3.min(filteredMap, (d) => d.module)],
+          [1, d3.max(filteredMap, (d) => d.module) + "_"]
+        ],
+        {
+          stroke: "none"
+        }
+      ),
+      Plot.arrow(
+        edges.filter((edge) => edge[1]),
+        {
+          x1: 0,
+          y1: (edge) => `${edge[0].module}#${edge[0].name}`,
+          x2: 0,
+          y2: (edge) => `${edge[1].module}#${edge[1].name}`,
+          stroke: (edge) => edge[0].module,
+          headLength: 0,
+          bend: 90
+        }
+      ),
+      Plot.ruleY(new Set(filteredMap.map((cell) => cell.module + "-")), {
+        y: (d) => d,
+        stroke: (d) => d,
+        strokeOpacity: 0.5,
+        strokeDasharray: [5, 10]
+      }),
+      Plot.text(new Set(filteredMap.map((cell) => cell.module)), {
+        x: -1,
+        y: (d) => d + "_",
+        fill: (d) => d,
+        fontSize: 14,
+        frameAnchor: "top-left",
+        dy: 8,
+        href: (cell) => linkTo(`${cell}`),
+        ...(isOnObservableCom() && { target: "_blank" })
+      }),
+      Plot.text(
+        filteredMap,
+        Plot.pointerY({
+          x: 1,
+          text: (d) => `${d.module}#${d.name}`,
+          y: (d) => `${d.module}#${d.name}`,
+          fill: (d) => d.module,
+          fontSize: 14,
+          frameAnchor: "right",
+          href: (cell) => {
+            if (!cell) return undefined;
+            return linkTo(`${cell.module}#${cell.name}`);
+          },
+          ...(isOnObservableCom() && { target: "_blank" })
+        })
+      )
+    ]
+  });
+};
+const _cjxin = (G, _) => G.input(_);
+const _1nt2irf = function _detailVizTitle(cellMapViz,linkTo,md){return(
+md`${cellMapViz ? `### [\`${cellMapViz?.module}#${cellMapViz?.name}\`](${linkTo(`${cellMapViz?.module}#${cellMapViz?.name}`)})` : `\`<click the above viz to pin a cell and open its dependancy graph below>\``}`
+)};
+const _1lxiffy = function _detailViz(Plot,width,nodes,variableToCell,modules,linkTo,isOnObservableCom){return(
+Plot.plot({
+  symbol: {
+    domain: ["simple", "mutable", undefined, "import", " ", "viewof"],
+    legend: true
+  },
+  margin: 50,
+  axis: null,
+  width,
+  height: 1000,
+  marks: [
+    Plot.link(
+      nodes
+        .filter((d) => d.parent)
+        .map((n) => {
+          if (variableToCell.get(n.parent.data) == variableToCell.get(n.data)) {
+            n.type = variableToCell.get(n.data).type;
+          } else {
+            n.type = "connector";
+          }
+          return n;
+        }),
+      {
+        x1: "y",
+        y1: "x",
+        x2: (d) => d.parent.y,
+        y2: (d) => d.parent.x,
+        stroke: "type",
+        strokeLinecap: "round",
+        strokeWidth: (d) => (d.type == "connector" ? 2 : 20),
+        opacity: (d) => (d.type == "connector" ? 0.5 : 0.1),
+        inset: 0
+      }
+    ),
+    Plot.dot(nodes, {
+      x: "y",
+      y: "x",
+      r: 10,
+      fill: "white",
+      symbol: (node) => variableToCell.get(node.data)?.type,
+      stroke: (d) => modules.get(d.data._module)?.name,
+      strokeWidth: 4,
+      href: (d) => {
+        const cell = variableToCell.get(d.data);
+        if (!cell) return undefined;
+        return linkTo(`${cell.module}#${cell.name}`);
+      },
+      ...(isOnObservableCom() && { target: "_blank" })
+    }),
+    Plot.arrow(
+      nodes
+        .filter((d) => d.parent)
+        .flatMap((d) => d.reused.map((reused) => ({ ...d, parent: reused }))),
+      {
+        x1: "y",
+        y1: "x",
+        x2: (d) => d.parent.y,
+        y2: (d) => d.parent.x,
+        bend: -10,
+        strokeDasharray: [1, 5],
+        stroke: "red",
+        opacity: 0.5,
+        inset: 14
+      }
+    ),
+    Plot.text(nodes, {
+      x: "y",
+      y: "x",
+      text: (d) => d.data._name,
+      dy: 16
+    })
+  ]
+})
+)};
+const _j5pb2k = (G, _) => G.input(_);
+const _glmq4i = function _7(md){return(
+md`## cellMap`
+)};
+const _izhsfx = function _8(Inputs,filteredMap){return(
+Inputs.table(filteredMap, {
+  layout: "auto",
+  format: {
+    variables: (d) => d.length
+  }
+})
+)};
+const _7t7pwf = function _9(md){return(
+md`## \`liveCellMap\`
+
+Prefer using this variable for an always live view of the runtime state`
+)};
+const _1xnzq7y = async function _liveCellMap(keepalive,cellMapModule,Inputs,cellMap)
+{
+  keepalive(cellMapModule, "maintain_live_cell_map");
+  return Inputs.input(await cellMap());
+};
+const _14vvdt2 = (G, _) => G.input(_);
+const _193osz9 = async function _maintain_live_cell_map(runtime_variables,$0,cellMap,Event)
+{
+  runtime_variables;
+  $0.value = await cellMap();
+  $0.dispatchEvent(new Event("input"));
+};
+const _1vhxngh = function _usage(md){return(
+md`## cellMap function
+
+You can call it with zero args to default to the current runtime, or pass in a subset of variables to extract the cell structure from just those.
+
+\`\`\`js
+import {cellMap, liveCellMap} from "@tomlarkworthy/cell-map"
+\`\`\`
+
+If you wanted to use the visualizations in your own notebooks. You would import the views e.g.
+
+\`\`\`js
+import {viewof cellMapViz, viewof detailViz, detailVizTitle} from "@tomlarkworthy/cell-map"
+\`\`\`
+
+and then call them in your notebooks`
+)};
+const _17c6bac = function _cellMap(runtime,moduleMap,moduleVarInfo,importedModule,findModuleName,decompileImport){return(
+async (variables, _moduleMap) => {
+  const map = new Map();
+  if (!variables) variables = runtime._variables;
+  variables = [...variables];
+  if (variables.length === 0) return map;
+
+  if (!_moduleMap) _moduleMap = await moduleMap(variables[0]._module._runtime);
+
+  const byNotebookModule = new Map();
+  for (const v of variables) {
+    const info = _moduleMap.get(v._module);
+    if (!info) continue;
+    if (!byNotebookModule.has(info.module))
+      byNotebookModule.set(info.module, []);
+    byNotebookModule.get(info.module).push(v);
+  }
+
+  const isModuleVar = (v) =>
+    typeof v?._name === "string" && v._name.startsWith("module ");
+
+  await Promise.all(
+    [...byNotebookModule.keys()].map(async (m) => {
+      const variables = byNotebookModule.get(m);
+      const order = new Map(variables.map((v, i) => [v, i]));
+
+      const cells = new Map();
+      const moduleVars = variables.filter(isModuleVar);
+      const moduleVarInfos = new Map(
+        await Promise.all(
+          moduleVars.map(async (v) => [v, await moduleVarInfo(v, _moduleMap)])
+        )
+      );
+
+      const moduleVarsByKey = new Map();
+      for (const v of moduleVars) {
+        const info = moduleVarInfos.get(v);
+        const key = info?.module ?? info?.name ?? null;
+        if (!key) continue;
+        if (!moduleVarsByKey.has(key)) moduleVarsByKey.set(key, []);
+        moduleVarsByKey.get(key).push(v);
+      }
+
+      const viewofs = new Set();
+      const mutables = new Set();
+      const namedNonModuleVars = variables.filter(
+        (v) => v?._name && !isModuleVar(v)
+      );
+
+      const sources = new Map(
+        await Promise.all(
+          namedNonModuleVars.map(async (v) => [
+            v._name,
+            await importedModule(v)
+          ])
+        )
+      );
+
+      const imports = new Map();
+      const moduleNamesPromises = new Map();
+      const groups = new Map();
+      let anonCounter = 0;
+
+      for (const v of variables) {
+        if (v?._name) {
+          if (isModuleVar(v)) {
+            continue;
+          }
+
+          const source = sources.get(v._name);
+          if (source) {
+            const key = source;
+            if (!imports.has(key)) {
+              imports.set(key, []);
+              moduleNamesPromises.set(
+                key,
+                Promise.resolve(
+                  findModuleName(key, _moduleMap, { unknown_id: v._name })
+                )
+              );
+            }
+            imports.get(key).push(v);
+          } else if (v._name.startsWith("viewof ")) {
+            cells.set(v, { type: "viewof", lang: ["ojs"] });
+            viewofs.add(v);
+            groups.set(v._name, []);
+          } else if (v._name.startsWith("mutable ")) {
+            cells.set(v, { type: "mutable", lang: ["ojs"] });
+            mutables.add(v);
+            groups.set(v._name, []);
+          } else if (v._name.startsWith("dynamic ")) {
+            continue;
+          } else {
+            cells.set(v, { type: "simple", lang: ["ojs"] });
+            groups.set(v._name, [v]);
+          }
+        } else {
+          cells.set(v, { type: "simple", lang: ["ojs"] });
+          groups.set(anonCounter++, [v]);
+        }
+      }
+
+      for (const [key] of moduleVarsByKey.entries()) {
+        if (imports.has(key)) continue;
+        if (!moduleNamesPromises.has(key)) {
+          if (typeof key === "string")
+            moduleNamesPromises.set(key, Promise.resolve(key));
+          else
+            moduleNamesPromises.set(
+              key,
+              Promise.resolve(
+                findModuleName(key, _moduleMap, { unknown_id: Math.random() })
+              )
+            );
+        }
+      }
+
+      const moduleNames = new Map(
+        await Promise.all(
+          [...moduleNamesPromises.entries()].map(async ([k, p]) => [k, await p])
+        )
+      );
+
+      for (const v of viewofs) {
+        const name = v._name.substring(7);
+        if (groups.has(name)) {
+          groups.get(v._name).push(v, groups.get(name)[0]);
+          groups.delete(name);
+        } else {
+          groups.delete(v._name);
+        }
+      }
+
+      for (const v of mutables) {
+        const name = v._name.substring(8);
+        const initial = "initial " + name;
+        if (groups.has(name) && groups.has(initial)) {
+          groups
+            .get(v._name)
+            .push(groups.get(initial)?.[0], v, groups.get(name)[0]);
+          cells.delete(groups.get(initial)[0]);
+          cells.delete(groups.get(name)[0]);
+          groups.delete(initial);
+          groups.delete(name);
+        } else {
+          const vars = groups.get(v._name);
+          if (vars?.[0]) cells.delete(vars[0]);
+          groups.delete(v._name);
+          groups.delete(initial);
+          groups.delete(name);
+        }
+      }
+
+      for (const [key, importVars] of imports.entries()) {
+        const module_name =
+          moduleNames.get(key) ?? `<unknown ${Math.random()}>`;
+        let importInfo = null;
+        try {
+          importInfo = (await decompileImport(importVars)) ?? null;
+        } catch {
+          importInfo = null;
+        }
+        cells.set(importVars[0], {
+          type: "import",
+          lang: ["ojs"],
+          module_name,
+          importInfo
+        });
+
+        const groupName = `module ${module_name}`;
+        const moduleVarsForKey = moduleVarsByKey.get(key) ?? [];
+        groups.set(groupName, [...importVars, ...moduleVarsForKey]);
+        moduleVarsByKey.delete(key);
+      }
+
+      for (const [key, moduleVarsOnly] of moduleVarsByKey.entries()) {
+        if (!moduleVarsOnly.length) continue;
+        const module_name =
+          moduleNames.get(key) ??
+          (typeof key === "string" ? key : `<unknown ${Math.random()}>`);
+        let importInfo = null;
+        try {
+          importInfo = (await decompileImport(moduleVarsOnly)) ?? null;
+        } catch {
+          importInfo = null;
+        }
+        cells.set(moduleVarsOnly[0], {
+          type: "import",
+          lang: ["ojs"],
+          module_name,
+          importInfo
+        });
+
+        const groupName = `module ${module_name}`;
+        groups.set(groupName, [...moduleVarsOnly]);
+      }
+
+      const orderKey = (name, vars) => {
+        if (!vars?.length) return Infinity;
+        if (typeof name === "string" && name.startsWith("mutable ")) {
+          return order.get(vars[1] ?? vars[0]) ?? Infinity;
+        }
+        return order.get(vars[0]) ?? Infinity;
+      };
+
+      const sortedGroups = [...groups.entries()].sort((a, b) => {
+        const oa = orderKey(a[0], a[1]);
+        const ob = orderKey(b[0], b[1]);
+        if (oa !== ob) return oa - ob;
+        return String(a[0]).localeCompare(String(b[0]));
+      });
+
+      const moduleName =
+        _moduleMap.get(variables[0]._module)?.name ?? "<unknown module>";
+      map.set(
+        m,
+        sortedGroups.map(([name, variables]) => {
+          const head =
+            typeof name === "string" && name.startsWith("mutable")
+              ? variables[1]
+              : variables[0];
+          return {
+            name,
+            module: moduleName,
+            ...(cells.get(head) ?? { type: "simple", lang: ["ojs"] }),
+            variables
+          };
+        })
+      );
+    })
+  );
+
+  return map;
+}
+)};
+const _1clgb7s = async function _test_cellmap_importInfo_on_real_import(cellMap,expect)
+{
+  const mapped = await cellMap();
+  const allCells = [...mapped.values()].flat();
+  const cell = allCells.find(
+    (c) => c?.type === "import" && typeof c?.module_name === "string"
+  );
+  expect(Boolean(cell)).toBe(true);
+
+  expect(cell.type).toBe("import");
+  expect(cell.importInfo != null).toBe(true);
+  expect(cell.importInfo.type).toBe("import");
+  expect((cell.importInfo.specifiers?.length ?? 0) >= 1).toBe(true);
+
+  const vars = cell.importInfo?.meta?.variables ?? [];
+  expect(Array.isArray(vars)).toBe(true);
+  expect(vars.length >= 1).toBe(true);
+
+  return cell.importInfo;
+};
+const _yubgz5 = function _15(md){return(
+md`### \`cellMapCompat\`
+
+Migration helper from old cellMap`
+)};
+const _71n0hz = function _cellMapCompat(cellMap){return(
+async (module, { excludeInbuilt = true } = {}) => {
+  const map = await cellMap(
+    [...module._runtime._variables].filter(
+      (v) => v._module == module && (!excludeInbuilt || v._type == 1)
+    )
+  );
+  const cells = map.get(module) || [];
+  return new Map(cells.map((c) => [c.name, c.variables]));
+}
+)};
+const _x7j8bo = function _17(md){return(
+md`## Visualizations`
+)};
+const _1l7cvxn = function _nodeToSymbol(variableToCell){return(
+(node) =>
+  ({
+    viewof: "triangle",
+    mutable: "cross",
+    import: "square",
+    simple: "circle"
+  }[variableToCell.get(node.data)?.type] || "diamond")
+)};
+const _y7kfs7 = function _focus_variables(cellMapViz,descendants,ascendants){return(
+cellMapViz
+  ? [
+      ...descendants(cellMapViz.variables[0]),
+      ...ascendants(cellMapViz.variables[0])
+    ]
+  : []
+)};
+const _14ty3wh = function _focus_cells(focus_variables,variableToCell){return(
+new Set(focus_variables.map((v) => variableToCell.get(v)))
+)};
+const _12jpxa2 = function _descendents(d3,cellMapViz){return(
+d3.hierarchy(
+  cellMapViz ? cellMapViz.variables[0] : [],
+  (variable) => {
+    return variable._inputs;
+  }
+)
+)};
+const _16z9f8f = function _dedupeHierarchy(){return(
+function dedupeHierarchy(root) {
+  const key = (n) => n.data;
+  const deepest = new Map(); // datum → deepest node
+
+  // pass-1: pick deepest representative
+  root.each((n) => {
+    const k = key(n);
+    if (!deepest.has(k) || n.depth > deepest.get(k).depth) deepest.set(k, n);
+  });
+  deepest.forEach((n) => {
+    n.reused = [];
+  });
+
+  // pass-2: alias shallower nodes → deepest
+  root.each((n) => {
+    const rep = deepest.get(key(n));
+    n.name = n.data._name;
+    const p = n.parent;
+    if (n !== rep) {
+      if (p) {
+        p.children = p.children.map((c) => (c === n ? rep : c));
+        if (!rep.reused.includes(p) && p == deepest.get(key(p)))
+          rep.reused.push(p);
+      }
+    }
+  });
+  return root;
+}
+)};
+const _1j8atwc = function _layout(d3,descendents){return(
+d3.tree()(descendents)
+)};
+const _eb858t = function _clustered(dedupeHierarchy,layout){return(
+dedupeHierarchy(layout)
+)};
+const _17lllwm = function _nodes(clustered){return(
+clustered.descendants().map((n) => ({ name: n.data._name, ...n }))
+)};
+const _ng770d = function _26(md){return(
+md`### visualize the cell ordering`
+)};
+const _xpas1q = function _runtimeMap(runtime_variables,liveCellMap)
+{
+  runtime_variables;
+  return [...liveCellMap.values()].flat();
+};
+const _hishw1 = function _variableToCell(runtimeMap){return(
+new Map(
+  runtimeMap.flatMap((cell) => cell.variables.map((v) => [v, cell]))
+)
+)};
+const _szpnyp = function _filteredMap(runtimeMap,filter){return(
+runtimeMap.filter(filter)
+)};
+const _1jdpo9p = function _filter(showBuiltins,showAnon){return(
+(v) =>
+  (showBuiltins || (v.module !== "builtin" && v.name !== "module builtin")) &&
+  (showAnon || typeof v.name == "string")
+)};
+const _10gdqhm = function _edges(filteredMap,variableToCell,filter){return(
+filteredMap.flatMap((cell) =>
+  cell.variables.flatMap((variable) =>
+    variable._inputs
+      .map((input) => [variableToCell.get(variable), variableToCell.get(input)])
+      .filter(([source, imported]) => imported && filter(imported))
+  )
+)
+)};
+const _qb7351 = function _cellMapModule(thisModule){return(
+thisModule()
+)};
+const _120483s = (G, _) => G.input(_);
+const _2ufyg8 = function _38(md){return(
+md`## testing`
+)};
+const _18tubss = function _39(tests){return(
+tests({
+  filter: (t) =>
+    t.name.includes("@tomlarkworthy/cell-map") || t.name.includes("main")
+})
+)};
+const _kdc1xp = function _modules(moduleMap,runtime){return(
+moduleMap(runtime)
+)};
+const _jrvq7q = function _moduleLookup(modules){return(
+new Map([...modules.values()].map((info) => [info.name, info]))
+)};
+const _rlmpw8 = function _42(md){return(
+md`low-level variables in this module`
+)};
+const _519lii = function _43(Inputs,runtime_variables,cellMapModule,toObject,modules){return(
+Inputs.table(
+  [...runtime_variables]
+    .filter((v) => v._module == cellMapModule)
+    .map(toObject),
+  {
+    columns: [
+      "_name",
+      "_inputs",
+      "_definition",
+      "_type",
+      "_reachable",
+      "_observer",
+      "_module"
+    ],
+    format: {
+      _inputs: (i) => i.map((i) => i._name).join(", "),
+      _observer: (i) => i.toString(),
+      _module: (m) => modules.get(m).name
+    }
+  }
+)
+)};
+const _pyrytd = function _unreached_main_import(toObject,lookupVariable,cellMapModule){return(
+toObject &&
+  lookupVariable("repositionSetElement", cellMapModule)
+)};
+const _12euivr = function _reached_main_import(runtime,lookupVariable,cellMapModule){return(
+runtime && lookupVariable("runtime", cellMapModule)
+)};
+const _1x88m7u = function _main_mutable(){return(
+"OK"
+)};
+const _1c3nv1y = (M, _) => new M(_);
+const _kbdqj3 = _ => _.generator;
+const _1q0qa04 = async function _test_importedModule(expect,modules,importedModule,reached_main_import,unreached_main_import)
+{
+  expect(modules.get(await importedModule(reached_main_import)).name).toBe(
+    "@tomlarkworthy/module-map"
+  );
+
+  expect(modules.get(await importedModule(unreached_main_import)).name).toBe(
+    "@tomlarkworthy/runtime-sdk"
+  );
+
+  return "ok";
+};
+const _1tqu9mu = async function _test_findModuleName(expect,findModuleName,importedModule,reached_main_import,modules,unreached_main_import)
+{
+  expect(
+    findModuleName(await importedModule(reached_main_import), modules)
+  ).toBe("@tomlarkworthy/module-map");
+
+  expect(
+    findModuleName(await importedModule(unreached_main_import), modules)
+  ).toBe("@tomlarkworthy/runtime-sdk");
+
+  return "ok";
+};
+const _1mk5ruc = async function _test_cellmap_mutable(main_mutable,lookupVariable,cellMapModule,cellMap,modules,expect)
+{
+  const initialMutable =
+    main_mutable &&
+    (await lookupVariable("initial main_mutable", cellMapModule));
+  const mutableMutable =
+    main_mutable &&
+    (await lookupVariable("mutable main_mutable", cellMapModule));
+  const mainMutable =
+    main_mutable && (await lookupVariable("main_mutable", cellMapModule));
+  const mapped = await cellMap(
+    [initialMutable, mutableMutable, mainMutable],
+    modules
+  );
+  const module = mapped.get(cellMapModule);
+  expect(module).toHaveLength(1);
+  const mutableCell = module[0];
+
+  expect(mutableCell.type).toBe("mutable");
+  expect(mutableCell.variables).toHaveLength(3);
+  return mutableCell;
+};
+const _rpm6xw = function _50(md){return(
+md`### Notebook 2.0 Compatability`
+)};
+const _1rtpyzk = function _cellMapVizView($0){return(
+$0
+)};
+const _1srzrzc = function _52(md){return(
+md`detailVizView = viewof detailViz`
+)};
+const _1hybsm8 = function _coverage_failures(runtime_variables,liveCellMap,modules)
+{
+  const byModule = new Map();
+  for (const v of runtime_variables) {
+    const m = v._module;
+    let arr = byModule.get(m);
+    if (!arr) byModule.set(m, (arr = []));
+    arr.push(v);
+  }
+
+  const isDynamic = (v) =>
+    typeof v?._name === "string" && v._name.startsWith("dynamic");
+
+  const failures = [];
+  for (const [m, vars] of byModule.entries()) {
+    const cells = liveCellMap.get(m) || [];
+    const covered = new Set(cells.flatMap((c) => c.variables || []));
+    const missing = vars.filter(
+      (v) => v._type == 1 && !isDynamic(v) && !covered.has(v)
+    );
+    if (missing.length) {
+      const moduleName = modules?.get(m)?.name ?? "<unknown module>";
+      failures.push({
+        module: moduleName,
+        missing: missing.map((v, i) => v._name ?? `<anonymous ${i}>`)
+      });
+    }
+  }
+  return failures;
+};
+const _1p0qclg = function _test_cell_map_covers_all_runtime_variables(coverage_failures)
+{
+  if (coverage_failures.length) {
+    throw JSON.stringify(coverage_failures);
+  }
+  return "pass";
+};
+const _1a18z7a = function _test_cell_map_no_variable_in_more_than_one_cell(runtime_variables,liveCellMap,modules)
+{
+  runtime_variables;
+
+  const where = new Map(); // variable -> Set(cellId)
+  const add = (v, cellId) => {
+    let s = where.get(v);
+    if (!s) where.set(v, (s = new Set()));
+    s.add(cellId);
+  };
+
+  for (const [m, cells] of liveCellMap.entries()) {
+    const moduleName = modules?.get(m)?.name ?? "<unknown module>";
+    for (const c of cells ?? []) {
+      const cellId = `${moduleName}#${String(c?.name ?? "<unknown cell>")}`;
+      const vars = c?.variables ?? [];
+      const uniq = new Set(vars);
+      for (const v of uniq) add(v, cellId);
+    }
+  }
+
+  const failures = [];
+  for (const [v, cellIds] of where.entries()) {
+    if (cellIds.size > 1) {
+      const vModuleName = modules?.get(v?._module)?.name ?? "<unknown module>";
+      failures.push({
+        variable_module: vModuleName,
+        variable_name: v?._name ?? "<anonymous>",
+        cells: [...cellIds]
+      });
+    }
+  }
+
+  if (failures.length) throw JSON.stringify(failures);
+  return "pass";
+};
+const _8nkqnx = function _56(md){return(
+md`### Utilities`
+)};
+const _8vqia9 = function _importedModule(){return(
+async (v) => {
+  if (
+    // imported variable is observed
+    v._inputs.length == 1 && // always a single dependancy
+    v._inputs[0]._module !== v._module // bridging across modules
+  )
+    return v._inputs[0]._module;
+
+  // Import from API
+  // 'async () => runtime.module((await import("/@tomlarkworthy/exporter.js?v=4&resolutions=ab5a63c64de95b0d@298")).default)'
+  /*
+  if (
+    v._inputs.length == 0 &&
+    v._definition.toString().includes("runtime.module((await import")
+  ) {
+    debugger;
+    v._value = await v._definition();
+    return v._value;
+  }*/
+  if (
+    // imported variable unobserved and loaded by API
+    v._inputs.length == 2 && // always a single dependancy
+    v._inputs[1]._name == "@variable" // bridging across modules
+  ) {
+    if (v._inputs[0]._value) return v._inputs[0]._value;
+    else {
+      return;
+      //const module = await v._inputs[0]._definition();
+      //debugger;
+      //return module;
+    }
+  }
+
+  // The inline case for live notebook. Two compiler shapes, one probe object:
+  //   legacy    "async t => t.import(e.name, e.alias, await i)"
+  //   notebook-kit (new.observablehq.com)
+  //             "async (__variable) => { ... __variable._module._runtime.module(_.default) ... }"
+  if (
+    v._inputs.length == 1 &&
+    v._inputs[0]._name == "@variable" &&
+    v._definition.toString().includes("import(")
+  ) {
+    const rt = v._module?._runtime;
+    let captured = null;
+    const probe = {
+      import: (...args) => {
+        captured ??= args[2];
+      },
+      _outputs: [],
+      _module: {
+        _runtime: {
+          module: (...args) => {
+            const m = rt.module(...args);
+            captured ??= m;
+            return m;
+          }
+        }
+      }
+    };
+    try {
+      await v._definition(probe);
+      return captured;
+    } catch (err) {
+      if (v._definition.toString().includes("derive")) {
+        console.error("Subbing derrived module for original", v);
+        const derrived = await v._definition(v);
+        return derrived._source;
+      }
+      // never leave the caller hanging — cellMap degrades to "no source module"
+      console.error("Cannot sourceModule for ", v, err);
+      return captured;
+    }
+  }
+
+  return null;
+}
+)};
+const _n7jdgk = function _findModuleName(){return(
+(module, moduleMap, { unknown_id = Math.random() } = {}) => {
+  try {
+    const lookup = moduleMap.get(module);
+    if (lookup) return lookup.name;
+    return `<unknown ${unknown_id}>`;
+  } catch (e) {
+    debugger;
+    return "error";
+  }
+}
+)};
+const _1ii3nc0 = function _extractObservableNotebookNameFromSpecifier(){return(
+(specifier) => {
+  if (specifier == null) return null;
+  const s = String(specifier);
+  try {
+    const u = new URL(s, "https://api.observablehq.com/");
+    const p = u.pathname;
+    let m = p.match(/\/(@[^/]+\/[^/]+)\.js$/);
+    if (m) return m[1];
+    m = p.match(/\/(d\/[0-9a-f]+@\d+)\.js$/);
+    if (m) return m[1];
+    m = p.match(/\/(d\/[0-9a-f]+)\.js$/);
+    if (m) return m[1];
+    return null;
+  } catch {
+    return null;
+  }
+}
+)};
+const _ejsyo1 = function _moduleVarInfo(extractObservableNotebookNameFromSpecifier){return(
+async (v, moduleMapLike) => {
+  const mod = v?._value ?? null;
+  const nameFromMap =
+    mod && moduleMapLike?.get?.(mod)?.name ? moduleMapLike.get(mod).name : null;
+
+  const def = v?._definition;
+  const defSrc = typeof def?.toString === "function" ? def.toString() : "";
+  const m = defSrc.match(/\bimport\(\s*(['"])(.*?)\1\s*\)/);
+  const specifier = m?.[2] ?? null;
+  const nameFromSpecifier =
+    extractObservableNotebookNameFromSpecifier(specifier);
+
+  return {
+    module: mod,
+    name: nameFromMap ?? nameFromSpecifier ?? null,
+    specifier
+  };
+}
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
+  main.define("module d/57d79353bac56631@44", async () => runtime.module((await import("/d/57d79353bac56631@44.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
+  $def("_1t29kxm", null, ["md"], _1t29kxm);  
+  $def("_199r1h0", "viewof showBuiltins", ["Inputs"], _199r1h0);  
+  $def("_v3idap", "showBuiltins", ["Generators","viewof showBuiltins"], _v3idap);  
+  $def("_jqf42f", "viewof showAnon", ["Inputs"], _jqf42f);  
+  $def("_10za42b", "showAnon", ["Generators","viewof showAnon"], _10za42b);  
+  $def("_125g1nt", "viewof cellMapViz", ["hash","Plot","width","d3","filteredMap","edges","linkTo","isOnObservableCom"], _125g1nt);  
+  $def("_cjxin", "cellMapViz", ["Generators","viewof cellMapViz"], _cjxin);  
+  $def("_1nt2irf", "detailVizTitle", ["cellMapViz","linkTo","md"], _1nt2irf);  
+  $def("_1lxiffy", "viewof detailViz", ["Plot","width","nodes","variableToCell","modules","linkTo","isOnObservableCom"], _1lxiffy);  
+  $def("_j5pb2k", "detailViz", ["Generators","viewof detailViz"], _j5pb2k);  
+  $def("_glmq4i", null, ["md"], _glmq4i);  
+  $def("_izhsfx", null, ["Inputs","filteredMap"], _izhsfx);  
+  $def("_7t7pwf", null, ["md"], _7t7pwf);  
+  $def("_1xnzq7y", "viewof liveCellMap", ["keepalive","cellMapModule","Inputs","cellMap"], _1xnzq7y);  
+  $def("_14vvdt2", "liveCellMap", ["Generators","viewof liveCellMap"], _14vvdt2);  
+  $def("_193osz9", "maintain_live_cell_map", ["runtime_variables","viewof liveCellMap","cellMap","Event"], _193osz9);  
+  $def("_1vhxngh", "usage", ["md"], _1vhxngh);  
+  $def("_17c6bac", "cellMap", ["runtime","moduleMap","moduleVarInfo","importedModule","findModuleName","decompileImport"], _17c6bac);  
+  $def("_1clgb7s", "test_cellmap_importInfo_on_real_import", ["cellMap","expect"], _1clgb7s);  
+  $def("_yubgz5", null, ["md"], _yubgz5);  
+  $def("_71n0hz", "cellMapCompat", ["cellMap"], _71n0hz);  
+  $def("_x7j8bo", null, ["md"], _x7j8bo);  
+  $def("_1l7cvxn", "nodeToSymbol", ["variableToCell"], _1l7cvxn);  
+  $def("_y7kfs7", "focus_variables", ["cellMapViz","descendants","ascendants"], _y7kfs7);  
+  $def("_14ty3wh", "focus_cells", ["focus_variables","variableToCell"], _14ty3wh);  
+  $def("_12jpxa2", "descendents", ["d3","cellMapViz"], _12jpxa2);  
+  $def("_16z9f8f", "dedupeHierarchy", [], _16z9f8f);  
+  $def("_1j8atwc", "layout", ["d3","descendents"], _1j8atwc);  
+  $def("_eb858t", "clustered", ["dedupeHierarchy","layout"], _eb858t);  
+  $def("_17lllwm", "nodes", ["clustered"], _17lllwm);  
+  $def("_ng770d", null, ["md"], _ng770d);  
+  $def("_xpas1q", "runtimeMap", ["runtime_variables","liveCellMap"], _xpas1q);  
+  $def("_hishw1", "variableToCell", ["runtimeMap"], _hishw1);  
+  $def("_szpnyp", "filteredMap", ["runtimeMap","filter"], _szpnyp);  
+  $def("_1jdpo9p", "filter", ["showBuiltins","showAnon"], _1jdpo9p);  
+  $def("_10gdqhm", "edges", ["filteredMap","variableToCell","filter"], _10gdqhm);  
+  main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
+  main.define("isOnObservableCom", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
+  main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
+  main.define("runtime", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
+  main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
+  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  main.define("toObject", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("toObject", _));  
+  main.define("repositionSetElement", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("repositionSetElement", _));  
+  main.define("ascendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("ascendants", _));  
+  main.define("descendants", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("descendants", _));  
+  main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
+  $def("_qb7351", "viewof cellMapModule", ["thisModule"], _qb7351);  
+  $def("_120483s", "cellMapModule", ["Generators","viewof cellMapModule"], _120483s);  
+  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
+  $def("_2ufyg8", null, ["md"], _2ufyg8);  
+  $def("_18tubss", null, ["tests"], _18tubss);  
+  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
+  $def("_jrvq7q", "moduleLookup", ["modules"], _jrvq7q);  
+  $def("_rlmpw8", null, ["md"], _rlmpw8);  
+  $def("_519lii", null, ["Inputs","runtime_variables","cellMapModule","toObject","modules"], _519lii);  
+  $def("_pyrytd", "unreached_main_import", ["toObject","lookupVariable","cellMapModule"], _pyrytd);  
+  $def("_12euivr", "reached_main_import", ["runtime","lookupVariable","cellMapModule"], _12euivr);  
+  $def("_1x88m7u", "initial main_mutable", [], _1x88m7u);  
+  $def("_1c3nv1y", "mutable main_mutable", ["Mutable","initial main_mutable"], _1c3nv1y);  
+  $def("_kbdqj3", "main_mutable", ["mutable main_mutable"], _kbdqj3);  
+  $def("_1q0qa04", "test_importedModule", ["expect","modules","importedModule","reached_main_import","unreached_main_import"], _1q0qa04);  
+  $def("_1tqu9mu", "test_findModuleName", ["expect","findModuleName","importedModule","reached_main_import","modules","unreached_main_import"], _1tqu9mu);  
+  $def("_1mk5ruc", "test_cellmap_mutable", ["main_mutable","lookupVariable","cellMapModule","cellMap","modules","expect"], _1mk5ruc);  
+  $def("_rpm6xw", null, ["md"], _rpm6xw);  
+  $def("_1rtpyzk", "cellMapVizView", ["viewof cellMapViz"], _1rtpyzk);  
+  $def("_1srzrzc", null, ["md"], _1srzrzc);  
+  $def("_1hybsm8", "coverage_failures", ["runtime_variables","liveCellMap","modules"], _1hybsm8);  
+  $def("_1p0qclg", "test_cell_map_covers_all_runtime_variables", ["coverage_failures"], _1p0qclg);  
+  $def("_1a18z7a", "test_cell_map_no_variable_in_more_than_one_cell", ["runtime_variables","liveCellMap","modules"], _1a18z7a);  
+  $def("_8nkqnx", null, ["md"], _8nkqnx);  
+  $def("_8vqia9", "importedModule", [], _8vqia9);  
+  $def("_n7jdgk", "findModuleName", [], _n7jdgk);  
+  $def("_1ii3nc0", "extractObservableNotebookNameFromSpecifier", [], _1ii3nc0);  
+  $def("_ejsyo1", "moduleVarInfo", ["extractObservableNotebookNameFromSpecifier"], _ejsyo1);  
+  main.define("hash", ["module d/57d79353bac56631@44", "@variable"], (_, v) => v.import("hash", _));  
+  main.define("decompileImport", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompileImport", _));
+  return main;
+}</script>
+
+<script id="@tomlarkworthy/cells-to-clipboard" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _y5656o = function _1(md){return(
+md`# Save source to clipboard
+
+\`\`\`js
+import {cellsToClipboard} from '@tomlarkworthy/cells-to-clipboard'
+\`\`\`
+
+Fork of [@tophtucker/generate-copied-cells](https://observablehq.com/@tophtucker/generate-copied-cells) to expose just the raw function. It won't work unless its executing during event handling
+`
+)};
+const _11ad3zw = function _2(copyCellButton){return(
+copyCellButton(["x = Math.sin(now / 1000)", "y = Math.round(x * 10)"])
+)};
+const _22fbf0 = function _3(copyCellButton){return(
+copyCellButton([{type: "md", value: "# Hello"}, "now"])
+)};
+const _1sqtx83 = function _4(md){return(
+md`Once you click “Copy cells”, press Esc to focus the main page and then Cmd-V.`
+)};
+const _10uloef = function _5(md){return(
+md`---
+## Implementation`
+)};
+const _1seifpc = function _cellsToClipboard(makeCell){return(
+(cells) => {
+  function listener(e) {
+    e.clipboardData.setData("text/plain", cells.join("\n\n"));
+    e.clipboardData.setData(
+      "application/vnd.observablehq+json",
+      JSON.stringify(cells.map(makeCell))
+    );
+    e.preventDefault();
+  }
+  document.addEventListener("copy", listener);
+  document.execCommand("copy");
+  document.removeEventListener("copy", listener);
+}
+)};
+const _1i8jhrq = function _copyCellButton(Inputs,cellsToClipboard){return(
+(cells) =>
+  Inputs.button("Copy cells", { reduce: () => cellsToClipboard(cells) })
+)};
+const _1ud4fa1 = function _makeCell($0,defaultJS,defaultOther){return(
+value => {
+  const id = $0.value++;
+  if (typeof value === 'string') {
+    return {
+      ...defaultJS,
+      id,
+      value
+    };
+  } else if (typeof value === 'object') {
+    if (value.type === 'js')
+      return {
+        ...defaultJS,
+        id,
+        ...value
+      };
+    return {
+      ...defaultOther,
+      id,
+      ...value
+    };
+  } else {
+    throw new Error('Value must be string or object');
+  }
+}
+)};
+const _h1t91h = function _defaultJS(){return(
+{
+  id: 0,
+  value: "",
+  pinned: true,
+  mode: "js",
+  data: null,
+  name: null
+}
+)};
+const _but2s9 = function _defaultOther(){return(
+{
+  id: 0,
+  value: "",
+  pinned: false,
+  mode: "md",
+  data: null,
+  name: ""
+}
+)};
+const _lj7470 = function _id(){return(
+0
+)};
+const _1bwa5dj = (M, _) => new M(_);
+const _mshfha = _ => _.generator;
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  $def("_y5656o", null, ["md"], _y5656o);  
+  $def("_11ad3zw", null, ["copyCellButton"], _11ad3zw);  
+  $def("_22fbf0", null, ["copyCellButton"], _22fbf0);  
+  $def("_1sqtx83", null, ["md"], _1sqtx83);  
+  $def("_10uloef", null, ["md"], _10uloef);  
+  $def("_1seifpc", "cellsToClipboard", ["makeCell"], _1seifpc);  
+  $def("_1i8jhrq", "copyCellButton", ["Inputs","cellsToClipboard"], _1i8jhrq);  
+  $def("_1ud4fa1", "makeCell", ["mutable id","defaultJS","defaultOther"], _1ud4fa1);  
+  $def("_h1t91h", "defaultJS", [], _h1t91h);  
+  $def("_but2s9", "defaultOther", [], _but2s9);  
+  $def("_lj7470", "initial id", [], _lj7470);  
+  $def("_1bwa5dj", "mutable id", ["Mutable","initial id"], _1bwa5dj);  
+  $def("_mshfha", "id", ["mutable id"], _mshfha);
   return main;
 }</script>
 <script id="@tomlarkworthy/codemirror-6-v2/codemirror_javascript%405.js.gz" 
@@ -4394,15 +6109,19 @@ codemirror.EditorView.theme({
 const _12m5h41 = function _9(md){return(
 md`---`
 )};
-const _1d6o6ga = async function _codemirror(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('codemirror_javascript@5.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        console.log('Loading codemirror from', objectURL);
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1d6o6ga = async function _codemirror(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("codemirror_javascript@5.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    console.log("Loading codemirror from", objectURL);
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -4445,7 +6164,7 @@ export default function define(runtime, observer) {
   type="text/plain"
   data-mime="application/javascript"
 >
-const _tku1if = function _1(md){return(
+const _1s23l0m = function _1(md){return(
 md`# Command Palette
 
 Plugin-driven command palette. Press **Cmd+K** (Mac) or **Ctrl+K** to open, or pick **Command palette** from the lopepage-2 burger menu (registered on the shared \`"lp2-menu"\` plugin bus).
@@ -4456,7 +6175,7 @@ import {commandPaletteOverlay, commandPaletteStyles, commandPaletteKeybinding} f
 
 ## Registering a command provider
 
-A provider is a function \`(query: string) => Command[]\` where \`Command = {label, href, hint?, module?, badge?, snippet?, score?}\`. Providers run on every keystroke; results are merged and sorted by \`score\` (descending).
+A provider is a function \`(query: string) => Command[]\` where \`Command = {label, href?, action?, hint?, module?, badge?, snippet?, score?}\`. Providers run on every keystroke; results are merged and sorted by \`score\` (descending). A command with an \`action\` runs it instead of navigating — that is how a notebook exposes a *verb* (arm a tool, toggle a layer) rather than a destination.
 
 Providers register on the shared [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) set named \`"lopecode_commands"\` — no import of this notebook needed, so any notebook can extend the palette:
 
@@ -4624,7 +6343,7 @@ const _rmjyys = function _commandPaletteStyles(theme_assets,htl)
 }
 </style>`;
 };
-const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
+const _cvimez = function _commandPaletteOverlay(Node,invalidation)
 {
   let selectedIdx = 0;
   let results = [];
@@ -4659,6 +6378,17 @@ const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
     all.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
     return all.slice(0, 50);
   }
+  // A command either navigates (href) or runs (action). Providers that do something to the
+  // page rather than move within it need the latter.
+  function activate(r) {
+    if (!r)
+      return;
+    close();
+    if (typeof r.action === 'function')
+      r.action();
+    else
+      window.location.href = r.href || '#';
+  }
   function render() {
     resultsContainer.innerHTML = '';
     if (results.length === 0 && input.value.length > 0) {
@@ -4669,6 +6399,8 @@ const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
       const row = document.createElement('a');
       row.className = 'command-palette-result' + (i === selectedIdx ? ' selected' : '');
       row.href = r.href || '#';
+      if (typeof r.action === 'function')
+        row.dataset.commandAction = '';
       row.style.textDecoration = 'none';
       row.style.color = 'inherit';
       if (r.module) {
@@ -4695,8 +6427,7 @@ const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
       }
       row.addEventListener('click', e => {
         e.preventDefault();
-        close();
-        window.location.href = row.href;
+        activate(r);
       });
       resultsContainer.appendChild(row);
       if (r.snippet) {
@@ -4711,8 +6442,7 @@ const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
         }
         snippet.addEventListener('click', e => {
           e.preventDefault();
-          close();
-          window.location.href = row.href;
+          activate(r);
         });
         resultsContainer.appendChild(snippet);
       }
@@ -4731,11 +6461,7 @@ const _1q8grv4 = function _commandPaletteOverlay(Node,invalidation)
     input.blur();
   }
   function navigateToSelected() {
-    if (results[selectedIdx]) {
-      const r = results[selectedIdx];
-      close();
-      window.location.href = r.href || '#';
-    }
+    activate(results[selectedIdx]);
   }
   input.addEventListener('input', () => {
     results = search(input.value);
@@ -4950,10 +6676,10 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
   main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
   main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
-  $def("_tku1if", null, ["md"], _tku1if);  
+  $def("_1s23l0m", null, ["md"], _1s23l0m);  
   $def("_yavx6b", "searchIndex", ["liveCellMap","modules"], _yavx6b);  
   $def("_rmjyys", "commandPaletteStyles", ["theme_assets","htl"], _rmjyys);  
-  $def("_1q8grv4", "commandPaletteOverlay", ["Node","invalidation"], _1q8grv4);  
+  $def("_cvimez", "commandPaletteOverlay", ["Node","invalidation"], _cvimez);  
   $def("_1vuj6tn", "commandPaletteKeybinding", ["cellSearchPlugin","moduleFinderPlugin","command_provider_sync","commandPaletteOverlay","invalidation"], _1vuj6tn);  
   $def("_104tbig", "cellSearchPlugin", ["searchIndex","linkTo","plugins","invalidation"], _104tbig);  
   $def("_1opf5e1", "moduleFinderPlugin", ["currentModules","linkTo","plugins","invalidation"], _1opf5e1);  
@@ -6020,9 +7746,8 @@ function cellLinks(label, variables) {
 const _1opggh8 = async function _identity(lookupVariable,editorModule){return(
 (await lookupVariable("lookupVariable", editorModule))._definition
 )};
-const _1nfia2p = function _variableLink(identity,navHref,modules)
-{
-    return v => {
+const _15v1lje = function _variableLink(identity,modules,navHref){return(
+v => {
         if (v._type === 2 && v._inputs.length == 1) {
             // Implicit variable created on reference, go up one
             v = v._inputs[0];
@@ -6034,9 +7759,13 @@ const _1nfia2p = function _variableLink(identity,navHref,modules)
                 v = v._inputs[0];
             }
         }
-        return navHref(`${ modules.get(v._module).name }${ typeof v._name == 'string' ? `#${ v._name }` : '' }`);
-    };
-};
+        // A module the registry never saw — a cloned dataflow, a module minted at runtime,
+        // any module on observablehq.com — has no page to link to. Link to the cell alone
+        // rather than throwing, which used to take the whole editor panel down with it.
+        const entry = modules.get(v._module);
+        return navHref(`${ entry ? entry.name : '' }${ typeof v._name == 'string' ? `#${ v._name }` : '' }`);
+    }
+)};
 const _1tm2n0w = function _31(md){return(
 md`Save edits by exporting to a single file`
 )};
@@ -7596,7 +9325,7 @@ export default function define(runtime, observer) {
   $def("_1t4gep6", "nav", ["html","cellLinks"], _1t4gep6);  
   $def("_1tv9qxo", "cellLinks", ["html","variableLink"], _1tv9qxo);  
   $def("_1opggh8", "identity", ["lookupVariable","editorModule"], _1opggh8);  
-  $def("_1nfia2p", "variableLink", ["identity","navHref","modules"], _1nfia2p);  
+  $def("_15v1lje", "variableLink", ["identity","modules","navHref"], _15v1lje);  
   $def("_1tm2n0w", null, ["md"], _1tm2n0w);  
   $def("_16wblye", null, ["md"], _16wblye);  
   $def("_1jdvxd9", null, ["md"], _1jdvxd9);  
@@ -7740,55 +9469,6 @@ export default function define(runtime, observer) {
   $def("_y040tx", "persist_attach_menu", ["viewof options","attachContextManu","Event"], _y040tx);  
   $def("_1jn7thk", "moveCellBeside", ["viewof command"], _1jn7thk);  
   $def("_2rhl00", "dragReorder", ["divToVar","runtime","moveCellBeside","findCell"], _2rhl00);
-  return main;
-}</script>
-<script id="@tomlarkworthy/escodegen/escodegen.browser.min.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICLP7DWcCA2VzY29kZWdlbi5icm93c2VyLm1pbi5qcwDsvQl3G7mxKPxXqJw8NXvYotncSanNy3XiZLbYM5nkysy83ki2RJEySdlWJL7f/tUCoNELKWkyuTf3fvY5hgg0lkKhUKgqFIDi7G7l76L1quiZD/J3wS16VmA+RLPiw768cLfff1r9sFnfhpvdfdl3l8uiC3/8RWh5prkJd3cbKMIpl970/KO7KYSOW96E2/XyYwg1n0NNJ6G5W2zWnwqr8FNhvNmsN0Vj4kbLMCjs1gWRt3CzDu6WYcEoQSGsx3ceoqDrWZvww120CbuuNYMiK/cmhMTw8+16s9t2H/bWcu0GYdA9sa1bdxOudt3A8hfRMoDf3cvp/jw4PQ3KMqV8e7ddFH1uYeZ45e0y8sNixfLKS3e7e7MKws/fz4rGK8Ms2eZ5poeOXxZNWyHjI07wrfj3DPADUYbNOalYeVXs3TJ3eutAP0QO/imQ4uhjxMAcHBZRFTTcUxForvtxHQWFClYahLNopddp+eaDntfx9wL1Ko8r2y24DmDFethFu2XYNTwYz224MayP4WYLGbvGR7tarlbLdtWwxMcu9DtcfcRBcjfzjzAa1ir8vPsx8q+7gPlw9+bmJgwidxc+PuoNwpcfo5twfbcrulbF3Fv+p6CrMsQAwYdFEG26OpJcx9vv90XzXHYXxnK3Xi+3r4A0Nvdnt+totStfbQ1LlfKtwAqtmflworVh3G3Dwna3ifydce6Vw62/DsJ5uHJcqFDFqCLftOIE0XUYcgBib1oaGMlSqi0g13Tz15Dwe+uP1o/W0lpZE6tv/WS5Fes7y7WtCGjrL5Zbtf5kuTVra/1sDayhdW+5dcttWB+tkfW19Vfre2tj/c36T+sHa2792XKb1i/WjfUP6xvLbVluO9W9ePIvtPG+LY8/3wId4uimSA6obXd/G5r7uGQnUfLdDgb1BjD+dEFXDehDBLMP5u/qbrm0PHcb8i+Y1fKnv77BSnGuz9abG3fXlWUetrt7JMsC/DO4MMy54Opuu/v2brmLljAEQ1V6D3T4CZO6xvuVYW1vXR/LGtbVFigZagdOcXfjIQXb1iL8DJPYj27cJUY/3K134bZrbKPVfBkaOPTubQjzZ4tfAUKobBdzo0W4hdwwEbbhTeSvl+sVx9wZwLPyAU0rFxFBJQDb4eZjOFi6q+tvALwtwXqz/kf3ASvehItwhcMRDwwgGhjJz9Fu0Yf4fCXRs4V0hOnrcBVu3N16QzVt13cbP/zWvWV0qujb9XqXSsIqh0CuWBnMsRBG6yNFNu4n7ABMew8Av9GLUX6M7+Px/QNwGaAM5ioG0Bowf/fRqZy7r/H/69eObXklxzPdU/v0tOjjT8l2fY1Mopi+Xl2+37xfTV/NyzAQwCI0atohC8C2gA2UYbGY7xaKh5+eLss4AcvRFnH7Y7i5iVaImqIHy4O7Qej7UN2Zber06QF/kJUy9IVoVfBML0PaJsJ/6U4dD4K8TrzltVXFQ23O4LRYzwBuxzHW3hXg2zg9xaZgJFc+fvqeUk9PT4qJ5LfhHMjB3BOAlh+DGJhBPohOAPBZIayCPVihEdbeW/oLnKyLf523sPiriK+64mlouYLihBRYiy1Ymq0AV3r/xIH8mcX+u7ubEFhNYRntgBqXhU+LNbCfj+7yLixE28J37ncGCQr+ReXx0QcUVE5P7VcQe3FVq3DuIqWK+qAq+1VFCir9noHUaXR/6hl2WK9UjC78LeEPzO0BfZZ86+Snx0dJPBc1WdY7D4GkIikflA3TOumfniZIp2JCe/X26WmI7QKqQwcECyVkAF1ZQJeUsglvl8B0ikZYMiwDwLVmkLcYgOyk2oBU8zVgojhzSq6oIwCpBCpxldwSQKXha4eynUE6w30WntmQrVSMM4amqiSESsySAY0GMBE/gWgUolinzQFRTSmAyUB9Ms/OAkkGwYkj2wsysMzER7fkQAdKM9NStV1IrD4+upDFf22HdvX09Ft3tyjPlmsYXR8b87G0Y1Q+w2CUd+t3sEit5kW7aZrpeoCaS64o4TmuaekE6oPsoISmont6VsXK29VatVf0esYdjP3793cg5hVdmW5UK9U2pMOfjmF2Md0GgqS/NSpFhWQZuwL0BCkbyMtQlmeb9c1Q4DHBmNzrYsDzZQ6zZQFzJrI8mDU+Ep7rBHFHYVDKzE5JCp8DfmGh8xfFV+9fFS///mr6lfn7V0B8cyV+05RfOPNLewrDYYBo4eBKhAESYOTICiVHDC+i81IpNL34izb4IQiuPRw/QCFKiFST2S3Oeh50ulMjgsQUjNZbPRxpQApFOzZ/rQCR6hXQt6pkJCBHltwShou9kuViVIEwa0nmorg3jlEP2vEMHpcqRmYc6eDvndFFIkhQDER+ugXWNwR5ABDbh7F8XW00ejTyJaMC/wxBvYqmSh7VCQR6otaLES//o2ge7ZBtQvmKgMPGyOfKgCjjM1WaU6VOCTfI9WnUCScCJe/hn3Euku1KnLyKU2tx6kalIuXG6XdEwtq3WvJbxzjPsNQ3K3+9wRV+eV/wQQvaRrMIVDMkCRBlQMbXoV9JOnaBhmFlJOLznO9w3QrWdx6IRD3jd0b3d8bvgBiB7QCNCbJzL0IgO+48LEIJhoNE4ji1jvkAXPh3IHFvQvd6L1h4rY7JUKNI9glzMPlLrqQfrxSU9Nm/lmAiUwc4adbRZKigsE1Q+/B7HoPnX8wBPF+MTQI8H3kugVcqwfRZwoojMAyglUpRIqneOj3tmx7PCvXlkOzhmsxggBIeoAxRx7m/Xu2i1V24l6VjUnyD4i4O0OYHkPzG7xq8qMNS5F7Uqo+PJ0WkchvTOMF9bVeBd3LtOLWSPcOlIG4P8hzgZABE6JwU9XF+fKSYe7dbg6wSXSxwEQt7ME5dGELrpBj2Ft1ImQlmJa/EiA9oEQTmlz8AWeQzqjuwsDKyanWYnSH2UaDZtA5CroSX0kyjj0AnY2BSSjTNJ1mPZSaQTvubjXsP40B/i6hrBxB2vRxx74pFXxy+gRJBDhVn4kHxxERRRJfw/qjJIEgPrvOwjy0Ty7XP5Xo4pf9YJHmcggF0zC2jweTxkSrucg4qU0YNYVdGJcjSE0BFubtZWQPA8kmlJ77QGsGVdDO1xh2+i3XzWW+GClX8bYFqNqM8pNmoMBY6KEvqC6BcqJAN9y6DaRdWwSsYMD3PPJHHhzyuk1zGpCgEApPnzJNyGlNUvcbkVG8AKeEP7/HxiYl25LMnZjLOf4+YeAMAs+5wRZ92VcGfFyC5vkONk+b+Mb6QV8Y7UgbICRqExiAEgXyq6zGfYl3jcmW50/jLWulM566zslYlZ2J5xZVprRx9Vb4tJrUgpWCd2aDHgRx5duaaRxhdUskChkS8XM1OVdmZ3uiH4jVaRljPwKk6t9BcsrAise5cl7e3oAqAcAQq4aNQDHEx+Y709/K3/b/+8pf+Nz+NgYGjOORlFqM5qWuaJBxcSNrShlsbgQQpgcgLC0Bw7r8OWLUClANgKAWz3a0HktnK8kA2AyJFdvmVgSISsK2CgSiegWTlo+p7dgb9clbmIUAjmAKfSE0T4oUPTVukoQ16UflqHa2KINJ3I4nSlbOwPJEOUoRGC2MWsJDlkDkGwcLRMnD8UPondUoybuMVimucRgxIrqt6umjz/vGRWfIKWbJcnLdlttaU2VhTzrfLnJ6CYr96v5m+Enq9AKMHVGC8+kq1VTK+eoVGt24mUSMcQI80OwRANJ51a32wbqwlmc/WQEAba2uFpCMCot0AmIoAYwuaSTpJjMXrCiHt1nGte1DjiQAzeS8rKIVfTkHU8Mrh510IfQ7euqs5iB2o+NGvhTMsb++8LXOzCMvMIADW5xQXSt5fvZrDbL+cSsUHFD2gJ5dt2H+gUQW1Dm2MlPKpOIY5Cv+6Ms9CfeMv1hpW3QDoa+4c6uM5kP95UCqZeV0LplofNok+rFH7UH3YHO7Dk+AjkOfbROUzrDyCgCrfvqBylqCeGqo/4ZiLmXBd/mGznm/cG0zz1sG9ttDAKsENMIHruLV2xStga9oShcuBnvsZeAdOcgjvS+cS25lSO8tUO8scqD5BLrSCi8itSTIcdHPj4qxTleOcv6dW018QPf+GRHyuhvSDc5LFunXjQK0Fw4IV66qIa501mSZykNmDhiLd47yxyGAFBuNDD2RYFDyAerD6Lv29mWqAWjfYB0oXXYI1BlaF+Rnw+hywyegBmREfsfFQWwvf8D6FlFo9WK94HfZhiQjOXZiyQ1wMHOK+IIKUSiIDrM8XHmUIGbxIWws+oJkEVwO5EF/4vUujCOizDNOAnmlMdRYLzbHmFyRWYBhuXsF8fQXzqXVaq6LSqoQ/8myKm1hGRKBmsfLvX27L0uIMU0CzlTL1GT3PgZ7MUJEMy+/CD3chyM5QGdkEcJ1DFQeGD1UUGCTQdsMAs5yw6KwndbUKsFY006Bl64qMGTG4tyDtxrHPmi0XxpYEZEu3AH2r26NAbne39yu/Z9Afo1T0eiAodkEaMLRl7J1uzp5LUz7QD7DA9T/KGSO/QlgPxIzSLFGXO5cWW0AnL5oWKsfnSYhYp0JgT/wybjrc7cKApqfWPmZ5Bx3GZrqGkTS8bYuuNN6QURWVjluLNoiUIiMrC9VGETR4QzZb2oPKZoy3PCCnNkJzM2vQ+Gl1vVp/AgkIZDQyrHcLKCikd552uM/GoC4c3Ieyrqy50koEZRQFsYVCeNFoDvCwSEk2tAvlyLympQrjjhQW5W2lvKKUgzMiB31bBE5pWhNIymkiW7GcBytRR3cFbHBihTmtIG8NQTg8VPexklY/LoSbZdZPcVxumlluxen3Tuyu+qJtoVnfwTdpQYhz8K6a5dpxdfHGGqxCKlVs3KGlQSbR9l0Mr9iCAxRHzsyZOCsHKfQvcX5tY85yq1o9aofO+pOWmt6ps9wafFV7YtbP0CHSjMMybVWC7hyW1T6aNVQxVBmsew2OzHbf6enwhJV5a+tARahSyB3l3h9xI0FWW35Hv77DHbc/0p40EvsvYiv/Fec7u3FvtZ+07QxadFwUKN6B+XptWoMe6thqQcLdv3eyreIDOl7gWMEfsdVHO4ZaNzG+R94ru0rc9vR0XsaGt+HunZ5e1BGUKhNXou1C9uZdrklbMdEq8IDqWfdKNwzciN3N/cF6sIy5/zGLNdA6Ni76M4TaT4E1EMBy8t+BBrN9tYy8V/RL5r12fiy/u1/t3M8wkx8kr+pWrL9F4TLo2pa2WWtb0PEgQspyl92q1Qce9mkimBTEh2sX2oLSNeub9Tzy3eX3b7t1+bv/3ajbsAbR7lO0DeFDU/7+K0RaMoK52tb4w50LK/V9t2O9DZeuaNGuyFzv/vBm8mPXBugChOdj2LWrFmlpsMD7LqfULODE6xUaP3jf2q5b/U9uBB1pWD+t3M09/vhhvd3Nos9du2l9f8sNDRdutIIh6tota+jCdLHb1nfhp67dsX505/Mw+DG8uQWowm61Yn0b0u571bZ+2ADXgEqr1b31e+fB6PWQa0ikWMbjI8YVZixgrVoCdByyYIJCkWX8XYv/lYpoCVQC+CmkSHxZxkkq7mQzJBOibTK22iWyX2DmeAws43U64cLJZMmkRKtsijQaZuq70PpIAw01vs5Ly0ksYZIkCss4S0a/wmiSTCzj/+QlvspL/IrKJ4lqb30EEXLkVK2vnbr1V6dtfe8AKW2cWtX6m9OsW//pjB6/tn5wPj6OQJCHEGJ/dj5abtP52voFEr4GNeCj9Q/4tbG+AWnfbcHP7y23DX/+at0C713v1riIAle594AFr/1rzelJ7j8FIIaGzm4RbZW86oDwJfxQHh9P3LSuZrmxIkm1KgkHRPLe5czCynLFH98EaTsuPL653d0nChvnRre4LmpOSoFzGYF6ER6oz5wCSw7M/YH+vrubwRx1ND8oKbg5Wf1E2bcPd++kqDCTY0MBDecEEOBas2mX/q6mXQgj+JsEUPblB3e3CzcrfVR0RUVDVWyL7aEY3k2gOCE4kgSf25rkuD+4oPpvE/5v5LtiISksUEBd4Maq1nqCYcetQXfJjQ8FkRPyAnOB8rdoFJC/NcuCSaYFajtOteNE0Kvz+gsa6iXJ6hXT+lzUMptTNtWxjvY0tD2uxgYavJxanrAnFA3hwEbgotBKW7u4b4OeCgl4z33QQnH7ZoFQyzKX/rQnakuMSrwAxlD7UytREPisAYt4nBWEfbObV5sglURV6YKWX7IvAvTY4L5Z6JxwroYo1ZtUPoWRchk9P0QMMY7FyRArMpiGqfYkj1PaYB3cJ/w7pQeP0noTfUwSKOSHJp+mQWlEmSkjiuG8NgjeMB58LZfvHJo9HlnD0ni1NB8Nkyzj0hHGeDDIJE7WBJ+sCQoIH20j2kDGTEk247ZR6czH4Bt0/cGeTtYbxX8czaHSsyKp6l5ChS7KJz0D5gIo2qBmlwxKMUDZxjSzNCsBjFPRd4n/BKdFY8ZsFyP8L+4mckGFGYX+0mVgeokConei3DUoUaW7Ymzm8nNYtsgbxFWSCe4b09wrbPn5I4MFYWRQriJad50F7vTij0v8daDYJpovdtmZgkO1V6AeGKDo8PhIf7M/hff66qJsGZex9Se2qF4ayRZzAPazoGoVTI2DAMWFnITXL24MxGYbvfILD+fOo/PRtD4UL48BRDh3TWtWmpdSq7uWM0iC7popBuWlliWli+Z4Yp+4Vej16Ybckc4NLBjPgofkqtzVVs+ZtpTBrHwwrGiakm5SJJwxf9/TjHaFAdi/tKdnPtDo6yraL4OEPRjTSzbnsUEMgaiyTRa5/alim4HJHvlza2EtrWsyLV47N9bs9K+Q+/rR+d4EOa9iLZwEUOfziwWsOXMT4Zo7wvOMcuCCmdnYIdgPfMWkpKU72x/qzaG+IPkeqPvx8U1RII32HFQ+lYQ7CHN09juR8M/P7GnG+IzSA3+d5shXbxJluW5bNTdPNwddWKA1GvG7Ma2DNcOw95ZOrpApi1jXZnfpHJBEtUxqwJdm7kZGEQYSxvTM7slSJTsHm560Y3fVL9PCoqpLcWeyKHxTTGOEkKR+eshwJaCfisae1su9NcAN69yZpdt1l64XLnsG7W6T2ZESyB5cIu6gpjY6fnA+I/tlj2YBcsp5bovSiecZjcqs+e2iCxgKJ9q5CmWWV3zj4Fq5kJqT9PWp0JaRPmuDixltr2Q2ePzDcgduuyTMvjANQaCbKf4f4aAd2YSLVCurWBba85pBXdaW8rye64LZpUF+cgZKylFAWze4yh6WnKIgBTzS1/YOXROxIuJMAA7zn61xpKa4ENRI9hZtwfdjAWOWv5rq0gYt4//gZXwkzZlPUNsWpsknxDn86VGYQ18uSuLKQGrmEdlo/TM6W+S05llqmwIwEqwFMrICyE2slApROa3aKlnStBA7lwY5eBgs7h3BMbofJMcLRaJ0N0Bfx9mC25wwHnfbUMeY9D48JlPSNDkXikeP1hEfa5MA5s4GkT0LHrKw+Z27CWglPlCWMqTKerSB54fFqlWxjEI0K6ANEzUtBdA05ofpwXDVYCCLHIXe3XwebnLHVQkwRiCyZXDqAkaTho9cMiSpZ0yH6EasLx6YvH7MtvjMHaAp9mN3fBCi/tG9EbPHELon8oQOkIEmiJu9nBmuzyUtLyKv+xRD0POnhNosndEM5e5+Bxw9eElnrWWCAOM+J2DovahzyIZuQ58sEMi79KjulifQ+kAEDay2q2dMWDS4cwMktncyR+8pHCbqSvHXblE1blrarItlYN4cV2sD2zRyeqLsGhnGunwSLD+zZgkjhBsbF16wbpWEKCL2NQSCLg30eDWOKB+yQGri5/CzhFKeIEHTorlJ49RfLnNJUJuhigQBLNqLtp6E0n0WlJ45JTDi829pPuEnzljNYrdFtacsz6s0TLTb81KO+5Xk1Kg59zXY7duu1vJ9MY/7b5q68+thINoEhMyaC0eb4ahXDoNB36vPBCeS4PiWy+e20jhhrwSxC39inydc0HVv1CS6zLgEu540aU4pP5CAPRmfU1nGQxR7GCB2JKyu5ZbykOcnkYeZ6HDBIfT5Jp85O4Y+mADigJ12IuWwWUCzrSWpGQRGJzXTrewRMiK4Gbn6LiiM2Lm4dnoanH6PtvW4/piHfsMn4k5PhW9AIhf5e+h+Aq4Te/mkV5yAdiLyGEHAa9GbG156nxCYU2vPoWXi0oioPsP6Z1kYAo5uVLLCKbH1FEvW7Og3mgSh1h0lzl8+a+lJ8/ipaeFqkW4VRfyThAuhZZhPgYarPXk3pBfFy5n1K4FTbnWwJD+kIJA+2HRsslc8rkk8f82LG9yjLd1MbGKl1MV40QNJhRTH7IJ8UH18ekF+Son8FQsy9kgpYL/VWhwgGeGCm7Yzrzfd7C6lB0Ldx968+5+xL1e0ina9y8NLbRSk7Y8w+XC/5dj6jJWmi027B3Zisi1ke5PgHL610Nbtq2LsYZ22iGvbjF7aOKTINuUMm2eZ8kjPiaeEbqA/nN+aO7Z1nQIrNkhek0EyA/b8uWATBb4MbrFH9STkYgmbW9eWh76kCe4MbNOnfQo8C7EAerrpfmPldvK13VsXr8wuDJGVv0wseJn4ER3zjmtylwA9+e8ZR+jO3czviIZSczdPNPxxc5+rfM7iVSlgx39cJ3ab+1z7Av4FnRbdww9aFigPHjouL9xVsAT2YspThSj0yMSMGnFckZTFkI+iUg1JMxBCltE/wg3IKSUbFpGAvYUPQaZVIe0fZrwbjEdLyAwQBn8QGdE9WyhA4YvADX81lGECOJJABdgoHqZOyalPeQj+dfj959GbwW7heS2zqSRu9TltqYbU1nKqvFh7MG2ZS9EqO1I1z853nyJUt/MUqJWcLOT0AOxCCHIwNMkdIphCW6pG2qyW+fJwEG39TYTS9CrPskaySClCM5Nf9t1tyFMJd4A82vURqXKsPdr28UwvtYUROJ8OmTtFDZceb0O4ct+JVvrg0EofL6iJzQCFPTxYriPuViJuRhx2lZKAE8gjWiZbY492aQ0E8CAGszZJQF3XoKMH0nDVRYM0zQ503V5tKe9OnrsIUHGIkxP2l7QrT3HmLHUCShUEItLszJ6DRyxx4hw42RALTivnBgYvUIMX4ODdniIRr2gEZzCCy/zhiwGAMVwlLN0ez1vR/OxQ83tWXma5C8SVvkBER3ZFUb2YSXqPXmJBJncs5+p0A8z2xqIDg9Rpr+wuUWqCWpQckJ3CMQKIhRxmGlpGN1G5pl7EOFBWJOJhxmH+paqx2FJExXDTYolkm4VXz28e8/fQ4BW2Tt2vI1+1PD4+5OkhnDo8loX5z3EHjqO+GST8fqNJXQc2q4SQrIb+P2NKNc6NGA8YsZhSclQt/7l0dbTyu9tAp6knq+f8hxow9QbQz+kpF5GATc1qTN+snthdStBerpdPEb1e8fS4qJrq/X72G9S7niXr/QZ3UMPgCfE1sdMK/Ng6sD8i6wUJVRwv1Ol6Ls1xeJVSvHOa2DUFmr/80+lp8LrSQ9Wmaxh4GBOvc8PLtIRp7eRPfJCd+GpxRtzlniQE9o3wjnkoeJp/AOdzNZcBmprsoSC/5nsoxGXzPBT0svGOe35z4eHlXJUAwR6FBtZ88NYZsq/TOhCmD9jd92SxXK8CX3kV+AmvghihMZx5XgXpXlDH1E9f86EFqhWD/6QdXXp3xkZO6x1ZfO9I+4oCdHmFP3hwzMp1GMStfCgBlPeWqnzSn0CqWz0USsSG22+inXUvZXWlPNXt8I7wc/l+Yn/Xf+nS/AJmRudj/ilIoYInAOVb4P5ZUPeW6xU1zzLdWcy09Dse44MqcVpXc6qcW4v4Jga+Zy6G7WKO3sHkL+fhiWq8RwXv+IlN0Fv9OCjdqXLcqJgoSxfW6dYksjDAXPfTDr0C4XhsM4G5vXbmJq9/Sefyw77K5GnpCs9Jt4yOjmiVE57lB/xwDzXzoXhsxmKP9fos4RUkDwvl1Q+1JzwatewX/nNcGtUEUUdsyLfR6B03amoyXMrREQt3jxeOJcUcJ0mtB4RicbInH7l+gpHJwcF9j16PfPUenb8JzjSI0HkmcTrAJwynP+j1R/FtJFegFuNdJPN4a/33l3GbUzxal4Dgq6+MXliWJ6MC6zrne9ANSrYVXES8en885o8taPEKQOLD7PrlONqW0jy+CEfcTnPsjhsFUnJXyuzBtObLbLQ+dj0H7/WJU47Dy5MGb3Sxkl1/ZdAFDAf8yF8ZqJEruHj3j3tjXKRLyn3MGn0+OTszekVPM+96sQM6Ak/30yWBidCr86Q4O/1o8kl4j0/CF5PZHh8TYGHS6akBYsbs9G+JcsiKQKMkX6FlLt3ShTbxuXfhmnBsfxGvfA5D6X38A0wUHyDhWRJvZvTKsQWcznII48ClIdfsrTGNbSqslj/lg50ojKp41ic74+MwSxtSUH2wotNR7wOd5qZeLMyudvEAYAsPDOYvRSSvhOX00cILl6f4SF4g/py1xcrWY3naOuLnZcCtme/CT/nQLXVbggc845rvIg3y8A5s4Or0ayC4vwAh03boL90/026SsQqPWMWDmAYAELJpnRShJpAM/wKiLF5Vo+2nqdGPHB9GOnrOSAfPG+koPdJu9iQMjzLCuQTE8eHO/NVrlu9veXjtUFIS0VAAJPVD98+4z64uL8D5/8TceMbZAw9FKDrVkLhgAtqbd3/RlOQpKsnFE71JCeThrXqVQ23Tx/cE+BmHAT9xDe0FqmSvLgHWv8qbk3z9orLk3ZWJi/XihQEP56n4a6dKpsLMxbaxLQ0vr1J9jvvaQ7R2DQ21nzXE4d4ZUwJTAKwDSAw7V54XSa7kQeoKUJIrpdAobgAp30DxhFsDpXRRJ8If2sEs7dyWKi0hS9YgU6mWGHiLZUoBO4oiPx0SFALrJrahEweIqdk7wpU0VUq69oKOD8AZZKULNHGTPNwuA03eiH/LcawK2x5mvs6SERCiNsbX2n15eOtPajXWrs7zxdV5vrw6D39ER6/O849fnReZvbw9WC+2N3kx8TBm0ERDp+kPScFBxuMqCJd4OzT6zRn3WPQrvMOVfxpoJxXYf4Y/tzZQBAS7dDN8nEDaAJ4yOySoqvtJF6hDL2Hu0KE0vFCFT6c9T+WmNrD5pObDyUSkZNN7WhehK3BAMoUlWRNjnweEJNap+g0kd0TJSBQWEjHSui4+xx9QKD+uU2nYzDGYTDW3iEBJg8qKkjjOGbHns55llvR9PqCskfsz7VcKF4ijqiVlTJ9MRrBFHflS4rW1lDo4yYkJE4NfBvLWb7FCj/IFesRlvrzGu8EvYdWzvF5EhkTNPnEtbsSxrsS90hXQZDJVnC8urkCIWJjxl8vFVM1ir3dN9wLJbbYDXnJxyYxsgV7Garm5Nq1FyQYuc5Vwn6LUi0QaXqQUdWd8gufJ7SgF7UqHlk8Sml3jcmqg0Wy7Gy+zBrN4SOlQcOmAG4wkdHmwJp9dBbH8/7/6mAms9ot1MMIXUaK0zVNdbuZpOLiEddndRb4xRQVURkp4hwCZmchjBVfIebgjfUzGtxDv+XT6ldKSfdVOqOL38B5f34kvuzoy0cWllNMu1O3O0Urz/IqfU6/FOiltE2SEoiS/Ptr1S9Ft1Nh/WwhhSd4u1psd+ib0RKq6RjSexGIKGD1meOl0WV+SYLvPB7VLEh5QU+9fMg7dyxfUd9zAFfc0weJAxeUnPfJZAjB76RqJC9wi5Uor5NIojNk9bhhlkoHXJ4zPwACOqjdQMnOaAretgcCiYuqiZpDasgvHDBYO4V2FJwVR9AXZ1NSVUXZxmzk2rCw5IJ/PaG2ZmTH3l66eT4I+yzh4zjJLxK8/KYgWigf0kcT7lSFpCovEw97QbcvPWf2fNiyjJyazASaRTK0+Xmgrlww8M41ryI3y0jnxs2iV1/kCwHwxHz4Skc2Gvr8mepAkCSJI3I9KcwHfVYtn/0nyZhI6GA0CTXxbJ0oSSyenRZAlliRLAFSphhcHGj4JYh6EbwOcVMTTANra+ZAr3lzJSbVQx1MXuUAF5GOkvIy93pUuI9zkSzQa6PmuxovfXFgRR1h/hJF/Usg3kD6AXN/h6n4oDy39kCkey0PE/JnO6+V70R8pA2IKzrXl2neXqnzW1b2bfKAtPtz2Fbk5+VSNz9Vk75OYlQx3a+CdG6XPdD+vOraQ04B4/401iKDMpwfCALfcPdraxw2tINmUi03hNyB8zoRGE6nD6q2jcuDLs1NPt06tpJvm01Rh8KtbFyanAyYWugo89ViUsXE/oT3759NTOvVr7jb3D8Q4fqbLDD6ZyplAs6Z6OVYuT9m15PKqZBioZk9nTPF6i32cHM7Dzz16J4Z/l2+ZA5b0tNnSnW+7ypqjjGdeNI9WOyMWTtSEKuGDPW6ZM/TkD5Eqy9O9n+KlqGzlyk60VsJCTi5hv+u5V8dyeev1MnRXCtKesdvchSBNzFx0quq616r03lK3vD5z+3KY/2KcugXrwHddBllaN7EnaAQEc5VyGddGOwc82gbBXf9LA73f8craFzxjR9rKCy8jiq8XsoSHNig9Ga/LgAzhMkPM8CNi+L5zdaBFyp5h7FbwuvL4+OLu9aQupa724VsnZhHuhiplj30Nj9/LxEVSUEm3vvjyJfPlY/D4+CvGIK0jPkEkAFtXXt6ToEnyaXjKqPf0tUwuclJ1C1NWIXrGBUzoZXsYC8nLl0T/vfJ61kOnsi5uKMrUw5XIq5gSEoPuyaj2xd5BKTc4bpK4JJvEMy2IKaUkeRvnIXuFPE/h/HA+Ox0BnbjOn+W22zHnAneu3Zl0ON+HO3cboQ2Qr/+03KY5Te7JJcGkaw4VzEdxIxkwrT2qTGZ9PLQpa/xfzcuawNy+dAtVFOMtNdlDbedUKUq/f9AP9jznuKmo9OD5OzOzE/t/eeZ9S3faPim+EQwCV2olYbnqOe4u8mRm0XjOMfAkX6E7LgTteGaeY1Nci5l7DZjm65QQg5TdSbsagq9MfHyMtQ4rvoIeha+UtBR/NHvuhhl7kfd6YMUQzehHwPBaxpA2Z/hqeTzdkQt1zg13+bfSUFvMbKeUJdGci81RM5afcwY5+/oF+pJGtPkkdwOTe4bxDViuM+hRjeJVy7fIy4qv3m9Lv39l4Zs0vnrvMk7EXrtk23frTvoZX/mE7157ibeSfIm3ol7ipQfIEu/wVuJ3eCvJd3jtxDu8NjTeoKvfxZ3coBCL96zptmeo4tqdh3TTOV2dLT5qLnsOFQLh1PUX0hnU+TGVADl+UO8L8Ouq+Mpi/Fg0auKT799+2//xl2/ffPdm8jfHrcdJo/Gk/9M3P75z3EbmUekkiMmJh1TiysfGnQd6Ot1Qr1BDh0I8lUN7t11jPPy2/46iBcxQUNf9G9ZifRPeQiNdY7Hb3XZfvZqDkHBHO+x4UTa/rh1Xe+NGK60duhTbg6SHcCux1jXKryDpVZxCuVSZ+LtWyZ4egN+CPPnNm+H4u3fj8uDdCNTot+P+6Ntx+SaA3x66h6faNhI4msYvllfLdrkCra7m9NbyA17u3TVeO01I3VM3dvAfcncvBfL+dre9uw4L7+7+cXcdQUnIs+wadzBD3RXoGaH7H3NMQswY1qfQy8PYEEhvFy75bmZjPwUSv11vI8D0ffeBXisw5rj9d7dZPgvhZcy9h8G8xbvrVn6EXYnvL+8af2+Uq9RPvq4cEiBarmLCLS4+kFCHBBsqkRv5o0RlRnyHPIgz/69SblLmIPyYzOf66w2g9e9tqK0OYw6LrBdtAkiplevlFg7P+lO4OQPtLdriY+z+MoLpAXX+HQYCQQQuExE4BLCB0bPws7+8C1ArknAbyNXWq6vtWQhdvP+0CDf0uVLuYCvzu+Wt6BNmxuhZuF1G3FKTW+LkmzU0gaktznwTraIbgI0gqpYbhsQIHrzmBmwDWQi0S6WgY4AJ9DlbIaqBIM+qZ3wdFOSj6QSIQa+MLrVYwGGJkCjvVtHuDD8Y8gv+thBMkUAQA3WAioh182sWNPYijanbu4uWwdkN3gYOsyZxQX0Z55B/tY1m9wUYvQIo0YuuqAMQDyNwu4ZGoJ7C60LmDfsy1MmTF1s4XvmL68b5vE+ysme+YJBUCHDx9svqrQKlYBx9EwEv7I+jZ4rVcW/NnOosrQ2cwPgK9Uua8EWZTAuyMtUAvsvw3JoxS7JGLP08rOZVo1CLzxNfWdfaeXyPlhRhqiLZzV8AVcDSivtw7M6vP+MA682ek/G5DseVb1TiQxlCD+KnJvFt4PiTp1flBPonsYWHjNiZ6R945wWf14PVXrzbcnpKmd0gKIZ87n326ykizKWI4MkKkd2KCqy586r4ftN7vzJfWQvHRu944/e//320jccNosa5R++X5rzC4cQP1xTX1k1icFbxg37CfoUGVoFEx7lbMTUE5oww4pvxO36hc90L+JXAa0uWQZsE/zrnEvi4jocOsBs0mLnLb/jZUBkd8qOh+CAwWyVBlhVIp5LQ2bV4Jmpu0qPUS0e3ycQ9i13XL6So2fMvw1Jp2lW92LOlFB/swTEwHx/jV4y8UrC3rhybHvpdECrkp5tyCCIZYPKWnpTTrtXFS91P4sdXry7UY0dhgD01V8WFtURPkatSCWvWn0EE6KYIAd8eRtfFFiuWVgMj5ywyzzFrnCkvC1SeSbawdRDmF440e+z5ocosnDxYElK06kYXmfrMFOBiiI8BjzrDcdhzId8DyMwEYNDVeOJBkdNThVJBkvISQphr8ilLfMtNkCG9IDmG4SumL+b3nJsk45nQbVfnnuQDxWv1Cw3pktKp5cy7NK64/HW2tzxNFQMI9ennEcmkn/I1vVwgFR/CvRLChXoT2gOe9fgofUA147LpCf4leax0guOi8YNXP0JZ8egVKLehD6gvuIWYpVgFrtEqrEFZxCfWANYCtBZn2UJ6ILJty4Wv17uCUYodoBGMJDJAh0ah7xkIQYsJbbbpb8UG+FZscHZmUgdFZYCKYPocxCSxcrfaLqLZ7t8EMZ/c5bWOFWlWOI/xgHfhJrug3WnEr24mPqOx2eM3FLB2qLKLB+1RJUdl/oEpv6utmShAigR6J4sX2a624Fqkyqi1dG8me4ETJK8XKGzlw47bttLfnLxyfBhh/yKAwfaxS5r1SvXLj+/+DmGyHsqSFDTUg7JZ3OuWBx362Kkohdi8npzZ8cX0jPSEQQPr6uYQZe9ZNTuqNlFRdn4bRiILdz/ZzzTHSsxClAFyJLHLAE09UJCtPZ45dfws5b5LSm9avXMeWsZiRVwblKEC7yI892C4k8jwpnT3WToxp0Vo5pxFBnZ5QCebbTGnO+Z5EppZGoJ5MWAhSnV5Bk2aeULqJX6ZpmaAtIs5CblEPHps6POfJ6XO7b0SLHnkC5pX40GB7lrWzw+aGQZPY1tO38oeJhXytRl6wwRoMAr5nbg5/4n4z1VC4skBEVe+B488sUtOLPAJ6QftmtiwFmUAREKvWMRvrnoRfk4xLPL4GNFvzv/4eEUxkgXRfAgLoJS8JNNShl4pRXYfqNNugnHJGveWEi5EPi+Rz1P5iL25grcBmlQ7cwEqiSqCF14JIBGnFbNLd3IkgH1mq9QSDQEOTkyiM5J1r2PPpuX5DEg04Xk/Q1MquutS1SBhylpxuSC3V0C8Xns3+O9Eqak+lEp7MatypnPycLmfL2tBeaZ4Jkl6vM/f761IV4a95yu0SuNSrd9ZrvXR+qQpGcsiHWBmdakQAa9Xr43iu7RSBlFnn2K/qJrM6KfFDSFq/M4ouSXjd4UIZIfCJvxwF21Q7hA1lfU32AP9aVd+K1k7Jdd72PqLEJFObxPc7Rbwqzq1FuvtDn7VphbadOFXHX659LUx3fO7h7rKnmVbQCJUMz/iKmN4RBe3n+hRd0A2tihz4O+S8R/kcoTty3T8TZtLAAmnoRskxyndjevA34lXYkPpiOU7VzBzAoiiHBHSqJyEXEA+p3vuO5xCmh+emwUh09sCDe7w+laQqXz1CPGr0qt49kXWgl56nsXi5xzFzzmIn5Ezw0v5aIejbPRmUgGZWzDBOBWSF6VSd4G3XhR5K6RXjDOWbGuBahnwDS3VqkIa1B/f9gDNs0rzyuCbaA0+13WNDi58WiqECU49dHzLK+ILrb5+e/AcyXUuS84dKqPVhHGxeKJ2jx5DuJwiFVN+HgBQ9hCC2enpyUyMuxm7ExVlmiIKGDCkSahlho5WTKTXZjwJuP4TSRYnbmLYOJk65DJ0dI9X8mRvz+8CzrTtoVdie4gcfXxtRhS5dmdB9ZndRYygG+YxrkSIywhy8aGauGKuV2xRV85Zh/bUWToXW8TrhCvCQxBXC3e7eyPP2sFXEnUvKopfsKOrqw4d44NL8uHzvxcv//7+1bTUff/K7L1/9dXvX8WvGuNFdVKWZW3JL9lS8S2XoaWSpmoz7UIG/Qbn+JC/9kL3KvkItdkzfg8zUn/De53OIYEHoteyXQmzyIkb3+gsrC6a1O9ddBJXRLv6quad2YjNTgNNUYn06oH0Gqbbtp35UOcPzcyHxqESTf5Qz3xo8Ydq5kP7AFAdTk9ebM00BD0EPQf5iY/8JNV/HwvWmnFB8aOivyDu6Z6Nfnw5bCANcYr+T+hCfb4aXLfCnQUpo1xeRmFfCtIGO8r8+BjK/GmDVJCxRSWqTxif9MwJSLBbLGIJ06BpJt6fT+DgiUpz0fFMqFU/8/Bs/QsR/CQO/OQFPMDGvF6lK025PbvryZ9ndtd97UHKmR0X3+jv8/wLEfhvir2txtL++O777/gV7qLG+//+3pzuDWDHq+lX71fsfRCXBwEc5MFImM9dsuXOcD28jMWG6Ym4pcK9rKjfxRnKS7TQzEquKb2FfFh8I5O98M2MiKiepP7p7TcFf323DAqr9a7ghQUCO+BFxueVlOrDuz0wll2NUJYhhYUlB84Vv1gGkg8sGuYeXc88EgvUgXx8NGCP9tpdfzN3lkJ2gDWr1y1evv9Uen9WnpbMLi5c719hIqR14b/5H2YPM5TPpl+ZkA4fghKeAyl/ZcL6eg1VBO7O7ZZL760yrOTnbvlus/wBe+YEFkW+lo4THu4VoNcF3kvq4HYCmZ4Wli7e5Tx/V3Cz14PM+OA7mlhx3Jf0trBzw2/K5dYhrQz+JgRgimT7t06Kxi+/kNr+yy8GaAZQXxEvNNDMJ868F3WBNJMWBkpdizNB7iYc3H8vSPkH3NpHxyznVv8ssRCo76Nwhn5ogfPheL43K5FvQzI2YFZZFN6sbu92zjY+msRfgNKc3Ys3BbPbYPEjKugah5dc6BwM5C/yAnyQOuEv6K1B3AWJDF1ZMcGwGNWcJX5MPpExTk5lv45u/wL0EpDvRLJI4pOBT9km2tiS+SQUachGkik3rEpz4jxZVBnFSL8SwuETWET/pWb97OPyA+MOr9949n7hjOwWT+Qmk/UZqNWiCB8qBpJEQ8cTZUVvz5bRVhUXxoRvIOnc14xXv0iPqJrlM9XnWbBmUmqelePRQ5sIoNMvPuDQd2foqRxa8fdusFcSzuzg9hwz1YwlJrX5FVs30rtQ+/PYzCV2gny5OaosJkH2m6c4STGwZCrdNijXKUdCkljjFCDJ5WxvyRMbqiHay5Y7plaom3TIG3z25PaX77jngTLX0dsnGtAu1SrJGF0W6bUTLUlsBws+mbuTNpcAh3k2HDodGO4tP7ldJrqRQyHzeNrOLEONFSrBiS8SeZID+ImvDKj8FiS+ITrFl/M8vvH4yKkfOSWUKJ/TBjbocH48RI6wIPspbqJwmUxldJoaNQWyBnnslHkPlQ9UeU7D0ur4seJIlPyQoPXunA11KUqHZGHW1OmxG8YDSKWSZKl/FqWFNdFnu1+AO0T+M/cgQimJ+k54nubxJ7lkms5laQjsFXMZMSw0+Qw6Z1E383n5pZfYFPHNqROITZl0VhzFcBnuwsIza7IyOxjpMmbiVd3i4dXGTOEeaGJ5n8uAA+tK3iM7c+gI7pVwaUDBNiDWKxIyQmnWu+Vgk9KsuS2E0W4R0uZp+BltX9GuwD0oEJfHjVXIINOAmt8b28Lv8NvvCvJWnXJhsN4tCp/CTVhY30Q7IGU0Zc0chnevXeOlUch5PEFnOiX5eBmssDTx2h7x3/PUjLpbbek03SSHq5Ier1xn6GkYfTadCJyy70ysskj5DJnmi1YF8zxMr06q/VBtXWS/eWwumsdOOzrjcnMWMV/PmoTOEawhDZ2jeEKYXLt40XJC6e2D6LhSq+n5lcx4siBOd2Weni6IkV3xAF2LZe9ceWecRJTzGnJGlPNa+kuk5LhFQoaLlBZ6eJHEccpb2eLuaPjVEJvEaAqV8Q23mTUREcKgJydvesVJbd6yHQS1P+0NL7EdF18Ipr6onTn5LTuv5WBSLeTOoFK4dAGUDNI/uYpt4eyscL++w/npud7yvnATuqtdYbem2UnzWdZQELOpgKeEATH3XP8KCwGbwKxqeSrcitlRLryZAUewQNndbguIWTwanl9vhG7SboBOGcBj+IK0At6bWwjxhVDkL1QBHebZlllx9k5PDewsam/4m7spYry9hdZ8uYNFCvSJjwfK4b80h8d+KMdq87WPfuKjf7ApXyX7enKQaDgzjG9WRDgSM92CUSJDB+v50exe36b05PIdxLuAYiXHzbsURW7DTUQK+LdS/8lsevO763hXQwUUfNzOrFg38H/lGAZJTGvrVjyYoLHY3ZoN28mt0A9OFG+FfqCtUCJ4J6KbG7BGPynWA30vcO9DGuzzPoclxzg3rEWptJcjN0OHFDTBeM/RpWE+AwBn9tQ05dPY51ipZezhT1AOV7g7qbctTFZzvno1bS7z0xz91knKiXLTQWkVlt7O7dmNCSi+tZKNJ+xq9tm1Sa9QJVMPFBHgXpl0l1PKzOYnWfva0WXSGFLi9In612cgey+dNbDCVckJpXFplaIxdZApId8kZZf4kFhQBhpKr8gn+VKUbBB9Ho5x6nPphaYLaq5SPYW4FoOcPNtFN23my2gg7fbyhcJgyruxeevAbo3TN8+95EGeTREaijhuJCpPiqfxFKPZLb/ysMXf5IyUhdMTvmjuE/4iZLZRuPRYboy/ZC03Wl7NnJPOdUAM14opwuCM+VQT57b05vj6Nf9JJx7dTBxzT2qQB6WIHHKRd57Af74FLWtd0a96mCfeuZux7V/uOCZNGmHanI8vPmS4zTxrwpcjGr4OQN2np3Hmrx3axn0OO0SQLpyK7kogPMt+IauTcvn/heVodLznONqonZSyClwprahW9kK0f7ZJLCAvQTW8KQk+3w2OgVViIR9WPe7XOyvG/QAk9LSoI84miFrVDZXFJCbs3FxpfzCanbm0qdem9FyuDBOLzxpBMz08pg7VHq8xja19L3GwSRkdY4vwnI9LP4Niwp3j91C6ARC6OQr7Mw2sSWPpEywcr09guRkaRZFZHSaQJy4yAxJKbTrgMwzaxi968WoP5c3IzTXgwyb4sNxcrSxBynsTdzryBt3vKeRQJomXebjTekF35BRVTmlEOE7TcltqBlj3umlXUBRfuG1UvjyzGyZWu3CH6F04OhWKfhdP5o+PkSl8O5Pkbs3x4gi9TyG+QblQBpZwB/IeSG5J0AGErFe5byYnBtTGoMaHMNBckOyW4n/Z3uyTbQr5Jq9dUXfc7jwkV3MSLx3lBTLbK0DmWUDQqSkNxNzM9OlyPt3nuZN5wp0MdbRoxQaVkDzJkoO+y3bAI9XCu8iOXbJ1+nLpTc8z7X+3LogrOguEJlDkvHtygn8pOxP8izxNoPBc7VW8hPekt1TUE8L0oulSYz4J95iLSq945l5c2GYJn1anHxXd1UU+hu6AvkfH2vF6VO/1a1t5cPXO0InmeSsWQ0kQosub07ACx7648NDLDVZCoNXzuRCgdYRdSWULVKAFFInQUhKsCwtYu0MreP36Naw/AXmiLR4dfPKhhLeysiC+MIV2hH74Euo54jkI0w0htoT96sZZyFvoI6HcrawAWkXyAXnhJmtRUIcpbtabsBDgpeJb8qGEXhea9cJfvvkzK+RCHw/4HVwCMvEoBXBMtNs7zpltHlR4GZfcDGq9C7nzO8c7y89XzslJMTgFZASnTmhFoJpcXFxb1yWgKsbHyjxfiuuWrvAOtSUoBrDgzfcvpbokxflWwmnF6A+Go/Hk6z+8+eOfvvn2u+9/+PPbdz/+9Jef//q3/3Q9H1qZL6Kr6+XNan37YbPd3X389Pn+HxW7Wqs3mq12p/TKEO6L6J/mpYlDTOfKhYMmjAs3NYnd5NTVDr58e7clxwIv3H0Kw1WhQhaaZq2rpnCKOmJ/0WYDyLWDhxQ7LbyosVqFsaq3YbVotGA5qNeAYOotUCarTSCbRlUdm7hw8GayCyfsuWde15fRGUT90lU3kAlzSAhK1+jksug1q/g36gFoZ/b+V+1UJ87Xapzhim9i1zaq/fjqGnV3hrSpaYc6hB6Zs8Fe5KuNtiHVuBUbFWRnBsF5ZnbxZ0A/dXffUF3djDsj3GD4vAZDU+7Q6TveQjk0EttfavN8a/A17nE6KYaGdTlN7KXl7rZf5VUoNDCZ5zqRR2qZBhoEDuz5Iz+YnzgJ1TY793+Cgbzly+4KUhsGggWZyhc7R8pphLfaHLYY8JJr0m8tj5kxJ0imjqa5hB9xKsE1eyk7QtfdJzbxnFksOhYjHQorlril2VrPG2jfXdGe0HOdAzr+oW54GV8PBBVobZ848EI6ua+nKHX7Ku0BcZ2AnF2VpNWdrAGaj/m1FPMTKp9TSV7vI9Q+mSy2JuhAAyUktiKyyaJ0/IH2HpLO7iGeWZcC+6EJFjx/ggX6BFsk0uXMN/5pis46qMwyDiqzc2YavKl0ph0JksUFOLCYJ2hkRsvGDH2ucnb8GCKyvkOGwgwfLcCFXNbGEufNLct/vC0nrWjaJv1shrdNJ/buAUNkFjetJDqFfZxF4gt5aohvhcTfp6fzC3k0JQfgUDgwU4vbwo1Y3NabIKRDFit0pFudrQHDS6ZkBFm5ewVWbJX4nuropswUYSlrp5iX7L0l15Yu+7Lo/ccbUdDxDxYtdSr9mWrrgo5MPyV80FtkoG+7G38hi81e6Bq00FyDli91XFqYz3An+nAX+ddnaGyQDVLKO0g4P+QzlPB5DZKZxMVQB72QtGRlJwzUDgbxCaFAsxyhbunSilpGtqiBp5FWs2h+t8FbBPH2KLx+KlQxGPmudnFBQsfJVie9O4jlKHtrktummbRcFrK17el1dL3rkj++vOfpkv9cx9O1/VP9TleW6TaqAG+24vO78NZl+6ym4mjPgagDJ4EZP8Dj4HbR4yP9sIwUnSWAzrErZhipR480hIIlKZZZSNZkED1/Pf5u/Lb/43j0y/dvR+O3Dt779f3bN1+/+a7/jUiqYra3Y8j07sdfvvn+5/HbXwbf//TdiPJ+M+5D6k8//KBSqwnoNRe6pM4XyTfJQnyph+hk5lyhPTgFEuh/W3raHtcPfJG+kMnSDVImekWifAn3uSiW7JgqlR5gUUi+YZ+zfF6v1p9WzOlxNziSDzijGYSX7RQxnWc3kYTyHnt2xPfHpFy4dsp5QjvClSNmzS0/R1Ay1aF830quL2njfnqtyRr2E15cKXeSlBNX5i4W7chmTmeFv9lO+HGgUYz2qZStfGGFac+j5TJrb54kJ57QrBYJGUEIA4EjEZPjx2cm+7pId08vIuQIq2LuycIgh1TuUa0CHiNylS/GZxTkL3V+63IqhL7LqaUXl/6A4sKhDMHGvokIrBFHhwIy74gbuBVlJzGLRK/lyTP/wES5DKdke5Sng/WLfR7YASe5HSy3zNHbICFiO86VOWdjrTz4K/Dray6Z3DvhfZkaBz2f7DbnxK2SYTY3Jn+dW2KvLjfO9rhUCqexefU6s3d9pIcLPU1oEM71/6Bu72M73lXO5WOwyMWzM+X4qM1bU89W9nNLZ2ZNLKSpc0UBkl6KzebvuKcyxZ5SCd9ZN20DT3lGiCOj/M40XyiSqy/L7YhSyTclhOk8eDWYE8TnVvnHGYj2wWGH9kjefe6nkBvoyF0BSeYaAzL78KjxrzF3nkEgytvVx9czfF1/j5JusmlFPjq4ae7nVe8npC+fVfuId/ktP6X+32BK2lTh/5N2igSV4It+POZLhCLrSCS3D6xbbDhH7gc2/oE+ZeRi4PRy9w69mDbOUpLN1cXm/Aq9kFg2Wl5eTS12Hr0+X6SMGmFqAV9k7BthZgmXHpxotpcL1VoReagWp0XaHTOx2C+ybpnpq9fEGxDQChtHtDbE8YIP4g0dky5H5p+KxxTz8HZ0IaNXJYJ8DS1fBQl0FURaKVEtP6xapCe73EHaJ9naYaF9Zn3msb0Vd8J9oPGvWFs0RsH/O3U5AN1L9xGvLbzC4AbpiS43DKw1PsBkfRKrTXhxZ/I6zKpFaLJGYd6WSlao3RBXyOayDBNy8NYlP0VAtGaljmk6t0CF4fni4u58AdSpGFu+7oMHskyTxWjIusaDHHyZGqrvvvPxcj0F5SUsAekJuicAfJwYsk8Lcyl3amZWCOqC9cm5ki9XwS/cOLHEEyOfxCFF5cRezRpsJmuQTgqu8P+2Ct7drrBaF5Qnqm4O8vU7Np6oiQqTs7KsUtWE/XT8feb4qhOVfLzIP3KCHFc9+U4W2gflFN1CAXtqbUsO/U0eYnU+wNcqMpvU4dZktAQUlz7S6mygaG0KFBhkvfAEIHUChGbxDnLXp9YOwajjAw7ioij072ADZ5AWe2JH4RuZdz8vrizvOWcPDxsfnJU1L948wRAOaPDOzT4rbeS6QNP5G2uGnhfiFrgLEIpzN7ewu8oIOKeVGf2I0VMYGPmHO3eJXsu2VZjzvW14nRg5CF8G04sDdfJIPF1rJa4Vb60THCsqs5mO+oF92KdEL1r+uI13t+4q5WqrXWp1LjftM8MQSzteUlfI5MRdQexuyX6iLmkzP1hPyZ7yHE1yKMdJ8Sy85CdH3M3OObwXTnjZ7vf5Zd6s6IXI+30ShzmHLVIXlbH6mbLsKoF8HpumU8q3nkXyk73yata1Qnn8IIOpjAqRVRWeNQktHRYvcrfGAYuQSQQdKb0xPDiG0ZT9UNIjuEiPYMrCH6YO2ulHDQMnYzcJeCsyI+ilNYIgz24iL7DRG9dP8klvmxiCmZMyZszM2PoSWEkNL0xr7fkKXpjV5jkj2VNme6mVyWbIkkYt0S9RHf2mErRJlSRi0H6k9+v3s/5yKaXpg94zSTG/l5OmHm5PDgl6khXxafe8Itv1TVjMPRnPO2smPY+gA54+QpOYeri7rRy1k00l3LR1Qk3bauaxIeRw/9EKwpxvfn5IH/WP6aO+9Ac/ptEiHcubC9KZTFN51Gl3TNAJZ7wuga8ZYssUX6jk8C64dJXT1eCZeayr+arxzKTpXDwJxLVO/JeuQjDzGuGrlF7eEJeb7vF+5MQgHrz9zM+6qynlmpzWgpwHToID7HyW4UeawZCdiw7Y/IAPKSvfQ/7s1Ow1RO7CFPiQOTyTXEFie+bTFkr0JM9ZQOb/ErOi3v7Ti8Yis2hkbFALsWYog/lcKqs6XnXG+SwLWvgiC1p41IK2f9EIoxlt4G4jP2tLw2ezn2VLC1O2tN3mzqfDAYkvT2rC4bM0YfGYVmy7cEE0dC+Su/5SInRBTcwTIWW+S3eqrH/qwKS8OBXK+toVvEcL4VWqal+E7r18voCmJIxDAlr4tIAW6vNr5iipWwkVAvbEOxGHbkfShFp2CjhwW1LP7WavSTpSWJ7tVSZehdHZNPYq9WPkHj5GnJKyz4pPwHxmq0mXlbyfKpyV6ntP9vLM7lZMC3lONyzjHxAdXigehf+MeBRPBXoNpph/Y5BE9IHq8VmlJBzHpB16/u7YbNNnVoLNKjrw8JrsMD27tPPJ5CN2rjvA+7gQz563EAdPLcThyxZi2dkQTVsHOhvKzmaIPhQapOptZsnOW+JN9g5WJzKZdWi15MEtbqwMpDu1nER0te6L5o644/ZZU2b5/Jmyj/2zj65fqWlx2MRJj7QetNuoczdHreILGNbFgWFdyGEN0sO6mFrXTqCNatYhQN3ECg1EF+oe5CgmlWvQTtE3XqtGUynVAdnzME+zDNITiG8dyt2Xz97Uggv6gYO5oVRH+WyptK7PEnAqxVMejk1f5jIzrVnuaVp5T8WVEjjDlLdAytxSKgZPk256zcwcTH6yFiDmVMO94Hn8PyEu+0d9FfxcX4WZ9GfMsVSRaHKljJ5Xh42eB2hd1rDfz4uHWnmuiVTV8LLtEhQ/3/ApmqwA+oI3m1K+dtqTTT5bTjXWIJ7fFAfq0CSIAfzypxYGTqB7qOsOed/iVYIbNLwX3RJH3FWwvimaXxW9M1e/P9HD0/PWXNxdMb8QQt413kGMLx8tnPmZfY5eWddWKHf48DkZ7WaA+fnsIqTrAKKij1cBLPH8KW5noRXdpcdYcc7Qr5INv8X0gci5BOAK5wBHriAPerX4sSNi4slP88GjJznxrRv1oOVLDoVk/DK1syEunw3REITHfqEDCKVke4TT2XINKCiGZ4H5qmqWAuvKiYqQEcfnJD7Jc4XXBPX87tXrSg9k1td2D3sZV9mdow9txq2kF17Iva0eeg53/a5/FlDpgDa0jpf2u6BE442jwd495JHm5nqkuUImd7RjF3MyirORKNRuPzLlZrz0Li7iJQZyS06Uwlt5c5XZ5IXMUIk4BnVmk4KL8lIxpBe7LyGNkEo3PPNe2dlZsFcHNY8Mvng4Ufnvbg+8Q3eiKW/GHUhm6Hnu7wxYP/D8sHusXlccFfdwK97PfQNOz+7HL79B/uvw/tN6ExwvIjKJUpmHRJ9V7lif/VSnk5dJC6dCl50KDeUmuTW6nACC72bmgtzHcfFmp4xtoo/AfVVsvaNTaDJ+5y0jX0S2O3enIstwZ3TlxcvKxVBeybzXjw9o3O/EOz2ly8Tv0Sve6J3AHGCX5DS35DtirmJvFmhF9lTtr5A7ZLWrXe+Lj7oDTdOvlfwVrA32nKwlssK0kDnwMXDxE6R9+XO3uRcF64mCuErJPKgnyN+EGPH74zoK5G+8WkflhwVVVNpIVErzS+aiWRRXC71WMKFKor6goURGGKXyC3rOysj27haWcG60mWiUf6u6SQhQWKOb2VQdhHvVC3r5VmGaXp4WDbQSDQjCUHjGlXt5H1cDOlmwFSXbiZKSILS+krISg+fdzeeqX3YlSQaAGHflY3eOEecscz+0gWJpTABxezOXRzpM0ev85VWkSf46uUkAePnoqgrUaxmG/m6BPE8IXDzgC+IzjJ9vjserL7TToSBPnvjlaPsGH4Wm98jf7dzNbvyugfcjJq5i9xyb3njR3gDCzdFsnV6mzh9yqsxe0r7UMVd0zxqNaqdpfmVXqvUSXkHfrFUrZqnZaNSa+v386oHumYXdn/OGQF73sRd4iVBOd5uWS5cNBMrKdzGD7vGdOB7qInH/XNMi0MQxUQcAszuUEQpY7mtnlsB4mCl9UqS+XDig6IRQvlWr1zTMeA4+nAJCFe7y4NH2+FMaekZsc59F5k2CDJFA8DGKFKElj4ZEnIkJeO8/f1n04pevo+2feBGD4QZNS4s2uwFE34bbcPMxDH4WWWaZtGZ3zmm0uHFq99rSe423M2DhRU5qsxslUjHfTSql2V3tn78q+5k3W9WT3yepazlwpfYOLc76Ufl6Wx7PbbRSb0Hk5Hh87LRkDGbD42OzIaOtygG28dqpt7l4IzHDEoylVmWm0uE/9LwD/hXJdrMCP14DBM0K3ioYe4y+dpKklqjVrojiNf7brsp24FctIQnwJZAXDk5q+fJDgU92ks/mUMwb6aTqOXkfdQnfPSMGYb5CtmGWmIdYfm45lfn/EI9hBhO/b+rnP/fhXtjVds+/dKfdefm79aq/9aMoxVD4knQE28x/EYQrCQ5V8sOhOm7zAZm9CJAP+YDMngMIsdCHA611X12+/9zvv/88aMB/+DusnL3/PGrC/zb8mMCPCfy4q1SHNoVNiowoMq5QZFyncEjhGMJaiz7UWnUKmxS2KOzzhxGFEwzb9LlNjdTafQqHFI4pqW9TWKPIpEFhCyP1tk0hVdmoYmWNmk2RRpPCDoZNTmpj+40RAdYYYzONCUcmVQibVYo06/il2RxTiFU2W1S+OapRiO03xxw2KaSsY8o6IVCakyGFmNSyKxRW8UOLYGzVRxTpYyWtAfahNaSCLQKrNalTSJ8nmNKuEGxtu0EhJVXrFLYxrPPnBkX6HBnQ90GTI4juTqWOkU6tQyElNSoUEu47TQSlw93ttOlLu8GRIYUIfadDHzo0HJ1+m0KCvjOgL4MqhU1Oora4+SEiqjOiqkaUMppQpjG1O6HSE/zdr1Cz/UqfQmy2T3js29Rsn7rdr1Kz/Rp9qVUprFHYoLBJIWWlPvcbHSrQGFKI4PRbNDB9ItQ+97bfHlFIwPU7BBB3t0/d7XN3+9TdPnW3P6B2B1yeOt2nTvdHlGnMIVU1wa8D7uGgMqQQezigHg64hwPq4YB7OKAeDqiHA+rhoMbFqVsDGsoB9WrQ4N8E+4AGdNCisE3luIcDmmUDnl8DGtBBp8qRBoVUb4dydajezphCArRPVfXrFBLpDPqUtc8VUv8H1PMh93NI/RxW6PuQOjrkKTGkjg65o0Pqz5D6M2SiHDaw5mGTilB/hkSZQ+7JkChzyD0ZUk+G3JMhjdWQx2pI4zPk8RkSfEMan+EI+zWk8RnS+AwnHCKyRwz9iKAfMfQjgn7E0I9qfQqxqlEdqxo1aJKNiAGNeBxGBPeIWd+ImN6IwR91KFuHvxArGA1qHBlQSDUPaUqPhph5XKH5OSaaGBNNjIkmxswFxnXKRaxx3KbP7TqFLQrbFPYpxMrHHQJ43KHPnQ5HEMZxn1ui4R4Ttxr3KReN9rg/oJCY2Zgmw5gmw5iQPSbQxwz6eEggcAdGQ0oaYRuTCpabMOiTeotCgmHSRKRPeFmY4DDbFWKDsO73MaxNMGxwUqNBYZ8jIwwR6RDSh2aTwjF9blUobFCkTbnaYwz7XNeQigxbFFJVI/4woXYnCL5drbcp7HMEs1UZlioOPYT0nSGqEkTVJn9v05c2f2nTlw5/QSRCWOVIg8I2RxDA6pC+D/k7gVkd8vcRtTmiSA0pFMIqRxoU8hecTHatTa3VkJ3bNe40rasQcrYJAlUnQrObOA4QTiiCxGs32/wF+YPd5AqaY4qMCcXNCXaxxcPVwtkDIX1p2YjvVpW/1ChS50iDIoyjFjXa4gFr0YC1GOoWEpfdGrUoxFxtrqyN8oXd5lxtJHkIWxRBTgAhAtge8HfqbocB7NiI3A6PXqeJfe+0OILLgt3hOjtI73aHK+gMgYfYfa6gbyP2+wxHv4Fl+jhRbObyNvFse1DnSB2rAXZMkX6FwjGFiNvBgOhigBKGPeT6h1UsPySxAf5gtiET1hDlKHvIAA6JsIbjDkVQGoOQMEg8DUKqc4LAjrjm0QArG3NkQqQyYVKZ2FjzhPs0qdOXOn8hYp8wuiaNFoUdCgcU8meilwnBN2H4JiiSQNjkyJBC7PmEKXoypO9D/j6k7zzzJih7QchfRtTMmL9QNycTrmBCFUw4Gwph1QoufhBOMKRZBn/wA3ARClsUIjKrtl2jsEFhh5NGGKKsBWGTwjaFXKLKnycUwcULwiFHsEWbhhz+0BdcH6o2EXjVxrGq8vjChMYvwxpHGhThbEOUrCEccIS+4MoEIcLKo1gdVRsUtihEkEZc16hJSSjGAm/gJFxxqqM+R/ocaXMEqx8N+MuAvgz4y4C+DPnLkL4M+cuQvoz4y4i+jPgLLqzVMQq8tQpNA/jTwrBqU6TawbDGERTYIGxzZIhhnb8guBCOOEK19fkLcuMac2P4g19sbodGpWZz1Tay9ppN/a3BHMNwwhEqUycU1kfIbes8EToTFPL7vNr067j09OsjjiBn7Df4SxMZW79pc8SeYIhLE4QDDOv8AVWJPjBOinSwPLPMPukM/ZaNTAr+UKRapQhSB4QDiuC49Fs0LvCnhSHpP/12xaawxpEGheJLn8IhRapVDBmcdquGYZvaaQ8oMuHIpEXhgEKEs0Pzot9B8gIJmMp3ULzod5ocaSEGOu06RXDx73eG2I/OmL8j+ULY5Ah9mXCdE+wU888+ifP9PgPYr1cprHMEoelza33UIyHsUzimJOSZ/T4KThA2KKRMgw59Rhmk38dlE0Kqd0Q47Y/oA0PZH1ONjIU+8hAQ7ZF44E+Twg5HEOSBzV9s+kLsEf5wpM0RysbYGuCCCyGNwwBlkf6gxV/GCA4zAJAMaxgOOIITDMIBRXA4JrxQTfq4Nk36LY6MYAJNBvyFAJ2w7gB/WhSOKJxQEmJ4wurEZFCjzDTb4M+QwjGG9QqFNoU1CusUNinrgD6MqBGSeWGiUPMjFCUmIxK8JyOUnCajCX8h+McM8hiXUwiptjHyZ2DciM7JBOVoYN8caVCkSdlohZjwCgF/WhT2OYKNTkb8ZURfRvxlNJy+svINI/8ac0flv9LcUeNI68W2jw5HSDBvDKgIdbKBUwPCOoUNCp8wlthsLCFThLScNDtsOUlYSzhC9hDW9pvjNoV5lhKygZABRtpIhHWEv+RYRJDVx/aPwVH7R3tEmk6b1Lz2mA0YzRqFbK0ge48ygNR+QwMIqTwdwnCHcNsZUkGa5co00jpkICFQxlyjsJDYbCGp/QvNJTWyk9RoQIktQ9iikDLVB/yB7BwN+4CBhVHbb1EbbYaaUPsbW1sIw32i3v6wxRH6wijuDxPmGEoitPYZrX0y4EnjjM3GmdpvbqkhKImrQtiikIozLgd1tt40KWwdsupQvYzXAZGsNPFU/1sMPQOOEBMZML8cEHUP2Ko5INSzPWhAND5gnA8I57wGwp/ar7cXUYSwOqS1Cv5Qtjpnq7NBqUFhM8e4RBHC65DxOiS8smIFf2q/jcWJRn9IXGDIiBoSooaMqOGQTVIE56ipm6foM9HrkHE3ZNwljFU2G6tqL7JcUYRQN2LUjQh1I0ZdyqjV0o1a1A6ji1SMtIWLgCLU/Xpr12hIYA65yRGBSZhhNQP+UFuMkxHhZMTYmNR0Y1lfN5Bhl8YNjtAy+V9vLaNWB4Ozo4Yy0rHgD33ntXg86hwwodltCvEza+3whyLE3Sc1Mq3VOGV8yNrGS9+EUDBpE1In1NUJd5W0dtC5mpo1DpVbZYfrjP7/ZEhrjDgy+W+3qtV1q1pdt6rVjlvVWlUKa5qFbZS2sLVQGLFbbHFpjXG825UB2dEq+KVts1HN7hwyxz1le+MynSpZ2GocqVGEeNLLrHIdprLOKGGiG+gmOmyUtUq7jzoshDQS/TaVYSrqdzrKktfnBkihtFnpkpY8JtYBmcAGTULLgPA5YAgHk5pmysN5aA95cIY0daRdL8eUxx0ZjqoU1s+U+W5IpDBEaUWZ8gitoG/9rzXlVThE+xYZ/6sV1FerFTS4Hjb0Mc+BPxQZU64xmeUquOP4P9IQ+HLjH5H3f7HxbzTmL6jdHbUETl5iCSSzYaf/P8QqmLQEkomwRZatZmukmQVRjPunLIHVVtbEx5EhmQUZ0DayxH6bzV559j622lVHmr0PF5C0vY8jZFbrkGjWJ2arzH4J416tqRv3yO7W4Aiymoxx7+wJW91Et9U1/4tsdfQF+ROECM1gwh+QAf+LjXj/DuY7hm+Myu9kXOVIlSKo40JIdj1ax+DP5LjFj2bGhCTVlPmvNvmtjYB4BvqL49MXx6cvjk9fHJ++OD59cXz64vj0xfHpf7fj0xdfpy++Ti/2dWo/x8Txxb0pbeH4LRybBl8cm744Nn1xbPri2PRcm8YjIA/U4kv4I5A8rAwoHFEEhwzCNkWwdQiHFI4onNCHOkUaXL5BkTZHkPuMRkSyoxH2azTmL2NcS0bjPkdQyQFUUGSCU3w0qXEE7QgjXjJHE3T7GPGaOJogjxhNuILJsEZhmyNUwcimyKghOmnrnaTCQ6akIa6REHIncSRGvFaMaJUY8fowoi3q0VgAicQxYoEbwCO4mhxptkSD1QRWGxS2KewzOikJt3AgbGuoZaRSpby0Aa00NaSiEjnibfwRrXAQ1ilsaLDbFKlyBJfbEa9qo9GAeoUUMyIxBjuFoc2DYVM/7QZHWhR2KFKjLwzSuDXMjOaQI0MqM+QyyNvU0FKXc7GGO4fx0NoChTUdhfW2hoMBdXsocSDy1zl/7SzGbJsjyAFHvAUGqGsTnmo8xohanqFAolUKKYlLjqil0ZCoaYSC1mg0IqoeDWN6GKNAjqijCC5sCjVolxuRwghhn5NGFE4YdRTpcKRP2QZiVowJdTQQE1xFISTStmm6cGMT5FkQ9hnB9KVGyKTRmtS4OBHAhGbtpEGZaLsZ8C9x3dBxXSN6qrcY8X0N8YxIwsNwSCRKwy1pq09UxXNpNBpoGKoSpdV1HtDv69O+IwBpEiB9MTepuclEI69JW2RsJSaYPrWqNEOQT8PUqVJSeyJKtbVSk45stKPX1RzHHR7Va9PHS8qDI9C2cZEagbaEIVNyu9mmsM8RykaK3qjdqk715iYSiJHeXHXMqbbOosb1pkjt66nEKNhGMRqj9DtiXw6YaCMNmYRsOdHqRAhNJhfU7yDkwZdIsQeXWmEaI0ElHS7VofrGFc5e1QEFRUKk6gxvLOdkdShSKRTEVp0k0E301RKcbqgRG82aYUewPTFWtQSlNogSG03OMoz5I4E87BOf6BOh9omJ9jtMx5SVTG0jMmVBSCvfgFc+WlGAwokGKsxYWxyh2c8L5MgmhmA3OTKkcKyx3NqAI2NtHST8jurEZMjygeyHwipPiwazAmamxJqH/IUYD1t+AMMUIckeZg+NGcMxodkLSxSP5lhbQYmyJ4zqCWF3wjxpQpxn0ufIkBjIsM6RgcC7TojMAeRag3OEshAdyRlf4QVTLCQ0havEJlHShpBYAS2x46pYYOhDrc4R+kJoHNeIk9Tpc53S65Re5/QRzxhqokFNNCgrEce4QQUaVKBBBUhGGTcof5PyNyl/k/I3aZzHRJbjJiObFoZxiyGjOTRudbR1sDXWWT41RXoJcHZqkbSxERkBcYA5Qtn6nG0gsNzUOdF41NTmpeQeTZ17iMGup7KM9bGySdqpJrO09MUV4BOpesGxPXqm63vrv839/Yvj+xfH9y+O718c3784vn9xfP/i+P7F8f2L4/v/bMf3Jm3C1ZAVf/GC//fzgu9/8YL/4gX/T3vB/3tsEf/Pc3z/TVzev7i5f3Fz/+Lm/sXN/d9mS3g0GR3dGB6Pn7k93P9tt4fFFlS/82WvOLFXnDDuU0hbnJXhs7aPa7yvQZQzrk1+xY5y879+R1nkJ8w2ea+pSftLLR6AQT+9vTyciJo6Gp7JVj/ijZkR9V1tPNe0jeeKttc85A2iIW0tcQNP7j+LnZPxb7ILPeZtJrGr19FwTyTw2+5PD7UNSNrnmdAYTciwNyLZWu1ft/RdbN7i5B0v2oGVm1ytet7+Nm9pS/bU0chA29OW4zlKTAiaKgPe4KbNObXbPdLGg/aexW53Q+zWdrTxGLR08u4k9sEp5H6RJ4FkdrXcHfJx59fskBNPGvJcFBvlCWyoXXNiIhzpt7T900Hzf+t+uuBGzU56c11NgoRLSzOz0y6WI0Lkr9h25/xjzvhvtPseL4wdgeAaccdRkzfJCWGj5kh3pOHd7zZF2pytTYsmbzSP+iPe1+URqn/Z4P/v2eCncJyYUrWmvpVPVD7mvo6bvONNnWjXeY+bF5GJvtUtK2onmFCTWRHvSxOB2QOetTaFNCrkGgCSJn/oH/Q/UBy6qTsj9LV1tdH54pnwv9QzAVNBfbvUhn48wVO6C+cSH6yw2nanikENgzoGDQyaGLQwaGPQsWDxqWBgYwAlqjVMa7csu1ptt61mo9rq4BOy+Oxrf7Nx74t2tW1a/Bgt/KRXcHx87c977XRa9CQMFH18hGizQdFOBWL43kaT/3Ya9BZNcLzO4Ok6+ZUPjx8JSbXg6q+yjEI/unGXo2ge7eiFlD+EnzlyBZHv/Z38hi+t/LyIduG7W9cPu0uI4tOPP4abm2jl7tab1Gsq8rmg7srKefGnu87L3Oze5mRudj+84FUW+YrbsUdZDr3EEsiHRxx6dDR+Xkc9KEZvkPP7aTQ848+3m3CLL42L5876EJmv8B2mzKcBvViYSR66y2U2cb0K6NVKN/ttIsDNfIgRJxK+geHauEsZW88jP6e+b0N8uTOT/F34KZPGb6lnkt+FH+7ClR9mPvy4iLaZxJ9y0fDTbeDuEjWot4vUe1zZF2KeM1Cj9c/4ZBrQ2I7eu5NoXG/erHIS00npwkfA8l4C1mC59q/TjQ3wPbd04lC8aJZOH4mXzTLp+R0e39zu7jOJCuG/Fj9vZumUb1wvXIZBOvktYSOd+o5Qk079EV+vyyRuMuD/xd1ErrcMgY0t3Y27i+kpFwU/R7vF84Zypj2Fg8P6+Oie0KCenvIo4pNrcibqre+1Fze1Rxf1kU9gTL2P7i5hsgInDbmdnpbS5dfTaZbtzo/hOGd8csfx+dgByLx1cL/X3jzX37TzxCNr+KCZR508AcToPUy8eebFnUrPEZdel1a9DNY0kxSu9SpxDA7UU4F6EPF7fobUlc82wdgm1r2Y7un5MVV318MVCNnmTp8T9GQZPxo85lcz6YWyHzZrIL4bfO5Sg687t3YbN1pGq3mc5j+5hkGZj+FmG2o/0y9+uqmVrODiK3f5i9lSPoDnOw97KOmRaOHiW/SBGZQX7vb7TyvowG242d3TC2/4nt2lO5VvPKO4YKyJ4wPGvRNGNL0rhQ/RmV365amHsXz9IanQmsmXBwloGBb1pKwP0owcHs9xX79+bVuB45c8i5+KNXtAC92i7wQl23LPHK9k5zWy4Efq6ClofPJ5tXNcfv/7Orx3vNTLoow5+ryit10tUXC3cDz+/Wnj3jo+/96EM/1pZg9khvz32ASvxxdKBd7cBN5koiLkLT04ZiSe/9KfN4Q81+X0QsvPpMn0H9wdEj8MGT7EigMYhVsDMnj6g2D08LR84Blnl3xm+dx9DSNwdubiG40eDCJjxHH8eBZlOeJNkTDIlaF86p0rDiHplbLERTZHimzC2yUIkqkSW34amghHPbjmfIBc+mPXCvk+vok9Dy8r09eu+kmTjF8MDYO3mOhcxl8t+dOeTi0kal/gBeg/VQyyOCi/q7IgiJ85tgXSdSUndyWR24bcbtyxHb9ALZFxObXm1gxo0kOueBJwIZMebS0gpsabDYycAQPt+ovh+oZe9oQvYbAtUF6YxzC2N7zo0CvMJwv13q32wjOTgE+PWMq0c/9idu6XHNucw0wOL32AdZ5GWcUKVMcRa/R++9w8x5cw3QBIWELluPETzsfaElVsi7LJhRk/qgdlbgBFDyE+QtzVXzSmR6kFv/AuXL2P/KI6wJkettcxYYiHprN5kN5Vrl7RT3fr8TGbBuOGjz2nUrlfAZLd9nYZAVF7lm2aXQ96vVcddNQTqb2oTHJeF6HPEJGC3Z5CxnfX0W0X3wguVP6/3q6vx3Ebh7/fp9h5GdtYzrR7j571FXdtURT30AO2LXAwjIETO4kbx87YTma3M/nuJfXHFillu33pPmRiipQoSqJ+JL0I/T72bCdU4Vz/RTstHb+vvGGNnRYeVNjnIjvZu40ZShKNpST5bzRVdSGLYNgKHZ6zDWztXttnL6EoLQ3HbrBQjdt1GQ0JuXg0mHrhoeZYunCeVFv/7Md1ii3UgBLPZcOV54QIeHyRyngDZDia+gEq8HAkleEJ8Ng1lbEstiP4/bYtEaBQ4/yALbuyYTMVBOSgX6b+D0JPbLNfDdXB26bRReCah/XNCcjRH/BhV3f0qAyDTB5N8LEeww0kEQjc0yvxPHiRXRoI9sCL89JA6AffNQNCg+bsdubTkE9Eh6kfLwIPFVMZOsL3Ckj/u23ZSoSolvc7/dvaAX6/xcrQD/dWAQlJt/wfjvVapT8s40xQHDLOTYPBL7ghVMoDKuCxVCpjK2r/acPbnWds9wPGNBhFQsgZhPzAD3VHsUo/uIwBYgRLdih1M0XgBi4syoIf1c+1ux1LiuVh8/FIC5daaWeZwnTLT+s8UrbRk/BbrIzH6nCYdFg658VARtGpH1eDlzZLA5k0kEm01E+rIc9U2oCL2pcn1bbrcVNjaNhMRp5TkEeFis4MBSEClrNLRQoPZFCR+vk8YAGGZZjvqf8NzRkN424lj0Rc/XYoD9SmviiKmfUyY/vNnbNPi4B+8dvG3JHzQC0soZR6GSbwE5NpKFkJH/BrWc2jsEdsPR1ppuoPPvGEVeplsAzHtyVdesv3CH4u0WVXP9cHjHwmptO1FpSxNKubICwc8+4WBORgWdhUZmWBJ9tSmXwDN++W8iwc/CJBhMzugkzspn6qFwJpvDSY2/M4+8Fn7HGV5B0nbziW60pF6gv+39Rt5aosCNEFuisoMo/aeoNdREOz3U1REcCPPosAj3lU69UdbeMiyluCqDGPjmiGw4gjUOqOOAVazKNy2J7UXAsJFHMr5AFET28BD7GdvCc2CFyYR+gt2xqPwDzuqLgWdGh0XlSWABFnvpi/cNDhrK8HDfOoqbDDkc6tanR6FxDxc6w+VvQMcQ0nom4kQL1tGkpYut2GgGIe0W+qI9eSCSWj2VynlhOQcTG7DxTzIoQLiSpRoDEjaAUKCQFRJAj68mhUWdGouA708qhyjnBxDd1xNlwMe6+R+cQoyyWo9gVSalo/NHbZaiYP7YkNxGAeLj9eN3byEJ2Uh1oWS+A+sf4umwv/rrIFUKDZgPLgBk93kDMEBD+z/ZwrHJf2R6b1n21BDxc6m8DHg/mVhbyCCfN5Ea+CQMnitjQHbzPYixHn6eE9e3Zmu/hozzvsHtTLbbYXbDr2k2Jz0F4eHfDRY+CQL4/2NZ3Ac9meyEIS7+EEOMC74lc9nJe7aeJCYDzR6EO8vJgR3exrnYlxnQOoTrK4gI5dRBLPscYAlHNPNKnOURyXVhAOZyLRGzqdZlwPDb3EoDY6VcJUZwuIC52I4jqaQ/Zyi9xPp3JsiFFAuLzwMFuumel88CkJ6EaiHKyxWTKgZg4/drkru6pVhx/XpGyb3/F74SE31pMH2lhrCK4x7z0GmPrBui7lawvwLiBjZbPFOEJzzphplxjN1fACqui1oY8tfTTZi84jrkGlCTe42Q79uU63F9jd4wGYeqrP2KpE5hTYeIkptwWmIltJUerQlZzLFArC3TejfqPH6S35xn2yKVE7BLxL4ObrJI1NRUoXTFS1E27eJRdYOcOrQhYb3Kl/rUC/mMAVKZPE5uu3c8b1Yf1++/D27TpZ6VxtSan6h7od6zeWklx0YY/qF1uoYKeqD0rJx8f1aVBzIX0Sp2hsXmzCHbzK/okrY9hVHrttxskOv3q/US857TwOSmHXcUVGp75tOpdIobGh4gZS9TfnFSBdiFGSRi5OnIoWcr++in6pQCitPqhsNzO8tk4F6wdtXjVnKnFen3OlXxbTBg5MXFXonCIoU8KoF9x6YgbUDRd+fKw/1uvTxHbuXLarwSnDnTpduq6gzni/YgGyeUVGOsCqQAprVWBe39OVpaYIlVIHvOleMdPdO2OGRA6HWvJJdT3eXZ9Cp9iqJARGdAru5jB1Yuol3vCThn6VPElUXONfi5MpHIPg3iZyPdS9qdx05pb+jdi5GRv0pbZ+PfT9ZOvXj4/P/bAni9GWk1Z0aNZual38lTKUDS7UqlzvNbG8n5+zLGrsGxLRN5JbowvyX+NcEWeydlIRbggpvHDOi0wdZR2OT18WEUU2Y5UqxI7N0xqXZ6pdvsRIJ8LWtmztbpQTjHrr76CBFXTwBC0cYEBPt8czPT2YfpdVUiIw0TUzOy27EHjxyHUg/0WnnKq8JKusO3/g5m7cdt5qWEyVj9V7Vxn22x9jqhFm2WRojaG1Vg1z2OPxXikEq4RvgCxbv762zrsAD2sTcF7U6zvqAFLfgR5V7fYLekRpY4Npnq0vtdFSm8QqQHJdplWAp6wzPnql3DLsM2fB86cCbvb0eoPYYMnMZilxZ243r/b+S7fv+me8vXC8NzTWm+jt09voPkI/nO2t79ZLEQ932bvkX9nXyjaHbJ8PBTr8Lj+gIhWbAr+DqyR52WaV6G3r9nZT5duCdXGMG1BERu3jJ6Bxk2SV6c1DPJAfAD+dxKvaQ3rOKPVbrHsKyCw7TnPPg+3sml0uTjeJ0lbp5ijGdnuFJ8nZxxf6J3ylh79OcHawzEf7xhleUVBCrV8qG+qNcbMxalFlmkIQqjbf9UWNsLDlpl7f3SXqjc0WcQ69G1Jv6O2yRQS3oN7wpe3zfWVq5Xd3Mw3nQUq16CcOgDcbeo4J/UWHPuQZPcgx6DXOCTyT12g9rzH4XuMpeyFfn57QYFnAdyBlhxsgIqYIvUg7n6vBfjNTbrnbaB238Wxog6FV8pCfF7dR3WQLIri9pce1/rPRf7a3t3ZlNHKtEojFId++vlb0J7m9/RgHPUfleI43T+q+Yy4poOLsh75ExdjTUXuY7PPaxkpdw6oh+ZfprtyDcWI3B3aAzZI9O0sWcIqV5xTH7MB9Ycd84YguqAv5ws7zhYe/4gtH7QsRRgjvNbne64hOcCrwHjzkR1Sk+YwvbPDs7vHK4r3tmS9s8n0hvN4INMLiwYgFcrwRuNdTB6SBfeL6PtVdSNI5VI7MPHArPCD2hJuidX1dA0e3lwMcE/J4bDdcEAN/+NRN5ccMwcWCRw707pVxhQN+56+BZROSftU48L8aHc3PPx3JTWbog+8pUzz0LUb+CBCr+3Xbd/X33bkZelWNcAGpDXvilwtCpOpCMR6Cpjj6aur7dvwK2YdPd8e+6dR/rkguDoqnjyT5xx9SVB3AzJABAA==
-</script>
-<script id="@tomlarkworthy/escodegen" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _hsp23a = function _1(md){return(
-md`# [escodegen@2.1.0](https://github.com/estools/escodegen)
-
-JS AST to code (the inverse of Acorn)
-
-\`\`\`js
-import {escodegen} from '@tomlarkworthy/escodegen'
-\`\`\``
-)};
-const _rg6wi4 = async function _escodegen(Response,FileAttachment,DecompressionStream)
-{
-  const source = await new Response(
-    (
-      await FileAttachment("escodegen.browser.min.js.gz").stream()
-    ).pipeThrough(new DecompressionStream("gzip"))
-  ).text();
-  const fn = eval(source.replace(".call(this,this)", ""));
-  fn(window);
-  return window.escodegen;
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-  const fileAttachments = new Map(["escodegen.browser.min.js.gz"].map((name) => {
-    const module_name = "@tomlarkworthy/escodegen";
-    const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
-    const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
-    return [name, {url: blob_url, mimeType: mime}]
-  }));
-  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
-
-  $def("_hsp23a", null, ["md"], _hsp23a);  
-  $def("_rg6wi4", "escodegen", ["Response","FileAttachment","DecompressionStream"], _rg6wi4);
   return main;
 }</script>
 
@@ -10219,247 +11899,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +12366,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +12517,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +12901,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +13148,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +13164,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +13177,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 
@@ -11664,7 +13356,7 @@ function (name, module = main) {
   $0.dispatchEvent(new Event("input"));
 }
 )};
-const _1b0vy8x = function _getFileAttachments(main,getFileAttachmentsMap,FileAttachment){return(
+const _9ktrsx = function _getFileAttachments(main,FileAttachment,getFileAttachmentsMap){return(
 function getFileAttachments(module = main) {
   // classic observablehq.com gives each notebook its own FileAttachment in module._builtins;
   // notebook-kit (new.observablehq.com) has one runtime-level builtin keyed by resolved href
@@ -11679,7 +13371,7 @@ function getFileAttachments(module = main) {
   return files;
 }
 )};
-const _5nfcyp = function _getFileAttachmentsMap(){return(
+const _q5nm4v = function _getFileAttachmentsMap(){return(
 (FileAttachment) => {
   let fileMap;
   const backup_get = Map.prototype.get;
@@ -11796,8 +13488,8 @@ export default function define(runtime, observer) {
   $def("_lask4g", "setFileAttachment", ["main","getFileAttachmentsMap","viewof attachments","getFileAttachments","Event"], _lask4g);  
   $def("_12z6s2j", "getFileAttachment", ["main","getFileAttachments"], _12z6s2j);  
   $def("_jhq2u", "removeFileAttachment", ["main","getFileAttachmentsMap","viewof attachments","getFileAttachments","Event"], _jhq2u);  
-  $def("_1b0vy8x", "getFileAttachments", ["main","getFileAttachmentsMap","FileAttachment"], _1b0vy8x);  
-  $def("_5nfcyp", "getFileAttachmentsMap", [], _5nfcyp);  
+  $def("_9ktrsx", "getFileAttachments", ["main","FileAttachment","getFileAttachmentsMap"], _9ktrsx);  
+  $def("_q5nm4v", "getFileAttachmentsMap", [], _q5nm4v);  
   $def("_l3um8o", "FileAttachmentClass", ["sampleFileAttachment"], _l3um8o);  
   $def("_17tlw1p", "viewof fileInput", ["Inputs"], _17tlw1p);  
   $def("_kltp8w", "fileInput", ["Generators","viewof fileInput"], _kltp8w);  
@@ -11982,20 +13674,20 @@ const _1aloau2 = (G, _) => G.input(_);
 const _7s1qq7 = function _6($0,sqrt){return(
 $0.resolve(Math.sqrt(sqrt))
 )};
-const _3iwba4 = async function _testing(flowQueue) {
-    flowQueue;
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return Object.fromEntries(await Promise.all([
-        'expect',
-        'createSuite'
-    ].map(n => module.value(n).then(v => [
-        n,
-        v
-    ]))));
+const _3iwba4 = async function _testing(flowQueue)
+{
+  flowQueue;
+  // load after implementation
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return Object.fromEntries(
+    await Promise.all(
+      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
+    )
+  );
 };
 const _j8s3j1 = function _suite(testing){return(
 testing.createSuite({ name: 'Unit Tests' })
@@ -12637,14 +14329,18 @@ FileAttachment("lm_popin_black.png").url()
 const _18kpe1x = function _lm_popout_black(FileAttachment){return(
 FileAttachment("lm_popout_black.png").url()
 )};
-const _1p7i538 = async function _gl(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('golden-layout-2.6.0.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1p7i538 = async function _gl(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("golden-layout-2.6.0.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -12873,6 +14569,146 @@ export default function define(runtime, observer) {
   $def("_b5ui8y", "isnode", ["Element","Text"], _b5ui8y);
   return main;
 }</script>
+
+<script id="@tomlarkworthy/invoke-variable" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _zkje0r = function _1(md){return(
+md`# \`invokeVariable(<name>, <module>, overrides = {})\`
+
+Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
+)};
+const _swiym2 = function _invokeVariable(lookupVariable)
+{
+  return async function invokeVariable(name, module, overrides = {}) {
+    if (overrides == null || typeof overrides !== 'object')
+      throw new TypeError('invokeVariable(name, module, {overrides}): overrides must be an object');
+    // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
+    // the caller already holds it); otherwise resolve by (name, module).
+    let variable;
+    if (name && typeof name === 'object' && typeof name._definition !== 'undefined') {
+      variable = name;
+      module = module ?? variable._module;
+    } else {
+      if (typeof name !== 'string' || !name.length)
+        throw new TypeError('invokeVariable(name, module, \u2026): name must be a non-empty string');
+      if (!module)
+        throw new TypeError('invokeVariable(name, module, \u2026): module is required');
+      variable = await lookupVariable(name, module);
+      if (!variable)
+        throw new Error(`invokeVariable: variable "${ name }" not found in module`);
+    }
+    module = module ?? variable._module;
+    const label = variable._name ?? (typeof name === 'string' ? name : '(anonymous)');
+    const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
+    const inputNames = inputs.map(v => v?._name);
+    for (const k of Object.keys(overrides)) {
+      if (!inputNames.includes(k)) {
+        throw new Error(`invokeVariable("${ label }"): override "${ k }" was provided but is not a declared dependency. Declared dependencies: ${ inputNames.filter(Boolean).join(', ') }`);
+      }
+    }
+    const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
+    const resolveDependency = async depName => {
+      if (hasOwn(overrides, depName))
+        return overrides[depName];
+      const scopeVar = module?._scope?.get?.(depName) ?? module?._runtime?._builtin?._scope?.get?.(depName);
+      if (scopeVar) {
+        if (scopeVar._value !== undefined)
+          return scopeVar._value;
+        if (scopeVar._promise && typeof scopeVar._promise?.then === 'function')
+          return await scopeVar._promise;
+      }
+      if (typeof module?.value === 'function') {
+        try {
+          return await module.value(depName);
+        } catch (e) {
+        }
+      }
+      if (module?._runtime && typeof module._runtime._global === 'function') {
+        try {
+          const g = module._runtime._global(depName);
+          if (g !== undefined)
+            return g;
+        } catch (e) {
+        }
+      }
+      throw new Error(`invokeVariable("${ label }"): could not resolve dependency "${ depName }" (no override and not found in module/builtins/global)`);
+    };
+    const args = [];
+    for (const dep of inputs) {
+      const depName = dep?._name;
+      if (!depName) {
+        args.push(undefined);
+        continue;
+      }
+      args.push(await resolveDependency(depName));
+    }
+    const def = variable._definition;
+    if (typeof def !== 'function') {
+      throw new Error(`invokeVariable("${ label }"): target variable does not have an invokable function definition`);
+    }
+    return def(...args);
+  };
+};
+const _jtrr9m = function _3(md){return(
+md`### Example
+
+let c = a + b`
+)};
+const _1v2c0s1 = function _a(){return(
+1
+)};
+const _ywl8oh = function _b(){return(
+3
+)};
+const _1mc3tpl = function _c(a,b){return(
+a + b
+)};
+const _o5e50u = function _7(md){return(
+md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
+)};
+const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule)
+)};
+const _smh5by = function _9(md){return(
+md`But we can set b to 20, and then we get the answer 21.`
+)};
+const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
+invokeVariable("c", invokeVariableModule, { b: 20 })
+)};
+const _qh0yhm = function _11(md){return(
+md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
+)};
+const _1hy0qcz = function _invokeVariableModule(thisModule){return(
+thisModule()
+)};
+const _jno7wc = (G, _) => G.input(_);
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  $def("_zkje0r", null, ["md"], _zkje0r);  
+  $def("_swiym2", "invokeVariable", ["lookupVariable"], _swiym2);  
+  $def("_jtrr9m", null, ["md"], _jtrr9m);  
+  $def("_1v2c0s1", "a", [], _1v2c0s1);  
+  $def("_ywl8oh", "b", [], _ywl8oh);  
+  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
+  $def("_o5e50u", null, ["md"], _o5e50u);  
+  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
+  $def("_smh5by", null, ["md"], _smh5by);  
+  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
+  $def("_qh0yhm", null, ["md"], _qh0yhm);  
+  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
+  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
+  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
+  return main;
+}</script>
 <script id="@tomlarkworthy/isomorphic-git-1-30-1/isomorphic-git-1%401.30.1.bundle.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -12902,23 +14738,35 @@ import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1"
 import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 ~~~`
 )};
-const _vz8us1 = async function _git(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('isomorphic-git-1@1.30.1.bundle.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _vz8us1 = async function _git(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("isomorphic-git-1@1.30.1.bundle.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
-const _2acekr = async function _http(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('isomorphic-git-http-1.0.0-beta.36.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _2acekr = async function _http(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("isomorphic-git-http-1.0.0-beta.36.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _1emihnv = function _4(md){return(
 md`
@@ -12992,15 +14840,21 @@ md`# jest-expect-standalone@24.0.2
 import {expect} from "@tomlarkworthy/jest-expect-standalone"
 ~~~`
 )};
-const _mh1f13 = async function _expect(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('jest-expect-standalone-24.0.2.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        await import(objectURL);
-        return window.expect;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _mh1f13 = async function _expect(unzip,FileAttachment)
+{
+  const blob = await unzip(
+    FileAttachment("jest-expect-standalone-24.0.2.js.gz")
+  );
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    await import(objectURL);
+    return window.expect;
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -13045,14 +14899,18 @@ md`# [jszip@3.10.1](https://stuk.github.io/jszip/)
 import {JSZip} from "@tomlarkworthy/jszip-3-10-1"
 ~~~`
 )};
-const _umavbe = async function _JSZip(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('jszip-3.10.1.min.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return (await import(objectURL)).default;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _umavbe = async function _JSZip(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("jszip-3.10.1.min.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return (await import(objectURL)).default;
+  } finally {
+    URL.revokeObjectURL(objectURL); // Ensure URL is revoked after import
+  }
 };
 const _g5fwfs = function _unzip(Response,DecompressionStream){return(
 async (attachment) => {
@@ -13104,14 +14962,18 @@ import {FS} from "@tomlarkworthy/lightning-fs-4-6-0"
 import {git, http} from "@tomlarkworthy/isomorphic-git-1-30-1" 
 ~~~`
 )};
-const _1tds3ro = async function _FS(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('lightning-fs-4.6.0.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return (await import(objectURL)).default;
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _1tds3ro = async function _FS(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("lightning-fs-4.6.0.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return (await import(objectURL)).default;
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _dqri64 = function _3(md){return(
 md`
@@ -14166,7 +16028,7 @@ async function listBranches({repo} = {}) {
   }
 }
 )};
-const _1bvisll = function _listFiles(ensure_branch,git,fs){return(
+const _bvp3oz = function _listFiles(ensure_branch,git,fs){return(
 async function listFiles({repo, branch, ref} = {}) {
   if (!repo)
     throw new Error('repo is required');
@@ -15125,7 +16987,7 @@ export default function define(runtime, observer) {
   $def("_1c4d7y5", "setFilesAndCommit", ["ensure_branch","git","fs","ensure_dir"], _1c4d7y5);  
   $def("_veyumo", "listRepos", ["fs"], _veyumo);  
   $def("_1rusr2m", "listBranches", ["ensure_repo","git","fs"], _1rusr2m);  
-  $def("_1bvisll", "listFiles", ["ensure_branch","git","fs"], _1bvisll);  
+  $def("_bvp3oz", "listFiles", ["ensure_branch","git","fs"], _bvp3oz);  
   $def("_xl9zth", "listCommits", ["ensure_branch","git","fs"], _xl9zth);  
   $def("_h6ylpe", "getCommitChanges", ["git","fs"], _h6ylpe);  
   $def("_fw7q7v", "getCompactISODate", [], _fw7q7v);  
@@ -16007,35 +17869,33 @@ module -> {
 }
 \`\`\``
 )};
-const _1798myt = function _moduleMap(runtime,keepalive,myModule,$0){return(
-async (
-  _runtime = runtime,
-  {
-    cache = new Map() // module -> {name}
-  } = {}
-) => {
-  if (!_runtime || !_runtime._variables)
-    throw "Invalid runtime passed to moduleMap";
-  keepalive(myModule, "submit_summary");
-  keepalive(myModule, "sync_modules");
-  keepalive(myModule, "currentModules");
-  return await $0.send({
-    runtime: _runtime,
-    cache: cache
-  });
-}
-)};
+const _1hn3uql = function _moduleMap(runtime,keepalive,myModule,$0)
+{
+  return async (_runtime = runtime, {
+    cache = new Map()  // module -> {name}
+  } = {}) => {
+    if (!_runtime || !_runtime._variables)
+      throw 'Invalid runtime passed to moduleMap';
+    keepalive(myModule, 'submit_summary');
+    keepalive(myModule, 'sync_modules');
+    keepalive(myModule, 'currentModules');
+    return await $0.send({
+      runtime: _runtime,
+      cache: cache
+    });
+  };
+};
 const _1yso65r = function _5(md){return(
 md`### \`currentModules\``
 )};
-const _1fcoh6x = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
+const _1e3kr85 = async function _sync_modules(runtime_variables,moduleMap,_,$0,Event)
 {
   runtime_variables;
   const latest = await moduleMap();
   let dirty = !this || !_.isEqual(new Set(latest.keys()), new Set(this.keys()));
   if (dirty) {
     $0.value = latest;
-    $0.dispatchEvent(new Event("input"));
+    $0.dispatchEvent(new Event('input'));
   }
   return $0.value;
 };
@@ -16043,261 +17903,260 @@ const _wi39n0 = async function _currentModules(Inputs,moduleMap){return(
 Inputs.input(await moduleMap())
 )};
 const _1gxgyd6 = (G, _) => G.input(_);
-const _1qag34d = function _8(Inputs,currentModules){return(
+const _1kxoygl = function _8(Inputs,currentModules){return(
 Inputs.table([...currentModules.values()], {
   format: {
-    dom: (d) => d.innerHTML,
+    dom: d => d.innerHTML,
     specifiers: JSON.stringify,
-    variable: (v) => v._name
+    variable: v => v._name
   }
 })
 )};
 const _1xamz8j = function _9(md){return(
 md`### Visualization`
 )};
-const _1n4p4hn = function _tipTitle(){return(
-([k, c]) => 
-`${k}\ndependsOn: [\n  ${(c[3].dependsOn || []).join(
-  "\n  "
-)}\n]\ndependedBy: [\n  ${(c[3].dependedBy || []).join("\n  ")}\n]`
+const _1sglrv3 = function _tipTitle(){return(
+([k, c]) => `${ k }\ndependsOn: [\n  ${ (c[3].dependsOn || []).join('\n  ') }\n]\ndependedBy: [\n  ${ (c[3].dependedBy || []).join('\n  ') }\n]`
 )};
-const _1kdcb71 = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom)
-{
-  return ({ useSpectral = true } = {}) => {
-    const modules = [...currentModules.values()].filter((m) => m && m.name);
-    const n = modules.length;
-    if (n === 0) return htl.svg`<svg width="1" height="1"></svg>`;
-
-    const indexOf = new Map(modules.map((m, i) => [m.name, i]));
-
-    const undirectedEdges = [];
-    const seen = new Set();
+const _5zbe1k = function _visualizeModules(currentModules,htl,d3,spectralCircleOrder,improveOrderSifting,bestOfRandomOrders,Plot,tipTitle,linkTo,isOnObservableCom){return(
+({
+  useSpectral = true
+} = {}) => {
+  const modules = [...currentModules.values()].filter(m => m && m.name);
+  const n = modules.length;
+  if (n === 0)
+    return htl.svg`<svg width="1" height="1"></svg>`;
+  const indexOf = new Map(modules.map((m, i) => [
+    m.name,
+    i
+  ]));
+  const undirectedEdges = [];
+  const seen = new Set();
+  for (let i = 0; i < n; i++) {
+    const from = modules[i];
+    for (const toName of from.dependsOn || []) {
+      const j = indexOf.get(toName);
+      if (j == null || j === i)
+        continue;
+      const a = Math.min(i, j), b = Math.max(i, j);
+      const k = `${ a },${ b }`;
+      if (seen.has(k))
+        continue;
+      seen.add(k);
+      undirectedEdges.push([
+        a,
+        b
+      ]);
+    }
+  }
+  const buildCSRLocal = (n, edges) => {
+    const adj = Array.from({ length: n }, () => []);
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      if (a < 0 || b < 0 || a >= n || b >= n)
+        continue;
+      adj[a].push(b);
+      adj[b].push(a);
+    }
+    const deg = new Float64Array(n);
+    let nnz = 0;
     for (let i = 0; i < n; i++) {
-      const from = modules[i];
-      for (const toName of from.dependsOn || []) {
-        const j = indexOf.get(toName);
-        if (j == null || j === i) continue;
-        const a = Math.min(i, j),
-          b = Math.max(i, j);
-        const k = `${a},${b}`;
-        if (seen.has(k)) continue;
-        seen.add(k);
-        undirectedEdges.push([a, b]);
+      const row = adj[i];
+      row.sort((x, y) => x - y);
+      let w = 0;
+      for (let j = 0; j < row.length; j++)
+        if (w === 0 || row[j] !== row[w - 1])
+          row[w++] = row[j];
+      row.length = w;
+      deg[i] = w;
+      nnz += w;
+    }
+    const rowPtr = new Int32Array(n + 1);
+    const colIdx = new Int32Array(nnz);
+    const val = new Float64Array(nnz);
+    let p = 0;
+    for (let i = 0; i < n; i++) {
+      rowPtr[i] = p;
+      const row = adj[i];
+      for (let j = 0; j < row.length; j++) {
+        colIdx[p] = row[j];
+        val[p] = 1;
+        p++;
       }
     }
-
-    const buildCSRLocal = (n, edges) => {
-      const adj = Array.from({ length: n }, () => []);
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        if (a < 0 || b < 0 || a >= n || b >= n) continue;
-        adj[a].push(b);
-        adj[b].push(a);
-      }
-      const deg = new Float64Array(n);
-      let nnz = 0;
-      for (let i = 0; i < n; i++) {
-        const row = adj[i];
-        row.sort((x, y) => x - y);
-        let w = 0;
-        for (let j = 0; j < row.length; j++)
-          if (w === 0 || row[j] !== row[w - 1]) row[w++] = row[j];
-        row.length = w;
-        deg[i] = w;
-        nnz += w;
-      }
-      const rowPtr = new Int32Array(n + 1);
-      const colIdx = new Int32Array(nnz);
-      const val = new Float64Array(nnz);
-      let p = 0;
-      for (let i = 0; i < n; i++) {
-        rowPtr[i] = p;
-        const row = adj[i];
-        for (let j = 0; j < row.length; j++) {
-          colIdx[p] = row[j];
-          val[p] = 1;
-          p++;
-        }
-      }
-      rowPtr[n] = p;
-      return { n, rowPtr, colIdx, val, deg };
+    rowPtr[n] = p;
+    return {
+      n,
+      rowPtr,
+      colIdx,
+      val,
+      deg
     };
-
-    const crossingsCountLocal = (n, edges, order) => {
-      const pos = new Int32Array(n);
-      for (let i = 0; i < n; i++) pos[order[i]] = i;
-
-      const intervals = [];
-      for (const [a0, b0] of edges) {
-        const a = a0 | 0,
-          b = b0 | 0;
-        if (a === b) continue;
-        const i = pos[a],
-          j = pos[b];
-        const s = Math.min(i, j),
-          t = Math.max(i, j);
-        if (s === t) continue;
-        intervals.push([s, t]);
-      }
-
-      intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
-      const bit = new Int32Array(n + 1);
-      const add = (i) => {
-        for (let x = i + 1; x <= n; x += x & -x) bit[x]++;
-      };
-      const sum = (i) => {
-        let s = 0;
-        for (let x = i + 1; x > 0; x -= x & -x) s += bit[x];
-        return s;
-      };
-      const range = (l, r) => (r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0));
-
-      let crossings = 0;
-      let k = 0;
-      while (k < intervals.length) {
-        const s = intervals[k][0];
-        let k2 = k;
-        while (k2 < intervals.length && intervals[k2][0] === s) k2++;
-        for (let t = k; t < k2; t++)
-          crossings += range(s + 1, intervals[t][1] - 1);
-        for (let t = k; t < k2; t++) add(intervals[t][1]);
-        k = k2;
-      }
-      return crossings;
+  };
+  const crossingsCountLocal = (n, edges, order) => {
+    const pos = new Int32Array(n);
+    for (let i = 0; i < n; i++)
+      pos[order[i]] = i;
+    const intervals = [];
+    for (const [a0, b0] of edges) {
+      const a = a0 | 0, b = b0 | 0;
+      if (a === b)
+        continue;
+      const i = pos[a], j = pos[b];
+      const s = Math.min(i, j), t = Math.max(i, j);
+      if (s === t)
+        continue;
+      intervals.push([
+        s,
+        t
+      ]);
+    }
+    intervals.sort((p, q) => p[0] - q[0] || p[1] - q[1]);
+    const bit = new Int32Array(n + 1);
+    const add = i => {
+      for (let x = i + 1; x <= n; x += x & -x)
+        bit[x]++;
     };
-
-    let orderIdx;
-    if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
-      orderIdx = Int32Array.from(d3.range(n));
-    } else {
-      const csr = buildCSRLocal(n, undirectedEdges);
-
-      const spectral = spectralCircleOrder(csr, {
-        alpha: 0.92,
-        maxIters: 80,
-        tol: 1e-4,
-        seed: 1,
-        passesOrtho: 1
-      });
-
-      const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
-        passes: 1,
-        vertexSequence: "order"
-      });
-
-      const baseline = bestOfRandomOrders(n, undirectedEdges, {
-        R: Math.min(n, 12),
-        seed: 1,
-        postSiftPasses: 0
-      });
-
-      const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
-      orderIdx =
-        baseline?.order && baseline.crossings < cSift
-          ? baseline.order
-          : sifted.order;
+    const sum = i => {
+      let s = 0;
+      for (let x = i + 1; x > 0; x -= x & -x)
+        s += bit[x];
+      return s;
+    };
+    const range = (l, r) => r < l ? 0 : sum(r) - (l > 0 ? sum(l - 1) : 0);
+    let crossings = 0;
+    let k = 0;
+    while (k < intervals.length) {
+      const s = intervals[k][0];
+      let k2 = k;
+      while (k2 < intervals.length && intervals[k2][0] === s)
+        k2++;
+      for (let t = k; t < k2; t++)
+        crossings += range(s + 1, intervals[t][1] - 1);
+      for (let t = k; t < k2; t++)
+        add(intervals[t][1]);
+      k = k2;
     }
-
-    const R = 100;
-    const nodes = new Map();
-    for (let p = 0; p < n; p++) {
-      const vid = orderIdx[p] | 0;
-      const a = (p * 2 * Math.PI) / n;
-      const [x, y] = d3.pointRadial(a, R);
-      const deg = (p * 360) / n;
-      nodes.set(modules[vid].name, [x, y, deg, modules[vid]]);
-    }
-
-    const edges = modules.flatMap((from) =>
-      (from.dependsOn || [])
-        .filter((to) => nodes.has(to))
-        .map((to) => [
-          [from.name, nodes.get(from.name)],
-          [to, nodes.get(to)]
-        ])
-    );
-
-    const plot = Plot.plot({
-      inset: 180,
-      aspectRatio: 1,
-      axis: null,
-      marks: [
-        () => htl.svg`<defs>
+    return crossings;
+  };
+  let orderIdx;
+  if (n <= 2 || undirectedEdges.length === 0 || !useSpectral) {
+    orderIdx = Int32Array.from(d3.range(n));
+  } else {
+    const csr = buildCSRLocal(n, undirectedEdges);
+    const spectral = spectralCircleOrder(csr, {
+      alpha: 0.92,
+      maxIters: 80,
+      tol: 0.0001,
+      seed: 1,
+      passesOrtho: 1
+    });
+    const sifted = improveOrderSifting(n, undirectedEdges, spectral.order, {
+      passes: 1,
+      vertexSequence: 'order'
+    });
+    const baseline = bestOfRandomOrders(n, undirectedEdges, {
+      R: Math.min(n, 12),
+      seed: 1,
+      postSiftPasses: 0
+    });
+    const cSift = crossingsCountLocal(n, undirectedEdges, sifted.order);
+    orderIdx = baseline?.order && baseline.crossings < cSift ? baseline.order : sifted.order;
+  }
+  const R = 100;
+  const nodes = new Map();
+  for (let p = 0; p < n; p++) {
+    const vid = orderIdx[p] | 0;
+    const a = p * 2 * Math.PI / n;
+    const [x, y] = d3.pointRadial(a, R);
+    const deg = p * 360 / n;
+    nodes.set(modules[vid].name, [
+      x,
+      y,
+      deg,
+      modules[vid]
+    ]);
+  }
+  const edges = modules.flatMap(from => (from.dependsOn || []).filter(to => nodes.has(to)).map(to => [
+    [
+      from.name,
+      nodes.get(from.name)
+    ],
+    [
+      to,
+      nodes.get(to)
+    ]
+  ]));
+  const plot = Plot.plot({
+    inset: 180,
+    aspectRatio: 1,
+    axis: null,
+    marks: [
+      () => htl.svg`<defs>
           <linearGradient id="gradient">
             <stop offset="15%" stop-color="red" />
             <stop offset="100%" stop-color="gold" />
           </linearGradient>
         </defs>`,
-        Plot.arrow(edges, {
-          x1: ([[, [x1]]]) => x1,
-          y1: ([[, [, y1]]]) => y1,
-          x2: ([, [, [x2]]]) => x2,
-          y2: ([, [, [, y2]]]) => y2,
-          bend: true,
-          stroke: "url(#gradient)",
-          strokeOpacity: 0.5,
-          strokeLinejoin: "miter",
-          headLength: 3,
-          inset: 5
-        }),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] > 180),
-          {
-            textAnchor: "end",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.text(
-          [...nodes.entries()].filter(([, c]) => c[2] <= 180),
-          {
-            fontSize: 12,
-            textAnchor: "start",
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
-            text: ([k]) => k
-          }
-        ),
-        Plot.tip(
-          nodes.entries(),
-          Plot.pointer({
-            x: ([, c]) => c[0],
-            y: ([, c]) => c[1],
-            title: tipTitle,
-            maxRadius: Infinity
-          })
-        )
-      ]
-    });
-
-    const xmlns = "http://www.w3.org/2000/svg";
-    const xlink = "http://www.w3.org/1999/xlink";
-    for (const text of plot.querySelectorAll("text")) {
-      const moduleName = text.textContent;
-      let url;
-      try {
-        url = linkTo(moduleName);
-      } catch {
-        continue;
-      }
-      const a = document.createElementNS(xmlns, "a");
-      a.setAttributeNS(null, "href", url);
-      a.setAttributeNS(xlink, "href", url);
-      text.parentNode.insertBefore(a, text);
-      if (isOnObservableCom()) {
-        a.setAttribute("target", "_blank");
-      }
-      a.appendChild(text);
+      Plot.arrow(edges, {
+        x1: ([[, [x1]]]) => x1,
+        y1: ([[, [, y1]]]) => y1,
+        x2: ([, [, [x2]]]) => x2,
+        y2: ([, [, [, y2]]]) => y2,
+        bend: true,
+        stroke: 'url(#gradient)',
+        strokeOpacity: 0.5,
+        strokeLinejoin: 'miter',
+        headLength: 3,
+        inset: 5
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] > 180), {
+        textAnchor: 'end',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.text([...nodes.entries()].filter(([, c]) => c[2] <= 180), {
+        fontSize: 12,
+        textAnchor: 'start',
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        rotate: ([, c]) => -c[2] - (c[2] > 180 ? 90 : -90),
+        text: ([k]) => k
+      }),
+      Plot.tip(nodes.entries(), Plot.pointer({
+        x: ([, c]) => c[0],
+        y: ([, c]) => c[1],
+        title: tipTitle,
+        maxRadius: Infinity
+      }))
+    ]
+  });
+  const xmlns = 'http://www.w3.org/2000/svg';
+  const xlink = 'http://www.w3.org/1999/xlink';
+  for (const text of plot.querySelectorAll('text')) {
+    const moduleName = text.textContent;
+    let url;
+    try {
+      url = linkTo(moduleName);
+    } catch {
+      continue;
     }
-
-    return plot;
-  };
-};
+    const a = document.createElementNS(xmlns, 'a');
+    a.setAttributeNS(null, 'href', url);
+    a.setAttributeNS(xlink, 'href', url);
+    text.parentNode.insertBefore(a, text);
+    if (isOnObservableCom()) {
+      a.setAttribute('target', '_blank');
+    }
+    a.appendChild(text);
+  }
+  return plot;
+}
+)};
 const _hgwvol = function _12(md){return(
 md`### Random helpers`
 )};
@@ -16308,88 +18167,85 @@ const _1cir47e = (G, _) => G.input(_);
 const _1nfaybn = function _tag(){return(
 Symbol()
 )};
-const _17qqkoj = function _forcePeek()
+const _1lkbrun = function _forcePeek()
 {
   //console.log("force peek");
-  return (variable, { forever = false } = {}) => {
-    if (variable._value) return variable._value;
+  return (variable, {
+    forever = false
+  } = {}) => {
+    if (variable._value)
+      return variable._value;
     let peeker;
     const promise = new Promise((fulfilled, rejected) => {
-      peeker = variable._module
-        .variable({
-          fulfilled,
-          rejected
-        })
-        .define([variable._name], (m) => m);
+      peeker = variable._module.variable({
+        fulfilled,
+        rejected
+      }).define([variable._name], m => m);
     });
-    if (!forever) promise.finally((v) => peeker.delete());
-    return Promise.race([promise, new Promise((_, r) => setTimeout(r, 1000))]);
+    if (!forever)
+      promise.finally(v => peeker.delete());
+    return Promise.race([
+      promise,
+      new Promise((_, r) => setTimeout(r, 1000))
+    ]);
   };
 };
-const _v9hg2i = function _observe(){return(
+const _1qva85d = function _observe(){return(
 (module, variable_name, observer) => {
-  const variable = module
-    .variable(observer)
-    .define(`dynamic observe ${variable_name}`, [variable_name], (m) => m);
+  const variable = module.variable(observer).define(`dynamic observe ${ variable_name }`, [variable_name], m => m);
   return () => variable.delete();
 }
 )};
 const _1bm642i = function _17(md){return(
 md`### Implementation`
 )};
-const _oothhq = function _queue(flowQueue){return(
-flowQueue({ timeout_ms: 15000, dedupe: true })
+const _1f31b1g = function _queue(flowQueue){return(
+flowQueue({
+  timeout_ms: 15000,
+  dedupe: true
+})
 )};
 const _648shl = (G, _) => G.input(_);
 const _1acbzli = function _19(md){return(
 md`We resolve what we can using variables named with prefix \`module\` that hold module values. We \`forcePeek\` the variables to make them resolve, which forces loading of the modules.`
 )};
-const _10dhunq = async function _module_definition_variables(notebookImports,queue)
+const _1g0cuj1 = async function _module_definition_variables(notebookImports,queue)
 {
-  console.log("module_definition_variables");
+  console.log('module_definition_variables');
   notebookImports;
   queue;
   let last_module_count = -1;
   let module_definition_variables = [];
   while (last_module_count < module_definition_variables.length) {
     last_module_count = module_definition_variables.length;
-    module_definition_variables = (
-      await Promise.all(
-        [...queue.runtime._variables]
-          .filter((v) => v._name && v._name.startsWith("module "))
-          .filter((v) => !v._name.startsWith("module <unknown"))
-          .map(async (v) => {
-            try {
-              v._value = await Promise.race([
-                v._definition(),
-                new Promise((_, reject) =>
-                  setTimeout(() => reject(new Error("timeout")), 1000)
-                )
-              ]);
-              return [v];
-            } catch (err) {
-              console.error("error loading module", v._name, err);
-              return [];
-            }
-          })
-      )
-    ).flat();
+    module_definition_variables = (await Promise.all([...queue.runtime._variables].filter(v => v._name && v._name.startsWith('module ')).filter(v => !v._name.startsWith('module <unknown')).map(async v => {
+      try {
+        v._value = await Promise.race([
+          v._definition(),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 1000))
+        ]);
+        return [v];
+      } catch (err) {
+        console.error('error loading module', v._name, err);
+        return [];
+      }
+    }))).flat();
   }
   return module_definition_variables;
 };
-const _dcxoxy = function _modules(module_definition_variables,queue)
+const _17frsyf = function _modules(module_definition_variables,queue)
 {
-  console.log("modules");
+  console.log('modules');
   module_definition_variables;
-  return [...new Set([...queue.runtime._variables].map((v) => v._module))];
+  return [...new Set([...queue.runtime._variables].map(v => v._module))];
 };
 const _1dqpbvy = function _builtin(queue){return(
 queue.runtime._builtin
 )};
-const _ir3ob0 = function _main_modules(queue,modules,builtin)
+const _13mmmk9 = function _main_modules(queue,modules,builtin)
 {
   const imports = new Set(queue.runtime._modules.values());
-  return modules.filter((m) => !imports.has(m) && m !== builtin);
+  return modules.filter(m => !imports.has(m) && m !== builtin);
 };
 const _yflsv5 = function _bootloaded_mains(queue){return(
 queue.runtime.mains || new Map()
@@ -16397,16 +18253,16 @@ queue.runtime.mains || new Map()
 const _ox2g3b = function _bootloader(queue){return(
 queue.runtime.bootloader
 )};
-const _1turw8j = function _resolve_modules(modules,module_definition_variables,findModuleName)
+const _10ufqkh = function _resolve_modules(modules,module_definition_variables,findModuleName)
 {
-  console.log("resolve_modules");
+  console.log('resolve_modules');
   const module_definitions = new Map();
   const unresolved = [];
-  modules.forEach((m) => {
-    const md = module_definition_variables.find((md) => md._value == m);
+  modules.forEach(m => {
+    const md = module_definition_variables.find(md => md._value == m);
     if (md) {
       module_definitions.set(m, {
-        type: "module variable",
+        type: 'module variable',
         name: findModuleName(md._module._scope, m),
         variable: md
       });
@@ -16414,239 +18270,218 @@ const _1turw8j = function _resolve_modules(modules,module_definition_variables,f
       unresolved.push(m);
     }
   });
-  return { module_definitions, unresolved };
+  return {
+    module_definitions,
+    unresolved
+  };
 };
 const _9fbvam = function _27(md){return(
 md`modules imported via notebook imports do not have module variables, so they are trickier to figure out. We can sniff the page DOM to find the import expressions, and try to map them to the modules we could to resolve earlier`
 )};
-const _1h0lryb = function _notebookImports(main,parser)
+const _1t4ga3d = function _notebookImports(main,parser)
 {
-  console.log("notebookImports");
+  console.log('notebookImports');
   main;
-  return new Map(
-    [...document.querySelectorAll(".observablehq--import")]
-      .map((dom) => [dom, parser.parseCell(dom.textContent)])
-      .map(([dom, node]) => [
-        dom.parentElement,
-        node.body.specifiers.map((s) => ({
-          name: node.body.source.value,
-          dom: dom.parentElement,
-          ast: s,
-          local: s.local.name,
-          imported: s.imported.name
-        }))
-      ])
-  );
+  return new Map([...document.querySelectorAll('.observablehq--import')].map(dom => [
+    dom,
+    parser.parseCell(dom.textContent)
+  ]).map(([dom, node]) => [
+    dom.parentElement,
+    node.body.specifiers.map(s => ({
+      name: node.body.source.value,
+      dom: dom.parentElement,
+      ast: s,
+      local: s.local.name,
+      imported: s.imported.name
+    }))
+  ]));
 };
-const _7t198q = function _notebookImportVariables(runtime,notebookImports)
+const _994hn4 = function _notebookImportVariables(runtime,notebookImports)
 {
-  console.log("notebookImportVariables");
+  console.log('notebookImportVariables');
   return [
-    ...[...runtime._variables] // Observable DOM nodes are referenced in runtime variables
-      .filter(
-        (v) =>
-          v._observer &&
-          v._observer._node &&
-          notebookImports.get(v._observer._node)
-      )
-      .map((v) => ({
-        variable: v,
-        notebookImports: notebookImports.get(v._observer._node)
-      })),
-    ...[
-      ...[...notebookImports.entries()] // visualizer DOM nodes have the variable attached
-        .filter(([pi, vars]) => pi.variable)
-        .map(([pi, vars]) => ({
-          variable: pi.variable,
-          notebookImports: vars
-        }))
-    ]
-  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length); // sort by complexity
+    ...[...runtime._variables]  // Observable DOM nodes are referenced in runtime variables
+.filter(v => v._observer && v._observer._node && notebookImports.get(v._observer._node)).map(v => ({
+      variable: v,
+      notebookImports: notebookImports.get(v._observer._node)
+    })),
+    ...[...[...notebookImports.entries()]  // visualizer DOM nodes have the variable attached
+.filter(([pi, vars]) => pi.variable).map(([pi, vars]) => ({
+        variable: pi.variable,
+        notebookImports: vars
+      }))]
+  ].sort((a, b) => b.notebookImports.length - a.notebookImports.length);  // sort by complexity
 };
-const _1lyens8 = function _pageImportMatch(){return(
-async (notebookImportVariables, modules) => {
-  console.log("pageImportMatch");
-  const backupHas = Map.prototype.has; // Save the original `has` method on Map.prototype
-
-  let currentImport = undefined;
-  const matches = new Map();
-  // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
-  Map.prototype.has = function (...args) {
-    const module = modules.find((m) => m._scope == this);
-    if (currentImport && module) {
-      matches.set(module, {
-        name: currentImport.notebookImports[0].name,
-        type: "notebook import",
-        module: module,
-        dependsOn: [],
-        dependedBy: [],
-        dom: currentImport.notebookImports[0].dom,
-        specifiers: currentImport.notebookImports.map((pi) => ({
-          local: pi.local,
-          imported: pi.imported,
-          variable: pi.variable
-        }))
-      });
-    }
-    return backupHas.call(this, ...args); // Call the original `has` method
-  };
-
-  // Iterate through the notebook imports and define them while capturing `has` calls
-
-  await notebookImportVariables.reduce((chain, pageImportVariable) => {
-    // Call the definition chain
-    return chain.then(async () => {
-      currentImport = pageImportVariable;
-      try {
-        await pageImportVariable.variable._definition();
-      } catch (err) {
-        console.warn(err);
-      }
-      currentImport = undefined;
-    });
-  }, Promise.resolve());
-
-  // Restore the original `has` method after the operations are done
-  Map.prototype.has = backupHas;
-
-  return matches;
-}
-)};
-const _1akt4kz = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+const _xanizk = function _pageImportMatch()
 {
-  console.log("notebookImportMatches");
+  return async (notebookImportVariables, modules) => {
+    console.log('pageImportMatch');
+    const backupHas = Map.prototype.has;
+    // Save the original `has` method on Map.prototype
+    let currentImport = undefined;
+    const matches = new Map();
+    // Override `Map.prototype.has` to intercept calls to `has` on any Map instance
+    Map.prototype.has = function (...args) {
+      const module = modules.find(m => m._scope == this);
+      if (currentImport && module) {
+        matches.set(module, {
+          name: currentImport.notebookImports[0].name,
+          type: 'notebook import',
+          module: module,
+          dependsOn: [],
+          dependedBy: [],
+          dom: currentImport.notebookImports[0].dom,
+          specifiers: currentImport.notebookImports.map(pi => ({
+            local: pi.local,
+            imported: pi.imported,
+            variable: pi.variable
+          }))
+        });
+      }
+      return backupHas.call(this, ...args);  // Call the original `has` method
+    };
+    // Iterate through the notebook imports and define them while capturing `has` calls
+    await notebookImportVariables.reduce((chain, pageImportVariable) => {
+      // Call the definition chain
+      return chain.then(async () => {
+        currentImport = pageImportVariable;
+        try {
+          await pageImportVariable.variable._definition();
+        } catch (err) {
+          console.warn(err);
+        }
+        currentImport = undefined;
+      });
+    }, Promise.resolve());
+    // Restore the original `has` method after the operations are done
+    Map.prototype.has = backupHas;
+    return matches;
+  };
+};
+const _1q5pc6n = function _notebookImportMatches(pageImportMatch,notebookImportVariables,modules)
+{
+  console.log('notebookImportMatches');
   return pageImportMatch(notebookImportVariables, modules);
 };
-const _1ang0sg = function _moduleTitle(observeVariable){return(
-async function moduleTitle(module) {
-  const runtime = module._runtime;
-  const vars = [...runtime._variables].filter(
-    (v) => v && v._module === module && v._definition
-  );
-  const candidates = vars.filter((v) => {
-    const n = v._name;
-    if (v._type != 1) return false;
-    if (n == null) return true;
-    if (typeof n !== "string") return true;
-    if (n.startsWith("dynamic observe ")) return false;
-    if (n.startsWith("module ")) return false;
-    return true;
-  });
-
-  if (candidates.length === 0) return null;
-
-  const first = candidates.find(
-    (v) => typeof v._id === "number" && Number.isFinite(v._id)
-  )
-    ? candidates.reduce((a, b) =>
-        (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b
-      )
-    : candidates[0];
-
-  const extract = (v) => {
-    // instanceof cannot be used hear for cross realm
-    if (v == null) return null;
-    if (typeof v === "string") return v.trim() || null;
-    if (v.tagName) {
-      if (v.tagName == "H1") return v.textContent;
-      const h1 = v.querySelector?.("h1");
-      if (h1) return (h1.textContent ?? "").trim() || null;
+const _12o3fj5 = function _moduleTitle(observeVariable)
+{
+  return async function moduleTitle(module) {
+    const runtime = module._runtime;
+    const vars = [...runtime._variables].filter(v => v && v._module === module && v._definition);
+    const candidates = vars.filter(v => {
+      const n = v._name;
+      if (v._type != 1)
+        return false;
+      if (n == null)
+        return true;
+      if (typeof n !== 'string')
+        return true;
+      if (n.startsWith('dynamic observe '))
+        return false;
+      if (n.startsWith('module '))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0)
       return null;
-    }
-    if (v.textContent) return (v.textContent ?? "").trim() || null;
-    const maybeNode = v?.nodeType ? v : null;
-    if (maybeNode?.tagName) return extract(maybeNode);
-    return null;
-  };
-
-  // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
-  // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
-  // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
-  // base_css <style>) out of the live page, breaking the frame. Instead:
-  //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
-  //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
-  //     existing variable reachable and replays its value, adding no intermediate variable (no
-  //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
-  //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
-  if (first._value !== undefined) return extract(first._value);
-  const peekValue = (v) =>
-    new Promise((resolve, reject) => {
+    const first = candidates.find(v => typeof v._id === 'number' && Number.isFinite(v._id)) ? candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b) : candidates[0];
+    const extract = v => {
+      // instanceof cannot be used hear for cross realm
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      const maybeNode = v?.nodeType ? v : null;
+      if (maybeNode?.tagName)
+        return extract(maybeNode);
+      return null;
+    };
+    // Read the title WITHOUT re-executing the cell. invokeVariable calls the cell's _definition
+    // directly, bypassing the runtime — for element cells (`htl.html`…${sharedNode}…``) that builds
+    // a *duplicate*, unmanaged DOM subtree and moves shared singleton nodes (e.g. golden-layout's
+    // base_css <style>) out of the live page, breaking the frame. Instead:
+    //  1. If already computed, read the settled _value (fast path, most modules — zero side-effects).
+    //  2. Else force the RUNTIME to compute the *single managed* variable via observe(): it marks the
+    //     existing variable reachable and replays its value, adding no intermediate variable (no
+    //     variable-set churn) and building only the one runtime-owned instance (no duplicate). We
+    //     attach a one-shot observer and fire its invalidation on first settle so it detaches again.
+    if (first._value !== undefined)
+      return extract(first._value);
+    const peekValue = v => new Promise((resolve, reject) => {
       let settled = false;
       let fireInvalidation;
-      const invalidation = new Promise((r) => (fireInvalidation = r));
+      const invalidation = new Promise(r => fireInvalidation = r);
       const finish = (fn, arg) => {
-        if (settled) return;
+        if (settled)
+          return;
         settled = true;
         fireInvalidation();
         fn(arg);
       };
-      observeVariable(
-        v,
-        {
-          fulfilled: (value) => finish(resolve, value),
-          rejected: (err) => finish(reject, err),
-          pending: () => {}
-        },
-        { invalidation }
-      );
+      observeVariable(v, {
+        fulfilled: value => finish(resolve, value),
+        rejected: err => finish(reject, err),
+        pending: () => {
+        }
+      }, { invalidation });
     });
-  try {
-    return extract(await peekValue(first));
-  } catch (err) {
-    return "Err";
-  }
-}
-)};
-const _197sgjt = async function _titles(modules,moduleTitle)
+    try {
+      return extract(await peekValue(first));
+    } catch (err) {
+      return 'Err';
+    }
+  };
+};
+const _ze3jk0 = async function _titles(modules,moduleTitle)
 {
-  const map = new Map(
-    await Promise.all(
-      [...modules].map(async (m) => [
-        m,
-        await Promise.race([
-          moduleTitle(m),
-          new Promise((resolve) =>
-            setTimeout(() => resolve("<TIMEOUT LOADING TITLE>"), 250)
-          )
-        ]).catch((e) => `err: ${e}`)
-      ])
-    )
-  );
+  const map = new Map(await Promise.all([...modules].map(async m => [
+    m,
+    await Promise.race([
+      moduleTitle(m),
+      new Promise(resolve => setTimeout(() => resolve('<TIMEOUT LOADING TITLE>'), 250))
+    ]).catch(e => `err: ${ e }`)
+  ])));
   return map;
 };
-const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
+const _pnpoh8 = function _summary(main_modules,titles,bootloader,builtin,queue,notebookImportMatches,bootloaded_mains,resolve_modules,module_definition_variables)
 {
-  console.log("generate summary");
+  console.log('generate summary');
   const modules = new Map([
-    ...main_modules.map((main_module) => [
+    ...main_modules.map(main_module => [
       main_module,
       {
-        name: "main",
+        name: 'main',
         module: main_module,
         title: titles.get(main_module),
         dependsOn: [],
         dependedBy: []
       }
     ]),
-    ...(bootloader
-      ? [
-          [
-            bootloader,
-            {
-              name: "bootloader",
-              title: "Bootloader",
-              module: bootloader,
-              dependsOn: [],
-              dependedBy: []
-            }
-          ]
-        ]
-      : []),
+    ...bootloader ? [[
+        bootloader,
+        {
+          name: 'bootloader',
+          title: 'Bootloader',
+          module: bootloader,
+          dependsOn: [],
+          dependedBy: []
+        }
+      ]] : [],
     [
       builtin,
       {
-        name: "builtin",
-        title: "Standard library",
+        name: 'builtin',
+        title: 'Standard library',
         module: builtin,
         dependsOn: [],
         dependedBy: []
@@ -16678,30 +18513,21 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   ]);
   // add cross links
   // notebookImportVariables[0].variable._module == main
-  [...notebookImportMatches.keys()].forEach((m) => {
+  [...notebookImportMatches.keys()].forEach(m => {
     const hostModule = modules.get(main_modules[0]);
     const importedModule = modules.get(m);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
     importedModule.dependedBy.push(main_modules[0].name);
   });
-
-  module_definition_variables.forEach((v) => {
+  module_definition_variables.forEach(v => {
     const hostModule = modules.get(v._module);
     const importedModule = modules.get(v._value);
     if (!hostModule?.dependsOn || !importedModule?.dependedBy) {
-      console.error(
-        "error building module dependancy map",
-        hostModule,
-        importedModule
-      );
+      console.error('error building module dependancy map', hostModule, importedModule);
       return;
     }
     hostModule.dependsOn.push(importedModule.name);
@@ -16709,11 +18535,11 @@ const _11z3pt0 = function _summary(main_modules,titles,bootloader,builtin,queue,
   });
   return modules;
 };
-const _1pou2g6 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
+const _hhecn4 = function _submit_summary(resolve_modules,queue,notebookImports,$0,summary)
 {
   resolve_modules;
   queue;
-  console.log("submit_summary");
+  console.log('submit_summary');
   notebookImports;
   $0.resolve(summary);
 };
@@ -16727,47 +18553,47 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/observablejs-toolchain", async () => runtime.module((await import("/@tomlarkworthy/observablejs-toolchain.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));
-  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));
-  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/invoke-variable", async () => runtime.module((await import("/@tomlarkworthy/invoke-variable.js?v=4")).default));  
+  main.define("module @tomlarkworthy/spectral-layout", async () => runtime.module((await import("/@tomlarkworthy/spectral-layout.js?v=4")).default));  
   $def("_1w9yf3l", null, ["md"], _1w9yf3l);  
   $def("_b6n8js", null, ["visualizeModules"], _b6n8js);  
   $def("_1sznqfl", null, ["md"], _1sznqfl);  
-  $def("_1798myt", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1798myt);  
+  $def("_1hn3uql", "moduleMap", ["runtime","keepalive","myModule","viewof queue"], _1hn3uql);  
   $def("_1yso65r", null, ["md"], _1yso65r);  
-  $def("_1fcoh6x", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1fcoh6x);  
+  $def("_1e3kr85", "sync_modules", ["runtime_variables","moduleMap","_","viewof currentModules","Event"], _1e3kr85);  
   $def("_wi39n0", "viewof currentModules", ["Inputs","moduleMap"], _wi39n0);  
   $def("_1gxgyd6", "currentModules", ["Generators","viewof currentModules"], _1gxgyd6);  
-  $def("_1qag34d", null, ["Inputs","currentModules"], _1qag34d);  
+  $def("_1kxoygl", null, ["Inputs","currentModules"], _1kxoygl);  
   $def("_1xamz8j", null, ["md"], _1xamz8j);  
-  $def("_1n4p4hn", "tipTitle", [], _1n4p4hn);  
-  $def("_1kdcb71", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _1kdcb71);  
+  $def("_1sglrv3", "tipTitle", [], _1sglrv3);  
+  $def("_5zbe1k", "visualizeModules", ["currentModules","htl","d3","spectralCircleOrder","improveOrderSifting","bestOfRandomOrders","Plot","tipTitle","linkTo","isOnObservableCom"], _5zbe1k);  
   $def("_hgwvol", null, ["md"], _hgwvol);  
   $def("_14bivfb", "viewof myModule", ["thisModule"], _14bivfb);  
   $def("_1cir47e", "myModule", ["Generators","viewof myModule"], _1cir47e);  
   $def("_1nfaybn", "tag", [], _1nfaybn);  
-  $def("_17qqkoj", "forcePeek", [], _17qqkoj);  
-  $def("_v9hg2i", "observe", [], _v9hg2i);  
+  $def("_1lkbrun", "forcePeek", [], _1lkbrun);  
+  $def("_1qva85d", "observe", [], _1qva85d);  
   $def("_1bm642i", null, ["md"], _1bm642i);  
-  $def("_oothhq", "viewof queue", ["flowQueue"], _oothhq);  
+  $def("_1f31b1g", "viewof queue", ["flowQueue"], _1f31b1g);  
   $def("_648shl", "queue", ["Generators","viewof queue"], _648shl);  
   $def("_1acbzli", null, ["md"], _1acbzli);  
-  $def("_10dhunq", "module_definition_variables", ["notebookImports","queue"], _10dhunq);  
-  $def("_dcxoxy", "modules", ["module_definition_variables","queue"], _dcxoxy);  
+  $def("_1g0cuj1", "module_definition_variables", ["notebookImports","queue"], _1g0cuj1);  
+  $def("_17frsyf", "modules", ["module_definition_variables","queue"], _17frsyf);  
   $def("_1dqpbvy", "builtin", ["queue"], _1dqpbvy);  
-  $def("_ir3ob0", "main_modules", ["queue","modules","builtin"], _ir3ob0);  
+  $def("_13mmmk9", "main_modules", ["queue","modules","builtin"], _13mmmk9);  
   $def("_yflsv5", "bootloaded_mains", ["queue"], _yflsv5);  
   $def("_ox2g3b", "bootloader", ["queue"], _ox2g3b);  
-  $def("_1turw8j", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _1turw8j);  
+  $def("_10ufqkh", "resolve_modules", ["modules","module_definition_variables","findModuleName"], _10ufqkh);  
   $def("_9fbvam", null, ["md"], _9fbvam);  
-  $def("_1h0lryb", "notebookImports", ["main","parser"], _1h0lryb);  
-  $def("_7t198q", "notebookImportVariables", ["runtime","notebookImports"], _7t198q);  
-  $def("_1lyens8", "pageImportMatch", [], _1lyens8);  
-  $def("_1akt4kz", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1akt4kz);  
-  $def("_1ang0sg", "moduleTitle", ["observeVariable"], _1ang0sg);
-  $def("_197sgjt", "titles", ["modules","moduleTitle"], _197sgjt);  
-  $def("_11z3pt0", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _11z3pt0);  
-  $def("_1pou2g6", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _1pou2g6);  
+  $def("_1t4ga3d", "notebookImports", ["main","parser"], _1t4ga3d);  
+  $def("_994hn4", "notebookImportVariables", ["runtime","notebookImports"], _994hn4);  
+  $def("_xanizk", "pageImportMatch", [], _xanizk);  
+  $def("_1q5pc6n", "notebookImportMatches", ["pageImportMatch","notebookImportVariables","modules"], _1q5pc6n);  
+  $def("_12o3fj5", "moduleTitle", ["observeVariable"], _12o3fj5);  
+  $def("_ze3jk0", "titles", ["modules","moduleTitle"], _ze3jk0);  
+  $def("_pnpoh8", "summary", ["main_modules","titles","bootloader","builtin","queue","notebookImportMatches","bootloaded_mains","resolve_modules","module_definition_variables"], _pnpoh8);  
+  $def("_hhecn4", "submit_summary", ["resolve_modules","queue","notebookImports","viewof queue","summary"], _hhecn4);  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
@@ -16781,8 +18607,8 @@ export default function define(runtime, observer) {
   main.define("isOnObservableCom", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
   main.define("viewof runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("viewof runtime_variables", _));  
   main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
-  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));
-  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
+  main.define("invokeVariable", ["module @tomlarkworthy/invoke-variable", "@variable"], (_, v) => v.import("invokeVariable", _));  
   main.define("spectralCircleOrder", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("spectralCircleOrder", _));  
   main.define("improveOrderSifting", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("improveOrderSifting", _));  
   main.define("bestOfRandomOrders", ["module @tomlarkworthy/spectral-layout", "@variable"], (_, v) => v.import("bestOfRandomOrders", _));
@@ -17061,6 +18887,441 @@ export default function define(runtime, observer) {
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));
   return main;
 }</script>
+
+<script id="@tomlarkworthy/modules" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _s7bl1p = function _1(md){return(
+md`# Modules
+
+\`modules(options?)\` is an async generator that yields a **cumulative \`Map\`** (module → \`{name, title, module, variable}\`) of every fully-formed record known so far, growing as modules resolve. 
+
+It's an effecient alternative to [moduleMap](https://observablehq.com/@tomlarkworthy/module-map) that blocks until all modules are loaded.
+`
+)};
+const _1eaa9lr = function _currentModules(modules){return(
+modules()
+)};
+const _dmem61 = function _modules(runtime,observeVariable,moduleTitle)
+{
+  const _runtime = runtime;
+  // default: the current runtime
+  return function modules({runtime = _runtime, titleTimeoutMs = 2000, rescanMs = 1000, load = true} = {}) {
+    if (!runtime || !runtime._variables)
+      throw 'Invalid runtime passed to modules';
+    return async function* () {
+      const records = new Map();
+      // module -> fully-formed record (title resolved before it lands here)
+      const watchers = new Map();
+      // module -> cancel fn (stops its title watch)
+      const peeking = new Map();
+      // unresolved `module X` variable -> stop fn (its force-load observer)
+      let pending = false, wake = null, dirty = true;
+      const bump = () => {
+        pending = true;
+        if (wake) {
+          const w = wake;
+          wake = null;
+          w();
+        }
+      };
+      const touch = () => {
+        dirty = true;
+        bump();
+      };
+      // Recover a module's @user/slug from its loader definition. On Observable's runtime the
+      // `module X` variable is named numerically ("module 1"), so v._name.slice(7) is a useless id;
+      // the real slug lives in the loader's import URL — import("/@user/slug.js?…") or
+      // importShim("/@user/slug.js", …). Matches both runtimes; null if no URL is found.
+      const slugFromDef = v => {
+        const m = v._definition && String(v._definition).match(/import(?:Shim)?\(\s*["'`]\/?([^"'`?]+?)\.js(?:[?"'`)]|$)/);
+        return m ? m[1].replace(/^\//, '') : null;
+      };
+      // Live candidate modules: Map<module, {name, variable?, title?}>. Side effect: force-loads
+      // unresolved `module X` variables via observe (which marks them reachable) so their modules
+      // become resolvable on a later scan.
+      const scan = () => {
+        const out = new Map();
+        const put = (m, r) => {
+          if (m && !out.has(m))
+            out.set(m, r);
+        };
+        const builtin = runtime._builtin, bootloader = runtime.bootloader;
+        if (builtin)
+          put(builtin, {
+            name: 'builtin',
+            title: 'Standard library'
+          });
+        if (bootloader)
+          put(bootloader, {
+            name: 'bootloader',
+            title: 'Bootloader'
+          });
+        for (const [name, mod] of runtime.mains || new Map())
+          put(mod, { name });
+        // main modules: variable-graph roots — own variables but aren't imported (nor builtin/
+        // bootloader). Catches the top-level main of a plain runtime where runtime.mains is empty.
+        const imported = new Set((runtime._modules || new Map()).values());
+        const owners = new Set();
+        for (const v of runtime._variables)
+          if (v._module)
+            owners.add(v._module);
+        for (const m of owners)
+          if (m !== builtin && m !== bootloader && !imported.has(m))
+            put(m, { name: 'main' });
+        // imported modules carried by `module X` variables
+        for (const v of runtime._variables) {
+          if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
+            continue;
+          const mod = v._value;
+          if (mod && typeof mod === 'object')
+            put(mod, {
+              name: slugFromDef(v) || v._name.slice(7),
+              variable: v
+            });
+          else if (load && !peeking.has(v))
+            peeking.set(v, observeVariable(v, {
+              fulfilled: bump,
+              error: bump
+            }));
+        }
+        return out;
+      };
+      // Reconcile the snapshot with the live runtime each scan.
+      const reconcile = () => {
+        const cand = scan();
+        // DELETE: drop modules no longer present; cancel their title watcher.
+        for (const m of [...watchers.keys()]) {
+          if (!cand.has(m)) {
+            const cancel = watchers.get(m);
+            watchers.delete(m);
+            if (records.delete(m))
+              touch();
+            try {
+              cancel();
+            } catch (e) {
+            }
+          }
+        }
+        // CREATE: start a persistent title watch for each new module. The module enters `records`
+        // only once its title resolves (or the timeout fires). Later title changes update in place.
+        for (const [m, c] of cand) {
+          if (watchers.has(m))
+            continue;
+          if (c.title != null) {
+            // static title (builtin / bootloader)
+            records.set(m, {
+              name: c.name,
+              title: c.title,
+              module: m,
+              variable: c.variable
+            });
+            watchers.set(m, () => {
+            });
+            touch();
+            continue;
+          }
+          const apply = title => {
+            if (!watchers.has(m))
+              return;
+            // module was pruned -> ignore late title callbacks
+            const t = title ?? c.name;
+            const prev = records.get(m);
+            if (!prev) {
+              records.set(m, {
+                name: c.name,
+                title: t,
+                module: m,
+                variable: c.variable
+              });
+              touch();
+            } else if (prev.title !== t) {
+              records.set(m, {
+                ...prev,
+                title: t
+              });
+              touch();
+            }
+          };
+          const cancel = moduleTitle(m, apply);
+          watchers.set(m, () => {
+            try {
+              cancel();
+            } catch (e) {
+            }
+          });
+          // title never resolved within the budget -> show the name so the module isn't withheld.
+          setTimeout(() => {
+            if (watchers.has(m) && !records.has(m))
+              apply(null);
+          }, titleTimeoutMs);
+        }
+      };
+      let stopped = false;
+      (async () => {
+        while (!stopped) {
+          try {
+            reconcile();
+          } catch (e) {
+          }
+          await new Promise(r => setTimeout(r, rescanMs));
+        }
+      })();
+      try {
+        while (true) {
+          pending = false;
+          if (dirty) {
+            dirty = false;
+            yield new Map(records);
+          }
+          // cumulative snapshot
+          if (!pending)
+            await new Promise(resolve => {
+              wake = resolve;
+              if (pending) {
+                wake = null;
+                resolve();
+              }
+            });
+        }
+      } finally {
+        stopped = true;
+        for (const cancel of watchers.values()) {
+          try {
+            cancel();
+          } catch (e) {
+          }
+        }
+        for (const stop of peeking.values()) {
+          try {
+            stop();
+          } catch (e) {
+          }
+        }
+      }
+    }();
+  };
+};
+const _up9atj = function _moduleTitle(observeVariable)
+{
+  return function moduleTitle(module, onTitle) {
+    // Observes a module's title-defining cell and calls onTitle(title|null) on every change.
+    // Returns a cancel fn. The fixed observe() forces a lazy title cell to compute (and replays
+    // the current value on attach), so no in-module forcing helper is needed — works for named
+    // and anonymous cells alike, even in a fresh runtime nothing else observes.
+    const rt = module._runtime;
+    const candidates = [...rt._variables].filter(v => {
+      if (!v || v._module !== module || !v._definition || v._type != 1)
+        return false;
+      const n = v._name;
+      if (typeof n === 'string' && (n.startsWith('dynamic observe ') || n.startsWith('module ')))
+        return false;
+      return true;
+    });
+    if (candidates.length === 0) {
+      onTitle(null);
+      return () => {
+      };
+    }
+    const first = candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b);
+    const extract = v => {
+      if (v == null)
+        return null;
+      if (typeof v === 'string')
+        return v.trim() || null;
+      if (v.tagName) {
+        if (v.tagName == 'H1')
+          return v.textContent;
+        const h1 = v.querySelector?.('h1');
+        if (h1)
+          return (h1.textContent ?? '').trim() || null;
+        return null;
+      }
+      if (v.textContent)
+        return (v.textContent ?? '').trim() || null;
+      return null;
+    };
+    const stop = observeVariable(first, {
+      fulfilled: value => onTitle(extract(value)),
+      error: () => onTitle('Err')
+    });
+    return () => {
+      try {
+        stop();
+      } catch (e) {
+      }
+    };
+  };
+};
+const _qpensj = function _5(Inputs,currentModules){return(
+Inputs.table([...currentModules.values()], {
+  columns: [
+    'name',
+    'title'
+  ],
+  format: { name: x => x }
+})
+)};
+const _1x0q6zt = function _7(md){return(
+md`## Tests`
+)};
+const _e0sbyj = function _8(tests,modulesModule){return(
+tests({
+  filter: (t) => t.variable._module == modulesModule
+})
+)};
+const _p3rq3v = function _modulesModule(thisModule){return(
+thisModule()
+)};
+const _16g1ab = (G, _) => G.input(_);
+const _cayyvt = function _testRuntime(Runtime){return(
+new Runtime()
+)};
+const _1j4p6g3 = function _testModulesLatest(modules,testRuntime){return(
+modules({
+  runtime: testRuntime
+})
+)};
+const _1oq6y7s = function _newModule(testRuntime)
+{
+  const m = testRuntime.module();
+  m.variable().define("greeting", [], () => {
+    const div = document.createElement("div");
+    div.innerHTML = "<h1>New Module</h1>";
+    return div;
+  });
+  return m;
+};
+const _1li1bty = function _test_detectsBuiltin(testModulesLatest)
+{
+  if (![...testModulesLatest.values()].find((m) => m.name == "builtin"))
+    throw Error();
+  return "ok";
+};
+const _vr1kp6 = function _test_detectsNewModule(testModulesLatest,newModule)
+{
+  const rec = testModulesLatest.get(newModule);
+  if (!rec) throw Error("newModule not detected yet");
+  if (rec.title !== "New Module")
+    throw Error(
+      "expected title 'New Module', got " + JSON.stringify(rec.title)
+    );
+  return "ok";
+};
+const _1p0sqk = async function _test_reflectsDelete(Runtime,modules)
+{
+  const rt = new Runtime();
+  const gen = modules({
+    runtime: rt,
+    rescanMs: 100,
+    titleTimeoutMs: 500
+  });
+  let snap = new Map();
+  (async () => {
+    for await (const s of gen) snap = s;
+  })();
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (pred, ms = 3000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (pred()) return true;
+      await wait(50);
+    }
+    return false;
+  };
+  try {
+    const m = rt.module();
+    m.variable().define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>Temp</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.has(m))))
+      throw Error("create not reflected");
+    for (const v of [...rt._variables]) if (v._module === m) v.delete();
+    if (!(await waitFor(() => !snap.has(m))))
+      throw Error("delete not reflected");
+    return "ok";
+  } finally {
+    if (gen.return) gen.return();
+  }
+};
+const _1315qaf = async function _test_reflectsTitleUpdate(Runtime,modules)
+{
+  const rt = new Runtime();
+  const gen = modules({
+    runtime: rt,
+    rescanMs: 100,
+    titleTimeoutMs: 500
+  });
+  let snap = new Map();
+  (async () => {
+    for await (const s of gen) snap = s;
+  })();
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (pred, ms = 3000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (pred()) return true;
+      await wait(50);
+    }
+    return false;
+  };
+  try {
+    const m = rt.module();
+    const tv = m.variable().define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>First</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.get(m)?.title === "First")))
+      throw Error("initial title not detected");
+    tv.define("title", [], () => {
+      const d = document.createElement("div");
+      d.innerHTML = "<h1>Second</h1>";
+      return d;
+    });
+    if (!(await waitFor(() => snap.get(m)?.title === "Second")))
+      throw Error("title update not reflected");
+    return "ok";
+  } finally {
+    if (gen.return) gen.return();
+  }
+};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
+  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
+  main.define("module @tomlarkworthy/observable-runtime-v6", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime-v6.js?v=4")).default));  
+  $def("_s7bl1p", null, ["md"], _s7bl1p);  
+  $def("_1eaa9lr", "currentModules", ["modules"], _1eaa9lr);  
+  $def("_dmem61", "modules", ["runtime","observeVariable","moduleTitle"], _dmem61);  
+  $def("_up9atj", "moduleTitle", ["observeVariable"], _up9atj);  
+  $def("_qpensj", null, ["Inputs","currentModules"], _qpensj);  
+  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
+  $def("_1x0q6zt", null, ["md"], _1x0q6zt);  
+  $def("_e0sbyj", null, ["tests","modulesModule"], _e0sbyj);  
+  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
+  main.define("Runtime", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("Runtime", _));  
+  $def("_p3rq3v", "viewof modulesModule", ["thisModule"], _p3rq3v);  
+  $def("_16g1ab", "modulesModule", ["Generators","viewof modulesModule"], _16g1ab);  
+  $def("_cayyvt", "testRuntime", ["Runtime"], _cayyvt);  
+  $def("_1j4p6g3", "testModulesLatest", ["modules","testRuntime"], _1j4p6g3);  
+  $def("_1oq6y7s", "newModule", ["testRuntime"], _1oq6y7s);  
+  $def("_1li1bty", "test_detectsBuiltin", ["testModulesLatest"], _1li1bty);  
+  $def("_vr1kp6", "test_detectsNewModule", ["testModulesLatest","newModule"], _vr1kp6);  
+  $def("_1p0sqk", "test_reflectsDelete", ["Runtime","modules"], _1p0sqk);  
+  $def("_1315qaf", "test_reflectsTitleUpdate", ["Runtime","modules"], _1315qaf);
+  return main;
+}</script>
 <script id="@tomlarkworthy/observable-runtime/runtime.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -17091,14 +19352,18 @@ observable.Library
 const _1iyzb44 = function _RuntimeError(observable){return(
 observable.RuntimeError
 )};
-const _b2ba5g = async function _observable(unzip, FileAttachment) {
-    const blob = await unzip(FileAttachment('runtime.js.gz'));
-    const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    try {
-        return await import(objectURL);
-    } finally {
-        URL.revokeObjectURL(objectURL);
-    }
+const _b2ba5g = async function _observable(unzip,FileAttachment)
+{
+  const blob = await unzip(FileAttachment("runtime.js.gz"));
+
+  const objectURL = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  try {
+    return await import(objectURL);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
 };
 const _17n6uge = function _unzip(Response,DecompressionStream){return(
 async (attachment) =>
@@ -17149,10 +19414,13 @@ runtime.Runtime
 const _bfntg8 = function _RuntimeError(runtime){return(
 runtime.RuntimeError
 )};
-const _axblun = async function _runtime(gunzipBase64ToBlob, source_gz) {
-    const blob = await gunzipBase64ToBlob(source_gz);
-    const url = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
-    return import(url);
+const _axblun = async function _runtime(gunzipBase64ToBlob,source_gz)
+{
+  const blob = await gunzipBase64ToBlob(source_gz);
+  const url = URL.createObjectURL(
+    new Blob([blob], { type: "application/javascript" })
+  );
+  return import(url);
 };
 const _1ljam5l = function _gunzipBase64ToBlob(DecompressionStream,Response){return(
 async (b64) => {
@@ -17252,7 +19520,8 @@ Then re-attach the resulting \`.js.gz\` files to this notebook
 (notebook menu → Attachments → drag-and-drop, replacing the existing
 attachments of the same name).`
 )};
-const _3cxbvl = async function _lr(unzip, FileAttachment) {
+const _3cxbvl = async function _lr(unzip,FileAttachment)
+{
     const blob = await unzip(FileAttachment('lezer-lr-bundled.js.gz'));
     const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
     try {
@@ -17261,7 +19530,8 @@ const _3cxbvl = async function _lr(unzip, FileAttachment) {
         URL.revokeObjectURL(objectURL);
     }
 };
-const _1v8kgvh = async function _lezerhighlight(unzip, FileAttachment) {
+const _1v8kgvh = async function _lezerhighlight(unzip,FileAttachment)
+{
     const blob = await unzip(FileAttachment('lezer-highlight-bundled.js.gz'));
     const objectURL = URL.createObjectURL(new Blob([blob], { type: 'application/javascript' }));
     try {
@@ -17636,13 +19906,6 @@ export default function define(runtime, observer) {
   $def("_104y7ux", "observable_lezer_parser", ["lezerhighlight","lr"], _104y7ux);
   return main;
 }</script>
-<script id="@tomlarkworthy/observablejs-toolchain/acorn-walk-8.3.2.js.gz" 
-  type="text/plain"
-  data-encoding="base64"
-  data-mime="application/gzip"
->
-H4sICB8jLWcCA2Fjb3JuLXdhbGtAOC4zLjIuanMApVlbU+O4En6fX2E4VZQza5wAs8yC8XK47FZRNbcC5mydonhQbDnRjC17JRkmh+S/n5bkm2zHITsvjNWt7v76olYrM3779o311rrMaRjj0JourG/8GsfkiVk5J3Rm3aZxnGfW06H7/sQ9sBANrXvMOGbW06/uwYl76Er5z4zMCEWxFZEYn1pjmiVjFKSM7j+j+Pu/f3OP3MNxSLgYy7WbfOMgJQWvU+vT53uwha272xvrmYi5FS4oSkiA4nhhzTDFDAmAJjXzHetjyrBFaJSyBAmS0lNrLkTGT8fj5+dn9xsPFXg3SJOxcmCfM7Iv1e4XaveVIrA9fhPlNJA6LGELBzvUYU46eqHLpU39ZOQ02MBwyOjlCTEL+WS5ZK5YZNijD+hR8cTIwfC9t4cLymgFKtW/lRbcNCI1Ef/h0VtnDek93EelNSfz2Y7vkwfixpjOwKODRy/b2yNulvO5zUYOfeANOFzB0ZTlkgB+R+9OM7sHHu3Co+eRDYTl8ikloTUZnTJvpwFT7R69kAfYgRXER0UTSjs2tDNbjF4YFjmju1wwSMyu70uRNLLEebnNxuUmC/vAX52K5bJilrydyWolAaZ+xQJzoxcxJ9ylaYh94ahvLqByfLzyKhik4+QWCfCa8SWQCra3Z2NF4EDwWU9UUWmwritPYXdU9ncMowj0KKOZz6usBz1ZD8ysZ49KGFClDVRIJd3JgArQnMDMfQMjLzASDQDkbCQDAh7ZZOQJtngxcXJQqnAGflYFh0S2TfM49n0saRB7Js58PAI0mkwlGdPwd58CET0Ej0oVoO7IQe57BIEqJYkdAPyRmLP02aL42UqlHuUV/A2QCOay2ACPgEYB+mggqywdFZUlPC0qVnUIsjoEkCjwm4L7EAci89UNQF+iZAB27MKB33GB+Uz5QRoponYm4bfwI4Uf/VP8wT/AX+DVIHvdKZ3x8d5eAbuN2mu4tvopF/KmC+rkecXulj9Oy5WscqUI/ahbnNpN6Ye9Ay7qNqFoijOS/smqAj73a+/AqC7ThnsOrzFHuvFIa9T/PP2GA+EGDEPXsaEAIPRwTdmSC40G4I7oA3v0BfypXKt1xdp/SJ9SWjN+lAzV9BL/ZeUl7heWzhhK/MS9jNPg+53sdAmmAgjymwSKbDRIqaLC40+gKwh3moYLj52lRW/x2C/+gUSQAkaQ2K307oL7jtat7cSw+iPJxKIm/ZCkHxnDnIPJJqQviMHHHHPyPxzWW4BzNUeENihtwGWcbOHiapdEVssANDB8E9UG20qktMBctOUcyQhSyvHfOci1HHaEi2KBGQWKrI/Gsh0asP8BTTFMUOtBNDyRUe9RcQmVY2TyKqWC0BybIf4LhplhX1NVib3erjF9BxNSsEErjG8BIwmMebSj22sXVoA45t3K0nOFrC6PqJTIwJLe5FQqEajkPmkkykNnvNSLiorlMHh1KrZ27QrwdLwSFQQxDKHyqoawxaG5VZlvJva/BMfmObh4RkQMnAMoPjbLpXhRisWq7yjcy95qdATgo/CPeGNhDmpli+H6mMqO0z1DcySfFkzDLhbQ34ATyRcDdISCVy176vNKXilXMcp7s5ghaIVaifqUCr4gIQ/rcNn/NYe3QDNS12mLtFUrWWPlz5StVyhcQkmRVPkl5UHgBj5V+IYrFDbkWVg1KP29JbYbozSB8HlDK41x1IIpqfACnIutTZOuid3/IEbQNMbXOIghnZK3K18D6io/19fjqd7eqdJrPM1nM8zMlvlnYaKhceAYKN8Krtbag2jj1RrWe/n6bqE7RFt/ynoDT0Kzsvtqpx2Q0pG+wgsLUVNtp+upM8WHOl4lu2rku3ljnzdxnbYroRDvVsJNCHtIRDBrF4BTVUll+3T3I06mmDUsdYT0jlqkmLUaKSixyLIxdquJ5xbO4JZ9tI4NyF8whhbr3G3HHWtDG65RdYOahqQlPY2+1lTG0gwzQTbc2btf9L6FjCzRkbXlzZxkucChvsy/40VPGyDuE4pzbACFlDUCWuvUevqDuDKGTJWUe3jrG5fpXQ4gfZk/gUrEKqEq/AO37E9mwDh7dRK2MDiUB7NllOfanCIY3Py9nJ4OKGcjNcwEeJuQVFsHO0InFPc4yWI49R8IJBLFG+38nSNOBqNQShCQQC1k5AyVYqQQQw9kGFl5rmWhfKWILYwAflVX60CgNs1Pl6Sj80M6kz9zblBaXrede7X3xlVdBr5nVAIxq6Mir2sLTXPmALXWFrxRQiJ1bPTjlS+wDtt4dbXNf8LP5nsSxUM4SGQri7AL455hqkwgH7XrseJsVfXtG2mb55ow+mrVGxZ9YYB1ysQnlOCwOaOUjGscoTwWQ+OLMbBogw1CYbPHRn3HLpeGCIwV542L/rTtHE9zFhRzq/5e79hFHA9jx2pbGalyJZ8Zw+pvEh2e1491PMOBmkgGe9NrrG6oik3idyUQv3ZDZbnLkDnjGQqwwapmK/kDDSNPkCmDVnZq2Q/vEQzVYdUpNxx0NOs9yKql9/aQGHFu1q0ivep3IalQ7W7oev2wKwtRTgtKrCjGaj3wmqltXcL6J39nK3uFmKdwtCI5yusolMNLL7HHSbNh9A1iQo9hekM1kRkJ8fTxecEW4pb85ZbDe8RJ5GqKOHYC+QV4wk9piC8iiKOTGSSW5jR0uEETTt5cX2KIEHaIouVx7KDy66I0GElKgr6Da/KL4SBnnDzBu0IuOYFSxCVWK9Slb8n/MPDejMf/svTx+YiyjNDZ19sP/pgn42gSTN4fTw7fhYfRydFheHz07t0xOkYBmh5hdDJ5Nwl/C8LjSXR4go6O8WSCDkHz++gwPJkERweBm6Ds/8t9I8syHQAA
-</script>
 <script id="@tomlarkworthy/observablejs-toolchain/parser-6.1.0.js.gz" 
   type="text/plain"
   data-encoding="base64"
@@ -20983,6 +23246,247 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
+<script id="@tomlarkworthy/plugin-registry" 
+  type="text/plain"
+  data-mime="application/javascript"
+>
+const _1ej2r92 = function _intro(md){return(
+md`# Plugin Registry
+
+A foundational notebook for **decoupled reactive plugin wiring**.
+
+Consumers get a realtime stream of all registered providers under a name. Providers can register themselves under a name. Neither has direct references between each other. This allows you to add more consumers and providers without changing individual providers and consumers. Useful for reactive plugin systems like audio instruments, dyamic menus, LLM tools and entity component systems.
+`
+)};
+const _16jmxgh = function _diagram(htl){return(
+htl.html`<svg viewBox="0 0 720 300" width="100%" style="max-width:720px;font-family:system-ui,sans-serif">
+  <defs>
+    <marker id="pr-arr" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="var(--theme-foreground,#333)"></path>
+    </marker>
+    <style>
+      .pr-box{fill:var(--theme-background-alt,#f4f4f6);stroke:var(--theme-foreground-faint,#bbb);stroke-width:1.5}
+      .pr-hub{fill:var(--theme-foreground-faintest,#eef);stroke:var(--theme-foreground,#556);stroke-width:2}
+      .pr-t{fill:var(--theme-foreground,#222);font-size:13px}
+      .pr-s{fill:var(--theme-foreground-muted,#666);font-size:11px}
+      .pr-e{stroke:var(--theme-foreground,#333);stroke-width:1.5;fill:none;marker-end:url(#pr-arr)}
+    </style>
+  </defs>
+
+  <rect class="pr-box" x="10"  y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="52" text-anchor="middle">Provider A</text>
+  <text class="pr-s" x="95" y="68" text-anchor="middle">plugins.add("x", v)</text>
+  <rect class="pr-box" x="10"  y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="95" y="142" text-anchor="middle">Provider B</text>
+  <text class="pr-s" x="95" y="158" text-anchor="middle">plugins.add("x", v, {invalidation})</text>
+  <text class="pr-s" x="95" y="215" text-anchor="middle">…N providers</text>
+
+  <rect class="pr-hub" x="270" y="78"  width="180" height="112" rx="10"></rect>
+  <text class="pr-t" x="360" y="104" text-anchor="middle" style="font-weight:600">plugins</text>
+  <text class="pr-s" x="360" y="128" text-anchor="middle">Map&lt;name, Set&lt;value&gt;&gt;</text>
+  <text class="pr-s" x="360" y="150" text-anchor="middle">add(name, value)</text>
+  <text class="pr-s" x="360" y="168" text-anchor="middle">get(name) → Generator</text>
+
+  <rect class="pr-box" x="540" y="30"  width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="52" text-anchor="middle">Consumer 1</text>
+  <text class="pr-s" x="625" y="68" text-anchor="middle">plugins.get("x")</text>
+  <rect class="pr-box" x="540" y="120" width="170" height="48" rx="8"></rect>
+  <text class="pr-t" x="625" y="142" text-anchor="middle">Consumer 2 (V2)</text>
+  <text class="pr-s" x="625" y="158" text-anchor="middle">plugins.get("x")</text>
+  <text class="pr-s" x="625" y="215" text-anchor="middle">…M consumers</text>
+
+  <path class="pr-e" d="M180,54 C225,54 235,116 268,126"></path>
+  <path class="pr-e" d="M180,144 C225,144 240,138 268,140"></path>
+  <path class="pr-e" d="M452,128 C500,116 510,54 538,54"></path>
+  <path class="pr-e" d="M452,142 C500,144 510,144 538,144"></path>
+</svg>`
+)};
+const _xnvzuh = function _contracts(md){return(
+md`## Contracts
+
+| Guarantee | How |
+|---|---|
+| **Named sets** | \`plugins\` maps a name → a set of values. Providers \`add\`, consumers \`get\`; they coordinate only by name. |
+| **Reactive** | \`get(name)\` is a Generator that yields the current set and re-yields on every add/remove for that name. |
+| **N↔M decoupling** | Providers and consumers share only \`plugins\`. Any number of each; a name is the whole contract. |
+| **Auto-cleanup** | \`add\` returns \`remove()\`. Pass \`{invalidation}\` (a cell's disposal promise) to remove automatically when the provider cell re-runs. |
+| **No leaks** | \`get\`'s Generator unsubscribes on disposal; per-name listeners are dropped when the last consumer leaves. |
+| **Eventual convergence** | Each consumer gets the current set immediately on \`get\`, then a full-set snapshot on every change — so any interleaving of add/remove/get converges. |`
+)};
+const _1ua5hud = function _apiReference(md){return(
+md`## API reference
+
+The whole API is two methods on \`plugins\`.
+
+**\`plugins.add(name, value, options?)\`** → \`remove()\`
+Add \`value\` to the set stored under \`name\` (creating the set on first use). Returns a \`remove()\` function
+that takes this value back out. \`options.invalidation\` (optional, may be null/omitted) is a promise — when
+it settles the value is removed automatically; pass a provider cell's built-in \`invalidation\` so re-running
+the cell replaces rather than duplicates. \`value\` is anything; for shared views it is commonly a factory
+\`() => element\` that each consumer calls to get its own instance.
+
+**\`plugins.get(name)\`** → Generator&lt;value[]&gt;
+Return a reactive Generator of the values currently in \`name\`'s set. It yields the current set immediately
+(so a late consumer still converges), then re-yields the full set on every add/remove. Use it from a cell
+and that cell recomputes on each change. Call it from as many consumers as you like (e.g. a module and its
+V2) — each call is an independent Generator that cleans up when its cell is torn down.`
+)};
+const _1pzt22q = function _createPlugins(Generators)
+{
+  return function createPlugins() {
+    const sets = new Map();
+    // name -> Set<value>
+    const listeners = new Map();
+    // name -> Set<() => void>
+    const notify = name => {
+      const ls = listeners.get(name);
+      if (ls)
+        for (const l of [...ls])
+          l();  // copy: a consumer may (un)subscribe while notifying
+    };
+    const add = (name, value, options) => {
+      let set = sets.get(name);
+      if (!set)
+        sets.set(name, set = new Set());
+      set.add(value);
+      notify(name);
+      const remove = () => {
+        const s = sets.get(name);
+        if (s && s.delete(value)) {
+          if (s.size === 0)
+            sets.delete(name);
+          notify(name);
+        }
+      };
+      const invalidation = options && options.invalidation;
+      if (invalidation)
+        Promise.resolve(invalidation).then(remove, remove);
+      return remove;
+    };
+    const get = name => Generators.observe(change => {
+      const push = () => change([...sets.get(name) ?? []]);
+      push();
+      // current set immediately → converges
+      let ls = listeners.get(name);
+      if (!ls)
+        listeners.set(name, ls = new Set());
+      ls.add(push);
+      return () => {
+        ls.delete(push);
+        if (ls.size === 0)
+          listeners.delete(name);
+      };  // leak-safe
+    });
+    return {
+      add,
+      get,
+      listenerCount: name => listeners.get(name)?.size ?? 0
+    };
+  };
+};
+const _1qu8dwj = function _plugins(createPlugins){return(
+createPlugins()
+)};
+const _a7p1z5 = function _testsHeader(md){return(
+md`## Tests`
+)};
+const _15xl311 = function _test_get_reflects_add(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('new set should start empty');
+  p.add('x', 1);
+  const after = await (await gen.next()).value;
+  if (after.length !== 1 || after[0] !== 1)
+    throw new Error('get did not reflect the add');
+  gen.return();
+  return '\u2705 get(name) yields the named set and updates on add';
+})()
+)};
+const _122zyhz = function _test_multi_provider_and_convergence(createPlugins)
+{
+  return (async () => {
+    const p = createPlugins();
+    const a = p.get('x'), b = p.get('x');
+    // two independent consumers
+    await (await a.next()).value;
+    await (await b.next()).value;
+    p.add('x', 'one');
+    // provider 1
+    p.add('x', 'two');
+    // provider 2
+    const va = (await (await a.next()).value).slice().sort().join(',');
+    const vb = (await (await b.next()).value).slice().sort().join(',');
+    if (va !== 'one,two' || vb !== 'one,two')
+      throw new Error('consumers did not converge to the full set');
+    a.return();
+    b.return();
+    return '\u2705 multiple providers accumulate; all consumers converge';
+  })();
+};
+const _1lojas7 = function _test_remove_and_names_isolated(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  const gx = p.get('x'), gy = p.get('y');
+  await (await gx.next()).value;
+  await (await gy.next()).value;
+  const remove = p.add('x', 1);
+  p.add('y', 2);
+  if ((await (await gx.next()).value).join() !== '1')
+    throw new Error('x set wrong');
+  if ((await (await gy.next()).value).join() !== '2')
+    throw new Error('names are not isolated');
+  remove();
+  if ((await (await gx.next()).value).length !== 0)
+    throw new Error('remove() did not take the value out');
+  gx.return();
+  gy.return();
+  return '\u2705 remove() works and names are isolated';
+})()
+)};
+const _8240yg = function _test_invalidation_and_no_leak(createPlugins){return(
+(async () => {
+  const p = createPlugins();
+  let settle;
+  p.add('x', 1, { invalidation: new Promise(r => settle = r) });
+  const gen = p.get('x');
+  if ((await (await gen.next()).value).length !== 1)
+    throw new Error('value should be present before invalidation');
+  if (p.listenerCount('x') !== 1)
+    throw new Error('get should have registered a listener');
+  settle();
+  await Promise.resolve();
+  await Promise.resolve();
+  if ((await (await gen.next()).value).length !== 0)
+    throw new Error('invalidation did not remove the value');
+  gen.return();
+  if (p.listenerCount('x') !== 0)
+    throw new Error('disposing the Generator leaked a listener');
+  return '\u2705 {invalidation} auto-removes and get() leaks no listeners';
+})()
+)};
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+  const $def = (pid, name, deps, fn) => {
+    main.variable(observer(name)).define(name, deps, fn).pid = pid;
+  };
+
+  $def("_1ej2r92", "intro", ["md"], _1ej2r92);  
+  $def("_16jmxgh", "diagram", ["htl"], _16jmxgh);  
+  $def("_xnvzuh", "contracts", ["md"], _xnvzuh);  
+  $def("_1ua5hud", "apiReference", ["md"], _1ua5hud);  
+  $def("_1pzt22q", "createPlugins", ["Generators"], _1pzt22q);  
+  $def("_1qu8dwj", "plugins", ["createPlugins"], _1qu8dwj);  
+  $def("_a7p1z5", "testsHeader", ["md"], _a7p1z5);  
+  $def("_15xl311", "test_get_reflects_add", ["createPlugins"], _15xl311);  
+  $def("_122zyhz", "test_multi_provider_and_convergence", ["createPlugins"], _122zyhz);  
+  $def("_1lojas7", "test_remove_and_names_isolated", ["createPlugins"], _1lojas7);  
+  $def("_8240yg", "test_invalidation_and_no_leak", ["createPlugins"], _8240yg);
+  return main;
+}</script>
+
 <script id="@tomlarkworthy/reversible-attachment" 
   type="text/plain"
   data-mime="application/javascript"
@@ -21726,7 +24230,7 @@ const _10rsemi = function _32(md){return(
 md`### lookupVariable
 lookup a variable by name in a module, pass an array to lookup multiple`
 )};
-const _1l90etb = function _lookupVariable(){return(
+const _lejdjn = function _lookupVariable(){return(
 async function lookupVariable(name_or_names, module) {
     if (typeof name_or_names === 'string') {
         const name = name_or_names;
@@ -22133,7 +24637,7 @@ export default function define(runtime, observer) {
   $def("_e0z7e2", "ascendants", [], _e0z7e2);  
   $def("_1kxbej", "ascendants_example", ["ascendants","lookupVariable","main","toObject"], _1kxbej);  
   $def("_10rsemi", null, ["md"], _10rsemi);  
-  $def("_1l90etb", "lookupVariable", [], _1l90etb);  
+  $def("_lejdjn", "lookupVariable", [], _lejdjn);  
   $def("_11hb1zq", null, ["md"], _11hb1zq);  
   $def("_kd8snz", "persistentIdToVariableRef", [], _kd8snz);  
   $def("_12s2v4c", "getVariableByPersistentId", ["persistentIdToVariableRef","WeakRef"], _12s2v4c);  
@@ -24236,7 +26740,7 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/themes"
+<script id="@tomlarkworthy/themes" 
   type="text/plain"
   data-mime="application/javascript"
 >
@@ -24606,16 +27110,14 @@ const _yqy56c = async function _css(theme_assets,extra_css){return(
   extra_css
 ]
 )};
-const _16bhmn1 = function _extra_css()
+const _17wrwba = function _extra_css()
 {
   // Only on ObservableHQ (the observableusercontent.com sandbox) do we bridge
   // the theme vars onto the underscore '--syntax_*' vars that Observable's
   // editor + inspector read. Off Observable we omit it so notebook authors use
   // the real --theme-* / --syntax-* vars, not these compatibility aliases.
   // Predicate mirrors @tomlarkworthy/runtime-sdk's isOnObservableCom.
-  const onObservable =
-    window.location.href.includes('observableusercontent.com') &&
-    !window.location.href.includes('blob:');
+  const onObservable = window.location.href.includes('observableusercontent.com') && !window.location.href.includes('blob:');
   const observableSyntaxBridge = onObservable ? `
 :root {
   /* notebook-kit themes omit --syntax-normal (hyphen), so Observable's
@@ -24723,12 +27225,10 @@ export default function define(runtime, observer) {
   $def("_p0at3d", "themes", [], _p0at3d);  
   $def("_m8taeu", "cssForTheme", ["themes","extra_css"], _m8taeu);  
   $def("_yqy56c", "css", ["theme_assets","extra_css"], _yqy56c);  
-  $def("_16bhmn1", "extra_css", [], _16bhmn1);  
+  $def("_17wrwba", "extra_css", [], _17wrwba);  
   $def("_rijq1n", "current_theme", ["themes"], _rijq1n);
   return main;
-}
-
-</script>
+}</script>
 
 <script id="@tomlarkworthy/view" 
   type="text/plain"
@@ -25924,21 +28424,19 @@ md`## [Optional] Tests`
 const _11gtx14 = function _RUN_TESTS(){return(
 true
 )};
-const _46icxz = async function _testing(RUN_TESTS, invalidation) {
-    if (!RUN_TESTS)
-        return invalidation;
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return Object.fromEntries(await Promise.all([
-        'expect',
-        'createSuite'
-    ].map(n => module.value(n).then(v => [
-        n,
-        v
-    ]))));
+const _46icxz = async function _testing(RUN_TESTS,invalidation)
+{
+  if (!RUN_TESTS) return invalidation;
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@tomlarkworthy/testing.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return Object.fromEntries(
+    await Promise.all(
+      ["expect", "createSuite"].map((n) => module.value(n).then((v) => [n, v]))
+    )
+  );
 };
 const _lf943y = function _suite(testing){return(
 testing.createSuite({
@@ -26174,13 +28672,14 @@ suite.test("Collection object creates matching keys", async () => {
   expect(v.value).toHaveProperty("a");
 })
 )};
-const _1qdb7yp = async function _toc() {
-    const [{Runtime}, {default: define}] = await Promise.all([
-        import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-        import(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`)
-    ]);
-    const module = new Runtime().module(define);
-    return module.value('toc');
+const _1qdb7yp = async function _toc()
+{
+  const [{ Runtime }, { default: define }] = await Promise.all([
+    import("https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"),
+    import(`https://api.observablehq.com/@nebrius/indented-toc.js?v=3`)
+  ]);
+  const module = new Runtime().module(define);
+  return module.value("toc");
 };
 
 export default function define(runtime, observer) {
@@ -26381,7 +28880,7 @@ visualizer(runtime, { // get a runtime reference from @mootari/access-runtime
 const _bym618 = function _8(md){return(
 md`## Customizing the visual representation
 
-The \`inspector\` variable defines a factory of variable observers, matching the signature of Observable's [\`Inspector.into\`](https://github.com/observablehq/inspector#Inspector_into) method. The visualizer uses this factory to build listeners to the runtime's variables. By default it is the default observable inspector, which renders cells in the way you are familiar, however, you can change this to anything. For example, the [minicell](https://observablehq.com/@tomlarkworthy/minicell) inspector renders just each variable's name, giving a minimap feel — but the possibilities are endless.`
+The \`inspector\` variable defines a factory of variable observers, matching the signature of Observable's [\`Inspector.into\`](https://github.com/observablehq/inspector#Inspector_into) method. The visualizer uses this factory to build listeners to the runtime's variables. By default it is the default observable inspector, which renders cells in the way you are familiar, however, you can change this to anything. In this notebook we also provide examples around the [minicell](https://observablehq.com/@tomlarkworthy/minicell), which renders just the variables's name, giving a minimap feel, but the possibilities are endless.`
 )};
 const _1quu22m = function _9(md){return(
 md`---
@@ -26854,8 +29353,7 @@ export default function define(runtime, observer) {
   main.define("liveCellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("liveCellMap", _));  
   main.define("navHref", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("navHref", _));
   return main;
-}
-</script>
+}</script>
 
 <script id="d/57d79353bac56631" 
   type="text/plain"
@@ -26912,2942 +29410,42 @@ export default function define(runtime, observer) {
   return main;
 }</script>
 
-<script id="@tomlarkworthy/invoke-variable" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _zkje0r = function _1(md){return(
-md`# \`invokeVariable(<name>, <module>, overrides = {})\`
-
-Test individual variables by calling them with injected values. Lets you test different scenarios without changing your core logic. Pairs with [@tomlarkworthy/tester](https://observablehq.com/@tomlarkworthy/tester)`
-)};
-const _kfe4ll = function _invokeVariable(lookupVariable){return(
-async function invokeVariable(name, module, overrides = {}) {
-  if (overrides == null || typeof overrides !== "object")
-    throw new TypeError(
-      "invokeVariable(name, module, {overrides}): overrides must be an object"
-    );
-
-  // Accept a Variable reference directly as the first arg (skip the lookupVariable stall when
-  // the caller already holds it); otherwise resolve by (name, module).
-  let variable;
-  if (name && typeof name === "object" && typeof name._definition !== "undefined") {
-    variable = name;
-    module = module ?? variable._module;
-  } else {
-    if (typeof name !== "string" || !name.length)
-      throw new TypeError(
-        "invokeVariable(name, module, …): name must be a non-empty string"
-      );
-    if (!module)
-      throw new TypeError("invokeVariable(name, module, …): module is required");
-    variable = await lookupVariable(name, module);
-    if (!variable)
-      throw new Error(`invokeVariable: variable "${name}" not found in module`);
-  }
-  module = module ?? variable._module;
-  const label = variable._name ?? (typeof name === "string" ? name : "(anonymous)");
-
-  const inputs = Array.isArray(variable._inputs) ? variable._inputs : [];
-  const inputNames = inputs.map((v) => v?._name);
-
-  for (const k of Object.keys(overrides)) {
-    if (!inputNames.includes(k)) {
-      throw new Error(
-        `invokeVariable("${label}"): override "${k}" was provided but is not a declared dependency. Declared dependencies: ${inputNames
-          .filter(Boolean)
-          .join(", ")}`
-      );
-    }
-  }
-
-  const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
-
-  const resolveDependency = async (depName) => {
-    if (hasOwn(overrides, depName)) return overrides[depName];
-
-    const scopeVar =
-      module?._scope?.get?.(depName) ??
-      module?._runtime?._builtin?._scope?.get?.(depName);
-
-    if (scopeVar) {
-      if (scopeVar._value !== undefined) return scopeVar._value;
-      if (scopeVar._promise && typeof scopeVar._promise?.then === "function")
-        return await scopeVar._promise;
-    }
-
-    if (typeof module?.value === "function") {
-      try {
-        return await module.value(depName);
-      } catch (e) {}
-    }
-
-    if (module?._runtime && typeof module._runtime._global === "function") {
-      try {
-        const g = module._runtime._global(depName);
-        if (g !== undefined) return g;
-      } catch (e) {}
-    }
-
-    throw new Error(
-      `invokeVariable("${label}"): could not resolve dependency "${depName}" (no override and not found in module/builtins/global)`
-    );
-  };
-
-  const args = [];
-  for (const dep of inputs) {
-    const depName = dep?._name;
-    if (!depName) {
-      args.push(undefined);
-      continue;
-    }
-    args.push(await resolveDependency(depName));
-  }
-
-  const def = variable._definition;
-  if (typeof def !== "function") {
-    throw new Error(
-      `invokeVariable("${label}"): target variable does not have an invokable function definition`
-    );
-  }
-  return def(...args);
-}
-)};
-const _jtrr9m = function _3(md){return(
-md`### Example
-
-let c = a + b`
-)};
-const _1v2c0s1 = function _a(){return(
-1
-)};
-const _ywl8oh = function _b(){return(
-3
-)};
-const _1mc3tpl = function _c(a,b){return(
-a + b
-)};
-const _o5e50u = function _7(md){return(
-md`If we invoke c without any overrides we get the notebook behaviour (i.e. the answer is 4, as a is 1 and b is 3)`
-)};
-const _tnoyf9 = function _8(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule)
-)};
-const _smh5by = function _9(md){return(
-md`But we can set b to 20, and then we get the answer 21.`
-)};
-const _d996jo = function _10(invokeVariable,invokeVariableModule){return(
-invokeVariable("c", invokeVariableModule, { b: 20 })
-)};
-const _qh0yhm = function _11(md){return(
-md`To call invokeVariable we need a reference to the module, which we can obtain with thisModule() (see runtime-sdk)`
-)};
-const _1hy0qcz = function _invokeVariableModule(thisModule){return(
-thisModule()
-)};
-const _jno7wc = (G, _) => G.input(_);
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  $def("_zkje0r", null, ["md"], _zkje0r);  
-  $def("_kfe4ll", "invokeVariable", ["lookupVariable"], _kfe4ll);  
-  $def("_jtrr9m", null, ["md"], _jtrr9m);  
-  $def("_1v2c0s1", "a", [], _1v2c0s1);  
-  $def("_ywl8oh", "b", [], _ywl8oh);  
-  $def("_1mc3tpl", "c", ["a","b"], _1mc3tpl);  
-  $def("_o5e50u", null, ["md"], _o5e50u);  
-  $def("_tnoyf9", null, ["invokeVariable","invokeVariableModule"], _tnoyf9);  
-  $def("_smh5by", null, ["md"], _smh5by);  
-  $def("_d996jo", null, ["invokeVariable","invokeVariableModule"], _d996jo);  
-  $def("_qh0yhm", null, ["md"], _qh0yhm);  
-  $def("_1hy0qcz", "viewof invokeVariableModule", ["thisModule"], _1hy0qcz);  
-  $def("_jno7wc", "invokeVariableModule", ["Generators","viewof invokeVariableModule"], _jno7wc);  
-  main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));
-  return main;
-}
-</script>
-
-<script id="@tomlarkworthy/plugin-registry" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _1ej2r92 = function _intro(md){return(
-md`# Plugin Registry
-
-A foundational notebook for **decoupled reactive plugin wiring**.
-
-Consumers get a realtime stream of all registered providers under a name. Providers can register themselves under a name. Neither has direct references between each other. This allows you to add more consumers and providers without changing individual providers and consumers. Useful for reactive plugin systems like audio instruments, dyamic menus, LLM tools and entity component systems.
-`
-)};
-const _16jmxgh = function _diagram(htl){return(
-htl.html`<svg viewBox="0 0 720 300" width="100%" style="max-width:720px;font-family:system-ui,sans-serif">
-  <defs>
-    <marker id="pr-arr" markerWidth="9" markerHeight="9" refX="7" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="var(--theme-foreground,#333)"></path>
-    </marker>
-    <style>
-      .pr-box{fill:var(--theme-background-alt,#f4f4f6);stroke:var(--theme-foreground-faint,#bbb);stroke-width:1.5}
-      .pr-hub{fill:var(--theme-foreground-faintest,#eef);stroke:var(--theme-foreground,#556);stroke-width:2}
-      .pr-t{fill:var(--theme-foreground,#222);font-size:13px}
-      .pr-s{fill:var(--theme-foreground-muted,#666);font-size:11px}
-      .pr-e{stroke:var(--theme-foreground,#333);stroke-width:1.5;fill:none;marker-end:url(#pr-arr)}
-    </style>
-  </defs>
-
-  <rect class="pr-box" x="10"  y="30"  width="170" height="48" rx="8"></rect>
-  <text class="pr-t" x="95" y="52" text-anchor="middle">Provider A</text>
-  <text class="pr-s" x="95" y="68" text-anchor="middle">plugins.add("x", v)</text>
-  <rect class="pr-box" x="10"  y="120" width="170" height="48" rx="8"></rect>
-  <text class="pr-t" x="95" y="142" text-anchor="middle">Provider B</text>
-  <text class="pr-s" x="95" y="158" text-anchor="middle">plugins.add("x", v, {invalidation})</text>
-  <text class="pr-s" x="95" y="215" text-anchor="middle">…N providers</text>
-
-  <rect class="pr-hub" x="270" y="78"  width="180" height="112" rx="10"></rect>
-  <text class="pr-t" x="360" y="104" text-anchor="middle" style="font-weight:600">plugins</text>
-  <text class="pr-s" x="360" y="128" text-anchor="middle">Map&lt;name, Set&lt;value&gt;&gt;</text>
-  <text class="pr-s" x="360" y="150" text-anchor="middle">add(name, value)</text>
-  <text class="pr-s" x="360" y="168" text-anchor="middle">get(name) → Generator</text>
-
-  <rect class="pr-box" x="540" y="30"  width="170" height="48" rx="8"></rect>
-  <text class="pr-t" x="625" y="52" text-anchor="middle">Consumer 1</text>
-  <text class="pr-s" x="625" y="68" text-anchor="middle">plugins.get("x")</text>
-  <rect class="pr-box" x="540" y="120" width="170" height="48" rx="8"></rect>
-  <text class="pr-t" x="625" y="142" text-anchor="middle">Consumer 2 (V2)</text>
-  <text class="pr-s" x="625" y="158" text-anchor="middle">plugins.get("x")</text>
-  <text class="pr-s" x="625" y="215" text-anchor="middle">…M consumers</text>
-
-  <path class="pr-e" d="M180,54 C225,54 235,116 268,126"></path>
-  <path class="pr-e" d="M180,144 C225,144 240,138 268,140"></path>
-  <path class="pr-e" d="M452,128 C500,116 510,54 538,54"></path>
-  <path class="pr-e" d="M452,142 C500,144 510,144 538,144"></path>
-</svg>`
-)};
-const _xnvzuh = function _contracts(md){return(
-md`## Contracts
-
-| Guarantee | How |
-|---|---|
-| **Named sets** | \`plugins\` maps a name → a set of values. Providers \`add\`, consumers \`get\`; they coordinate only by name. |
-| **Reactive** | \`get(name)\` is a Generator that yields the current set and re-yields on every add/remove for that name. |
-| **N↔M decoupling** | Providers and consumers share only \`plugins\`. Any number of each; a name is the whole contract. |
-| **Auto-cleanup** | \`add\` returns \`remove()\`. Pass \`{invalidation}\` (a cell's disposal promise) to remove automatically when the provider cell re-runs. |
-| **No leaks** | \`get\`'s Generator unsubscribes on disposal; per-name listeners are dropped when the last consumer leaves. |
-| **Eventual convergence** | Each consumer gets the current set immediately on \`get\`, then a full-set snapshot on every change — so any interleaving of add/remove/get converges. |`
-)};
-const _1ua5hud = function _apiReference(md){return(
-md`## API reference
-
-The whole API is two methods on \`plugins\`.
-
-**\`plugins.add(name, value, options?)\`** → \`remove()\`
-Add \`value\` to the set stored under \`name\` (creating the set on first use). Returns a \`remove()\` function
-that takes this value back out. \`options.invalidation\` (optional, may be null/omitted) is a promise — when
-it settles the value is removed automatically; pass a provider cell's built-in \`invalidation\` so re-running
-the cell replaces rather than duplicates. \`value\` is anything; for shared views it is commonly a factory
-\`() => element\` that each consumer calls to get its own instance.
-
-**\`plugins.get(name)\`** → Generator&lt;value[]&gt;
-Return a reactive Generator of the values currently in \`name\`'s set. It yields the current set immediately
-(so a late consumer still converges), then re-yields the full set on every add/remove. Use it from a cell
-and that cell recomputes on each change. Call it from as many consumers as you like (e.g. a module and its
-V2) — each call is an independent Generator that cleans up when its cell is torn down.`
-)};
-const _1pzt22q = function _createPlugins(Generators)
-{
-  return function createPlugins() {
-    const sets = new Map();
-    // name -> Set<value>
-    const listeners = new Map();
-    // name -> Set<() => void>
-    const notify = name => {
-      const ls = listeners.get(name);
-      if (ls)
-        for (const l of [...ls])
-          l();  // copy: a consumer may (un)subscribe while notifying
-    };
-    const add = (name, value, options) => {
-      let set = sets.get(name);
-      if (!set)
-        sets.set(name, set = new Set());
-      set.add(value);
-      notify(name);
-      const remove = () => {
-        const s = sets.get(name);
-        if (s && s.delete(value)) {
-          if (s.size === 0)
-            sets.delete(name);
-          notify(name);
-        }
-      };
-      const invalidation = options && options.invalidation;
-      if (invalidation)
-        Promise.resolve(invalidation).then(remove, remove);
-      return remove;
-    };
-    const get = name => Generators.observe(change => {
-      const push = () => change([...sets.get(name) ?? []]);
-      push();
-      // current set immediately → converges
-      let ls = listeners.get(name);
-      if (!ls)
-        listeners.set(name, ls = new Set());
-      ls.add(push);
-      return () => {
-        ls.delete(push);
-        if (ls.size === 0)
-          listeners.delete(name);
-      };  // leak-safe
-    });
-    return {
-      add,
-      get,
-      listenerCount: name => listeners.get(name)?.size ?? 0
-    };
-  };
-};
-const _1qu8dwj = function _plugins(createPlugins){return(
-createPlugins()
-)};
-const _a7p1z5 = function _testsHeader(md){return(
-md`## Tests`
-)};
-const _15xl311 = function _test_get_reflects_add(createPlugins){return(
-(async () => {
-  const p = createPlugins();
-  const gen = p.get('x');
-  if ((await (await gen.next()).value).length !== 0)
-    throw new Error('new set should start empty');
-  p.add('x', 1);
-  const after = await (await gen.next()).value;
-  if (after.length !== 1 || after[0] !== 1)
-    throw new Error('get did not reflect the add');
-  gen.return();
-  return '\u2705 get(name) yields the named set and updates on add';
-})()
-)};
-const _122zyhz = function _test_multi_provider_and_convergence(createPlugins)
-{
-  return (async () => {
-    const p = createPlugins();
-    const a = p.get('x'), b = p.get('x');
-    // two independent consumers
-    await (await a.next()).value;
-    await (await b.next()).value;
-    p.add('x', 'one');
-    // provider 1
-    p.add('x', 'two');
-    // provider 2
-    const va = (await (await a.next()).value).slice().sort().join(',');
-    const vb = (await (await b.next()).value).slice().sort().join(',');
-    if (va !== 'one,two' || vb !== 'one,two')
-      throw new Error('consumers did not converge to the full set');
-    a.return();
-    b.return();
-    return '\u2705 multiple providers accumulate; all consumers converge';
-  })();
-};
-const _1lojas7 = function _test_remove_and_names_isolated(createPlugins){return(
-(async () => {
-  const p = createPlugins();
-  const gx = p.get('x'), gy = p.get('y');
-  await (await gx.next()).value;
-  await (await gy.next()).value;
-  const remove = p.add('x', 1);
-  p.add('y', 2);
-  if ((await (await gx.next()).value).join() !== '1')
-    throw new Error('x set wrong');
-  if ((await (await gy.next()).value).join() !== '2')
-    throw new Error('names are not isolated');
-  remove();
-  if ((await (await gx.next()).value).length !== 0)
-    throw new Error('remove() did not take the value out');
-  gx.return();
-  gy.return();
-  return '\u2705 remove() works and names are isolated';
-})()
-)};
-const _8240yg = function _test_invalidation_and_no_leak(createPlugins){return(
-(async () => {
-  const p = createPlugins();
-  let settle;
-  p.add('x', 1, { invalidation: new Promise(r => settle = r) });
-  const gen = p.get('x');
-  if ((await (await gen.next()).value).length !== 1)
-    throw new Error('value should be present before invalidation');
-  if (p.listenerCount('x') !== 1)
-    throw new Error('get should have registered a listener');
-  settle();
-  await Promise.resolve();
-  await Promise.resolve();
-  if ((await (await gen.next()).value).length !== 0)
-    throw new Error('invalidation did not remove the value');
-  gen.return();
-  if (p.listenerCount('x') !== 0)
-    throw new Error('disposing the Generator leaked a listener');
-  return '\u2705 {invalidation} auto-removes and get() leaks no listeners';
-})()
-)};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  $def("_1ej2r92", "intro", ["md"], _1ej2r92);  
-  $def("_16jmxgh", "diagram", ["htl"], _16jmxgh);  
-  $def("_xnvzuh", "contracts", ["md"], _xnvzuh);  
-  $def("_1ua5hud", "apiReference", ["md"], _1ua5hud);  
-  $def("_1pzt22q", "createPlugins", ["Generators"], _1pzt22q);  
-  $def("_1qu8dwj", "plugins", ["createPlugins"], _1qu8dwj);  
-  $def("_a7p1z5", "testsHeader", ["md"], _a7p1z5);  
-  $def("_15xl311", "test_get_reflects_add", ["createPlugins"], _15xl311);  
-  $def("_122zyhz", "test_multi_provider_and_convergence", ["createPlugins"], _122zyhz);  
-  $def("_1lojas7", "test_remove_and_names_isolated", ["createPlugins"], _1lojas7);  
-  $def("_8240yg", "test_invalidation_and_no_leak", ["createPlugins"], _8240yg);
-  return main;
-}</script>
-
-<script id="@tomlarkworthy/modules" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _s7bl1p = function _1(md){return(
-md`# Modules
-
-\`modules(options?)\` is an async generator that yields a **cumulative \`Map\`** (module → \`{name, title, module, variable}\`) of every fully-formed record known so far, growing as modules resolve. 
-
-It's an effecient alternative to [moduleMap](https://observablehq.com/@tomlarkworthy/module-map) that blocks until all modules are loaded.
-`
-)};
-const _1eaa9lr = function _currentModules(modules){return(
-modules()
-)};
-const _dmem61 = function _modules(runtime,observeVariable,moduleTitle)
-{
-  const _runtime = runtime;
-  // default: the current runtime
-  return function modules({runtime = _runtime, titleTimeoutMs = 2000, rescanMs = 1000, load = true} = {}) {
-    if (!runtime || !runtime._variables)
-      throw 'Invalid runtime passed to modules';
-    return async function* () {
-      const records = new Map();
-      // module -> fully-formed record (title resolved before it lands here)
-      const watchers = new Map();
-      // module -> cancel fn (stops its title watch)
-      const peeking = new Map();
-      // unresolved `module X` variable -> stop fn (its force-load observer)
-      let pending = false, wake = null, dirty = true;
-      const bump = () => {
-        pending = true;
-        if (wake) {
-          const w = wake;
-          wake = null;
-          w();
-        }
-      };
-      const touch = () => {
-        dirty = true;
-        bump();
-      };
-      // Recover a module's @user/slug from its loader definition. On Observable's runtime the
-      // `module X` variable is named numerically ("module 1"), so v._name.slice(7) is a useless id;
-      // the real slug lives in the loader's import URL — import("/@user/slug.js?…") or
-      // importShim("/@user/slug.js", …). Matches both runtimes; null if no URL is found.
-      const slugFromDef = v => {
-        const m = v._definition && String(v._definition).match(/import(?:Shim)?\(\s*["'`]\/?([^"'`?]+?)\.js(?:[?"'`)]|$)/);
-        return m ? m[1].replace(/^\//, '') : null;
-      };
-      // Live candidate modules: Map<module, {name, variable?, title?}>. Side effect: force-loads
-      // unresolved `module X` variables via observe (which marks them reachable) so their modules
-      // become resolvable on a later scan.
-      const scan = () => {
-        const out = new Map();
-        const put = (m, r) => {
-          if (m && !out.has(m))
-            out.set(m, r);
-        };
-        const builtin = runtime._builtin, bootloader = runtime.bootloader;
-        if (builtin)
-          put(builtin, {
-            name: 'builtin',
-            title: 'Standard library'
-          });
-        if (bootloader)
-          put(bootloader, {
-            name: 'bootloader',
-            title: 'Bootloader'
-          });
-        for (const [name, mod] of runtime.mains || new Map())
-          put(mod, { name });
-        // main modules: variable-graph roots — own variables but aren't imported (nor builtin/
-        // bootloader). Catches the top-level main of a plain runtime where runtime.mains is empty.
-        const imported = new Set((runtime._modules || new Map()).values());
-        const owners = new Set();
-        for (const v of runtime._variables)
-          if (v._module)
-            owners.add(v._module);
-        for (const m of owners)
-          if (m !== builtin && m !== bootloader && !imported.has(m))
-            put(m, { name: 'main' });
-        // imported modules carried by `module X` variables
-        for (const v of runtime._variables) {
-          if (!v._name || !v._name.startsWith('module ') || v._name.startsWith('module <unknown'))
-            continue;
-          const mod = v._value;
-          if (mod && typeof mod === 'object')
-            put(mod, {
-              name: slugFromDef(v) || v._name.slice(7),
-              variable: v
-            });
-          else if (load && !peeking.has(v))
-            peeking.set(v, observeVariable(v, {
-              fulfilled: bump,
-              error: bump
-            }));
-        }
-        return out;
-      };
-      // Reconcile the snapshot with the live runtime each scan.
-      const reconcile = () => {
-        const cand = scan();
-        // DELETE: drop modules no longer present; cancel their title watcher.
-        for (const m of [...watchers.keys()]) {
-          if (!cand.has(m)) {
-            const cancel = watchers.get(m);
-            watchers.delete(m);
-            if (records.delete(m))
-              touch();
-            try {
-              cancel();
-            } catch (e) {
-            }
-          }
-        }
-        // CREATE: start a persistent title watch for each new module. The module enters `records`
-        // only once its title resolves (or the timeout fires). Later title changes update in place.
-        for (const [m, c] of cand) {
-          if (watchers.has(m))
-            continue;
-          if (c.title != null) {
-            // static title (builtin / bootloader)
-            records.set(m, {
-              name: c.name,
-              title: c.title,
-              module: m,
-              variable: c.variable
-            });
-            watchers.set(m, () => {
-            });
-            touch();
-            continue;
-          }
-          const apply = title => {
-            if (!watchers.has(m))
-              return;
-            // module was pruned -> ignore late title callbacks
-            const t = title ?? c.name;
-            const prev = records.get(m);
-            if (!prev) {
-              records.set(m, {
-                name: c.name,
-                title: t,
-                module: m,
-                variable: c.variable
-              });
-              touch();
-            } else if (prev.title !== t) {
-              records.set(m, {
-                ...prev,
-                title: t
-              });
-              touch();
-            }
-          };
-          const cancel = moduleTitle(m, apply);
-          watchers.set(m, () => {
-            try {
-              cancel();
-            } catch (e) {
-            }
-          });
-          // title never resolved within the budget -> show the name so the module isn't withheld.
-          setTimeout(() => {
-            if (watchers.has(m) && !records.has(m))
-              apply(null);
-          }, titleTimeoutMs);
-        }
-      };
-      let stopped = false;
-      (async () => {
-        while (!stopped) {
-          try {
-            reconcile();
-          } catch (e) {
-          }
-          await new Promise(r => setTimeout(r, rescanMs));
-        }
-      })();
-      try {
-        while (true) {
-          pending = false;
-          if (dirty) {
-            dirty = false;
-            yield new Map(records);
-          }
-          // cumulative snapshot
-          if (!pending)
-            await new Promise(resolve => {
-              wake = resolve;
-              if (pending) {
-                wake = null;
-                resolve();
-              }
-            });
-        }
-      } finally {
-        stopped = true;
-        for (const cancel of watchers.values()) {
-          try {
-            cancel();
-          } catch (e) {
-          }
-        }
-        for (const stop of peeking.values()) {
-          try {
-            stop();
-          } catch (e) {
-          }
-        }
-      }
-    }();
-  };
-};
-const _up9atj = function _moduleTitle(observeVariable)
-{
-  return function moduleTitle(module, onTitle) {
-    // Observes a module's title-defining cell and calls onTitle(title|null) on every change.
-    // Returns a cancel fn. The fixed observe() forces a lazy title cell to compute (and replays
-    // the current value on attach), so no in-module forcing helper is needed — works for named
-    // and anonymous cells alike, even in a fresh runtime nothing else observes.
-    const rt = module._runtime;
-    const candidates = [...rt._variables].filter(v => {
-      if (!v || v._module !== module || !v._definition || v._type != 1)
-        return false;
-      const n = v._name;
-      if (typeof n === 'string' && (n.startsWith('dynamic observe ') || n.startsWith('module ')))
-        return false;
-      return true;
-    });
-    if (candidates.length === 0) {
-      onTitle(null);
-      return () => {
-      };
-    }
-    const first = candidates.reduce((a, b) => (a._id ?? Infinity) <= (b._id ?? Infinity) ? a : b);
-    const extract = v => {
-      if (v == null)
-        return null;
-      if (typeof v === 'string')
-        return v.trim() || null;
-      if (v.tagName) {
-        if (v.tagName == 'H1')
-          return v.textContent;
-        const h1 = v.querySelector?.('h1');
-        if (h1)
-          return (h1.textContent ?? '').trim() || null;
-        return null;
-      }
-      if (v.textContent)
-        return (v.textContent ?? '').trim() || null;
-      return null;
-    };
-    const stop = observeVariable(first, {
-      fulfilled: value => onTitle(extract(value)),
-      error: () => onTitle('Err')
-    });
-    return () => {
-      try {
-        stop();
-      } catch (e) {
-      }
-    };
-  };
-};
-const _qpensj = function _5(Inputs,currentModules){return(
-Inputs.table([...currentModules.values()], {
-  columns: [
-    'name',
-    'title'
-  ],
-  format: { name: x => x }
-})
-)};
-const _1x0q6zt = function _7(md){return(
-md`## Tests`
-)};
-const _e0sbyj = function _8(tests,modulesModule){return(
-tests({
-  filter: (t) => t.variable._module == modulesModule
-})
-)};
-const _p3rq3v = function _modulesModule(thisModule){return(
-thisModule()
-)};
-const _16g1ab = (G, _) => G.input(_);
-const _cayyvt = function _testRuntime(Runtime){return(
-new Runtime()
-)};
-const _1j4p6g3 = function _testModulesLatest(modules,testRuntime){return(
-modules({
-  runtime: testRuntime
-})
-)};
-const _1oq6y7s = function _newModule(testRuntime)
-{
-  const m = testRuntime.module();
-  m.variable().define("greeting", [], () => {
-    const div = document.createElement("div");
-    div.innerHTML = "<h1>New Module</h1>";
-    return div;
-  });
-  return m;
-};
-const _1li1bty = function _test_detectsBuiltin(testModulesLatest)
-{
-  if (![...testModulesLatest.values()].find((m) => m.name == "builtin"))
-    throw Error();
-  return "ok";
-};
-const _vr1kp6 = function _test_detectsNewModule(testModulesLatest,newModule)
-{
-  const rec = testModulesLatest.get(newModule);
-  if (!rec) throw Error("newModule not detected yet");
-  if (rec.title !== "New Module")
-    throw Error(
-      "expected title 'New Module', got " + JSON.stringify(rec.title)
-    );
-  return "ok";
-};
-const _1p0sqk = async function _test_reflectsDelete(Runtime,modules)
-{
-  const rt = new Runtime();
-  const gen = modules({
-    runtime: rt,
-    rescanMs: 100,
-    titleTimeoutMs: 500
-  });
-  let snap = new Map();
-  (async () => {
-    for await (const s of gen) snap = s;
-  })();
-  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
-  const waitFor = async (pred, ms = 3000) => {
-    const t0 = Date.now();
-    while (Date.now() - t0 < ms) {
-      if (pred()) return true;
-      await wait(50);
-    }
-    return false;
-  };
-  try {
-    const m = rt.module();
-    m.variable().define("title", [], () => {
-      const d = document.createElement("div");
-      d.innerHTML = "<h1>Temp</h1>";
-      return d;
-    });
-    if (!(await waitFor(() => snap.has(m))))
-      throw Error("create not reflected");
-    for (const v of [...rt._variables]) if (v._module === m) v.delete();
-    if (!(await waitFor(() => !snap.has(m))))
-      throw Error("delete not reflected");
-    return "ok";
-  } finally {
-    if (gen.return) gen.return();
-  }
-};
-const _1315qaf = async function _test_reflectsTitleUpdate(Runtime,modules)
-{
-  const rt = new Runtime();
-  const gen = modules({
-    runtime: rt,
-    rescanMs: 100,
-    titleTimeoutMs: 500
-  });
-  let snap = new Map();
-  (async () => {
-    for await (const s of gen) snap = s;
-  })();
-  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
-  const waitFor = async (pred, ms = 3000) => {
-    const t0 = Date.now();
-    while (Date.now() - t0 < ms) {
-      if (pred()) return true;
-      await wait(50);
-    }
-    return false;
-  };
-  try {
-    const m = rt.module();
-    const tv = m.variable().define("title", [], () => {
-      const d = document.createElement("div");
-      d.innerHTML = "<h1>First</h1>";
-      return d;
-    });
-    if (!(await waitFor(() => snap.get(m)?.title === "First")))
-      throw Error("initial title not detected");
-    tv.define("title", [], () => {
-      const d = document.createElement("div");
-      d.innerHTML = "<h1>Second</h1>";
-      return d;
-    });
-    if (!(await waitFor(() => snap.get(m)?.title === "Second")))
-      throw Error("title update not reflected");
-    return "ok";
-  } finally {
-    if (gen.return) gen.return();
-  }
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
-  main.define("module @tomlarkworthy/observable-runtime-v6", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime-v6.js?v=4")).default));  
-  $def("_s7bl1p", null, ["md"], _s7bl1p);  
-  $def("_1eaa9lr", "currentModules", ["modules"], _1eaa9lr);  
-  $def("_dmem61", "modules", ["runtime","observeVariable","moduleTitle"], _dmem61);  
-  $def("_up9atj", "moduleTitle", ["observeVariable"], _up9atj);  
-  $def("_qpensj", null, ["Inputs","currentModules"], _qpensj);  
-  main.define("observeVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("observe", "observeVariable", _));  
-  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("thisModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("thisModule", _));  
-  $def("_1x0q6zt", null, ["md"], _1x0q6zt);  
-  $def("_e0sbyj", null, ["tests","modulesModule"], _e0sbyj);  
-  main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
-  main.define("Runtime", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("Runtime", _));  
-  $def("_p3rq3v", "viewof modulesModule", ["thisModule"], _p3rq3v);  
-  $def("_16g1ab", "modulesModule", ["Generators","viewof modulesModule"], _16g1ab);  
-  $def("_cayyvt", "testRuntime", ["Runtime"], _cayyvt);  
-  $def("_1j4p6g3", "testModulesLatest", ["modules","testRuntime"], _1j4p6g3);  
-  $def("_1oq6y7s", "newModule", ["testRuntime"], _1oq6y7s);  
-  $def("_1li1bty", "test_detectsBuiltin", ["testModulesLatest"], _1li1bty);  
-  $def("_vr1kp6", "test_detectsNewModule", ["testModulesLatest","newModule"], _vr1kp6);  
-  $def("_1p0sqk", "test_reflectsDelete", ["Runtime","modules"], _1p0sqk);  
-  $def("_1315qaf", "test_reflectsTitleUpdate", ["Runtime","modules"], _1315qaf);
-  return main;
-}</script>
-
-<script id="@tomlarkworthy/lopepage-2" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _1pg70e1 = function _lp2_doc_overview(md){return(
-md`# Lopepage-2: Multi-notebook layout
-
-A layout engine for lopecode notebooks. It tiles modules into resizable splits and tabbed stacks, serialises the layout to the URL hash, and preserves scroll position across layout changes. It owns its DOM directly.
-
-It rests on three mechanisms, each described in its own section:
-
-1. **Immortal panes** — one scroll container per module, created once and reparented on layout change, so \`scrollTop\` is retained.
-2. **Persistent-id scroll anchoring** — when a pane's content resizes after load, the cell at the viewport top is held in place by its \`pid\`.
-3. **A layout tree** reconciled to DOM and round-tripped through the \`#view=\` DSL under loop-protected hash ownership.
-
-Dependencies: [\`runtime-sdk\`](https://observablehq.com/@tomlarkworthy/runtime-sdk) (\`persistentId\`, \`runtime\`), [\`visualizer\`](https://observablehq.com/@tomlarkworthy/visualizer) (cell rendering), [\`modules\`](https://observablehq.com/@tomlarkworthy/modules) (\`currentModules\` — incremental module discovery), [\`themes\`](https://observablehq.com/@tomlarkworthy/themes) (\`apply_theme\`). Four orthogonal feature modules are composed by import and kept reachable from \`lp2_background_jobs\`: [\`command-palette\`](https://observablehq.com/@tomlarkworthy/command-palette) (⌘K), [\`claude-code-pairing\`](https://observablehq.com/@tomlarkworthy/claude-code-pairing) (\`cc_chat\`), [\`local-change-history\`](https://observablehq.com/@tomlarkworthy/local-change-history) (edit recording/replay), and [\`editor-5\`](https://observablehq.com/@tomlarkworthy/editor-5) (\`auto_attach\` — inline cell editing).`
-)};
-const _1ov8ye5 = function _lp2_doc_model(md){return(
-md`### Layout model and DSL
-
-The layout is a single tree. \`viewof lp2Model\` holds it as reactive state. A node is one of:
-
-- \`{t:'row'|'col', sizes:[..%], children:[node]}\` — a split; \`sizes\` are percentages summing to 100, one per child.
-- \`{t:'stack', active:int, tabs:[{module}]}\` — a tabbed pane; \`active\` indexes \`tabs\`.
-
-There is always exactly one root node. \`lp2_parseDSL\` and \`lp2_serializeDSL\` convert the tree to and from the \`#view=\` \`R\`/\`C\`/\`S\` weighted DSL, the same grammar the rest of lopecode uses, so a layout is fully described by its URL.`
-)};
-const _1rihrff = function _lp2Model(Inputs){return(
-Inputs.input({
-  t: 'row',
-  sizes: [
-    50,
-    50
-  ],
-  children: [
-    {
-      t: 'stack',
-      active: 0,
-      tabs: [{ module: '@tomlarkworthy/runtime-sdk' }]
-    },
-    {
-      t: 'stack',
-      active: 0,
-      tabs: [{ module: '@tomlarkworthy/visualizer' }]
-    }
-  ]
-})
-)};
-const _1ow4sob = (G, _) => G.input(_);
-const _l8xp7u = function _lp2_parseDSL(){return(
-input => {
-  if (!input)
-    return null;
-  input = String(input);
-  if (input.startsWith('#'))
-    input = input.slice(1);
-  const mView = input.match(/(?:^|&)view=([^&]*)/);
-  if (mView)
-    input = mView[1];
-  let i = 0;
-  const num = () => {
-    const s = i;
-    while (i < input.length && input[i] >= '0' && input[i] <= '9')
-      i++;
-    return s < i ? parseInt(input.slice(s, i), 10) : null;
-  };
-  const moduleName = () => {
-    const s = i;
-    while (i < input.length && !',)#'.includes(input[i]))
-      i++;
-    return input.slice(s, i);
-  };
-  const parseLeaf = () => {
-    const weight = num();
-    const module = moduleName();
-    let cell;
-    if (input[i] === '#') {
-      i++;
-      const s = i;
-      while (i < input.length && !',)'.includes(input[i]))
-        i++;
-      cell = input.slice(s, i);
-    }
-    return {
-      node: {
-        module,
-        ...cell ? { cell } : {}
-      },
-      weight
-    };
-  };
-  const parseItem = () => {
-    const c = input[i];
-    return c === 'R' || c === 'C' || c === 'S' ? parseGroup() : parseLeaf();
-  };
-  const parseList = isStack => {
-    const items = [];
-    while (i < input.length && input[i] !== ')') {
-      items.push(isStack ? parseLeaf() : parseItem());
-      if (input[i] === ',')
-        i++;
-    }
-    return items;
-  };
-  const parseGroup = () => {
-    const type = input[i++];
-    const weight = num();
-    let items = [];
-    if (input[i] === '(') {
-      i++;
-      items = parseList(type === 'S');
-      if (input[i] === ')')
-        i++;
-    }
-    if (type === 'S')
-      return {
-        node: {
-          t: 'stack',
-          active: 0,
-          tabs: items.map(it => it.node)
-        },
-        weight
-      };
-    const children = items.map(it => it.node);
-    const sizes = items.map(it => it.weight != null ? it.weight : Math.round(100 / items.length));
-    return {
-      node: {
-        t: type === 'R' ? 'row' : 'col',
-        children,
-        sizes
-      },
-      weight
-    };
-  };
-  const r = parseItem();
-  return r ? r.node : null;
-}
-)};
-const _15gufbj = function _lp2_serializeDSL(){return(
-root => {
-  const s = (node, weight) => {
-    const w = weight != null ? weight : 100;
-    if (!node)
-      return '';
-    if (node.t === 'stack') {
-      const tabs = (node.tabs || []).map(l => l.module + (l.cell ? '#' + l.cell : '')).join(',');
-      return `S${ w }(${ tabs })`;
-    }
-    if (node.t === 'row' || node.t === 'col') {
-      const n = node.children || [];
-      const kids = n.map((c, idx) => s(c, node.sizes && node.sizes[idx] != null ? node.sizes[idx] : Math.round(100 / n.length))).join(',');
-      return `${ node.t === 'row' ? 'R' : 'C' }${ w }(${ kids })`;
-    }
-    return (node.module || '') + (node.cell ? '#' + node.cell : '');
-  };
-  return s(root, 100);
-}
-)};
-const _14hgn59 = function _lp2_doc_panes(md){return(
-md`### Immortal panes
-
-\`lp2_paneRegistry\` is a \`Map\` from module name to a single scroll \`<div>\` that hosts that module's [\`visualizer\`](https://observablehq.com/@tomlarkworthy/visualizer) render. \`lp2_getPane\` builds the pane on first request and returns the cached element thereafter. \`lp2_moduleByName\` resolves a module name to its runtime module via \`currentModules\` from [\`modules\`](https://observablehq.com/@tomlarkworthy/modules), an async generator that yields a cumulative module map as modules resolve.
-
-Invariants:
-
-- One pane element per module name, for the lifetime of the page.
-- A layout change reparents the cached element; it is never recreated, so its rendered content and DOM state are preserved.
-- A layout-only change does not alter a pane's content height, so capturing \`scrollTop\` before the reparent and restoring it after is exact.`
-)};
-const _r14r4j = function _lp2_moduleByName(lp2_watchedModules){return(
-name => lp2_watchedModules && lp2_watchedModules.get ? lp2_watchedModules.get(name) : undefined
-)};
-const _j3eb9x = function _lp2_paneRegistry(){return(
-new Map()
-)};
-const _193se86 = function _lp2_getPane(lp2_scrollToCell,lp2_paneRegistry,lp2_moduleByName,visualizer,runtime,lp2_installAnchor){return(
-(moduleName, deepLinkCell) => {
-    const applyDeepLink = entry => {
-      if (deepLinkCell && !entry.transient && entry.deepLink !== deepLinkCell) {
-        entry.deepLink = deepLinkCell;
-        lp2_scrollToCell(entry, deepLinkCell);
-      }
-      return entry;
-    };
-    let entry = lp2_paneRegistry.get(moduleName);
-    if (entry)
-      return applyDeepLink(entry);
-    const el = document.createElement('div');
-    el.className = 'lp2-pane';
-    el.dataset.module = moduleName;
-    Object.assign(el.style, {
-      overflow: 'auto',
-      height: '100%',
-      width: '100%',
-      position: 'relative',
-      overflowAnchor: 'auto'
-    });
-    const mod = lp2_moduleByName(moduleName);
-    if (!mod) {
-      // Module not in the (incrementally-populated) map yet. Return a transient placeholder
-      // WITHOUT caching, so a later render retries once the module resolves. Caching here would
-      // freeze the pane on "not found" forever (panes are immortal).
-      el.textContent = 'loading ' + moduleName + '\u2026';
-      el.style.cssText += ';display:flex;align-items:center;justify-content:center;color:var(--theme-foreground-faint);font:12px var(--monospace,monospace)';
-      return {
-        el,
-        viz: null,
-        moduleName,
-        anchor: null,
-        transient: true
-      };
-    }
-    const viz = visualizer(runtime, {
-      invalidation: new Promise(() => {
-      }),
-      module: mod,
-      filter: (cell_name, variables) => {
-        if (variables?.[0]?._type !== 1)
-          return false;
-        if (typeof cell_name === 'string' && cell_name.startsWith('dynamic '))
-          return false;
-        return true;
-      }
-    });
-    el.appendChild(viz);
-    entry = {
-      el,
-      viz,
-      moduleName,
-      anchor: null
-    };
-    lp2_paneRegistry.set(moduleName, entry);
-    lp2_installAnchor(entry);
-    return applyDeepLink(entry);
-  }
-)};
-const _88b5go = function _lp2_doc_scroll(md){return(
-md`### Scroll anchoring
-
-When a pane's content changes height after mount (async cells, images), the anchor keeps the viewport stable. \`lp2_anchor\` records the cell at the viewport top as \`{pid, offset}\`, where \`pid\` is \`persistentId(node.variable)\` from [\`runtime-sdk\`](https://observablehq.com/@tomlarkworthy/runtime-sdk). Every visualizer cell node carries a \`.variable\` backref, so the pid is read without modifying the visualizer.
-
-\`lp2_installAnchor\` attaches a \`ResizeObserver\` to the pane content and re-applies the anchor (\`scrollTop = node.offsetTop + offset\`) on each callback. The observer fires after layout and before paint, so the correction lands in the same frame. A programmatic \`scrollTop\` write disables the browser's native \`overflow-anchor\`, so the anchor is maintained in JS.`
-)};
-const _78h40x = function _lp2_anchor(persistentId)
-{
-  const cellNodes = paneEl => [...paneEl.querySelectorAll('.observablehq[cell]')];
-  const pidOf = node => {
-    try {
-      return node.variable ? persistentId(node.variable) : null;
-    } catch (e) {
-      return null;
-    }
-  };
-  const capture = paneEl => {
-    const top = paneEl.scrollTop;
-    if (top <= 0)
-      return null;
-    for (const node of cellNodes(paneEl)) {
-      const nTop = node.offsetTop, nBot = nTop + node.offsetHeight;
-      if (nBot > top + 1) {
-        const pid = pidOf(node);
-        if (pid)
-          return {
-            pid,
-            offset: top - nTop
-          };
-      }
-    }
-    return null;
-  };
-  const restore = (paneEl, anchor) => {
-    if (!anchor || !anchor.pid)
-      return false;
-    const node = cellNodes(paneEl).find(n => pidOf(n) === anchor.pid);
-    if (!node)
-      return false;
-    paneEl.scrollTop = node.offsetTop + anchor.offset;
-    return true;
-  };
-  return {
-    cellNodes,
-    pidOf,
-    capture,
-    restore
-  };
-};
-const _d4xe91 = function _lp2_installAnchor(lp2_anchor,ResizeObserver){return(
-entry => {
-  const el = entry.el;
-  if (el.__lp2_anchor_bound)
-    return;
-  el.__lp2_anchor_bound = true;
-  const A = lp2_anchor;
-  let raf = 0;
-  el.addEventListener('scroll', () => {
-    if (el.__lp2_pinning)
-      return;
-    if (raf)
-      return;
-    raf = requestAnimationFrame(() => {
-      raf = 0;
-      entry.anchor = A.capture(el);
-    });
-  }, { passive: true });
-  const content = el.querySelector('.lope-viz') || el.firstElementChild;
-  if (content && window.ResizeObserver) {
-    const ro = new ResizeObserver(() => {
-      if (!entry.anchor)
-        return;
-      el.__lp2_pinning = true;
-      A.restore(el, entry.anchor);
-      requestAnimationFrame(() => {
-        el.__lp2_pinning = false;
-      });
-    });
-    ro.observe(content);
-    entry.ro = ro;
-  }
-}
-)};
-const _xwsg4w = function _lp2_doc_layout(md){return(
-md`### Layout rendering and docking
-
-\`lp2_renderNode\` reconciles the model tree to DOM: rows and cols are flexbox with draggable splitters that write percentages back to \`node.sizes\`; a stack is a tab header plus the active pane. \`lp2_view\` runs the render together with the scroll capture/restore, and exposes \`commit(newRoot)\`, which republishes the model through the \`lp2Model\` viewof. Every structural change therefore re-renders and round-trips to the URL through one path.
-
-\`lp2_ops\` holds the tree operations: \`findHost\`, \`removeLeaf\`, \`dropBeside\`, \`normalize\`, and \`move\`. \`normalize\` collapses emptied stacks and single-child splits, so the tree stays minimal. Dragging a tab onto a pane's edge splits it (left/right/top/bottom); onto its centre merges into that stack. \`lp2_dragOut\` writes the module's \`.js\` source to the drag \`DataTransfer\`, so the same drag can drop the module out to the filesystem.`
-)};
-const _1fxe40f = function _lp2_host()
-{
-  const host = document.createElement('div');
-  host.className = 'lp2-host';
-  Object.assign(host.style, {
-    position: 'absolute',
-    inset: '0',
-    display: 'flex',
-    overflow: 'hidden'
-  });
-  return host;
-};
-const _inou6n = function _lp2_renderNode(lp2_renderStack,lp2_renderSplit){return(
-ctx => {
-    // dispatch a layout node to its renderer; `make` recurses for nested splits
-    const make = node => {
-      if (!node)
-        return document.createTextNode('');
-      if (node.t === 'stack')
-        return lp2_renderStack(node, ctx);
-      if (node.t === 'row' || node.t === 'col')
-        return lp2_renderSplit(node, ctx, make);
-      return document.createTextNode('unknown node ' + node.t);
-    };
-    return make;
-  }
-)};
-const _1r0c4er = function _lp2_ops()
-{
-  // pure-ish surgery on the live layout tree; mutate then commit() to republish
-  const replaceNode = (root, oldRef, newNode) => {
-    if (root === oldRef)
-      return newNode;
-    const rec = n => {
-      if (!n || !n.children)
-        return;
-      for (let i = 0; i < n.children.length; i++) {
-        if (n.children[i] === oldRef) {
-          n.children[i] = newNode;
-          return true;
-        }
-        if (rec(n.children[i]))
-          return true;
-      }
-      return false;
-    };
-    rec(root);
-    return root;
-  };
-  // collapse empty stacks and single-child splits; returns cleaned node or null
-  const normalize = node => {
-    if (!node)
-      return null;
-    if (node.t === 'stack')
-      return node.tabs && node.tabs.length ? node : null;
-    const kids = (node.children || []).map(normalize).filter(Boolean);
-    if (kids.length === 0)
-      return null;
-    if (kids.length === 1)
-      return kids[0];
-    node.children = kids;
-    node.sizes = kids.map(() => Math.round(100 / kids.length));
-    return node;
-  };
-  // find the stack holding `module`; returns {stack, tabIndex} or null
-  const findHost = (root, module) => {
-    let res = null;
-    const rec = n => {
-      if (!n || res)
-        return;
-      if (n.t === 'stack') {
-        const ti = (n.tabs || []).findIndex(l => l.module === module);
-        if (ti >= 0)
-          res = {
-            stack: n,
-            tabIndex: ti
-          };
-      } else
-        (n.children || []).forEach(rec);
-    };
-    rec(root);
-    return res;
-  };
-  // is `target` reachable from root?
-  const contains = (root, target) => {
-    if (root === target)
-      return true;
-    return (root.children || []).some(c => contains(c, target));
-  };
-  // remove first leaf with `module`; returns {root, leaf}
-  const removeLeaf = (root, module) => {
-    const host = findHost(root, module);
-    if (!host)
-      return {
-        root,
-        leaf: null
-      };
-    const [leaf] = host.stack.tabs.splice(host.tabIndex, 1);
-    if (host.stack.active >= host.stack.tabs.length)
-      host.stack.active = Math.max(0, host.stack.tabs.length - 1);
-    return {
-      root: normalize(root) || {
-        t: 'stack',
-        active: 0,
-        tabs: []
-      },
-      leaf
-    };
-  };
-  // drop `leaf` relative to `targetStack`: side = left|right|top|bottom|center
-  const dropBeside = (root, targetStack, leaf, side) => {
-    if (side === 'center') {
-      targetStack.tabs.push(leaf);
-      targetStack.active = targetStack.tabs.length - 1;
-      return root;
-    }
-    const orient = side === 'left' || side === 'right' ? 'row' : 'col';
-    const newStack = {
-      t: 'stack',
-      active: 0,
-      tabs: [leaf]
-    };
-    const order = side === 'left' || side === 'top' ? [
-      newStack,
-      targetStack
-    ] : [
-      targetStack,
-      newStack
-    ];
-    const repl = {
-      t: orient,
-      sizes: [
-        50,
-        50
-      ],
-      children: order
-    };
-    return replaceNode(root, targetStack, repl);
-  };
-  // perform a full move: remove dragged module, then drop beside target
-  const move = (root, module, targetStack, side) => {
-    const host = findHost(root, module);
-    if (!host)
-      return root;
-    // dragging a tab within its own stack: a lone tab has nowhere to go;
-    // a centre-drop onto its own stack is a no-op
-    if (host.stack === targetStack && (host.stack.tabs.length === 1 || side === 'center'))
-      return root;
-    const {
-      root: r2,
-      leaf
-    } = removeLeaf(root, module);
-    if (!leaf)
-      return root;
-    // the target stack object is mutated in place, so it survives removal unless it
-    // was the host and got emptied (guarded above); confirm it is still in the tree
-    if (!contains(r2, targetStack)) {
-      // target collapsed away: drop the leaf back into whatever remains as the root
-      return dropBeside(r2, r2, leaf, side);
-    }
-    return dropBeside(r2, targetStack, leaf, side);
-  };
-  return {
-    replaceNode,
-    normalize,
-    findHost,
-    contains,
-    removeLeaf,
-    dropBeside,
-    move
-  };
-};
-const _sx484g = function _lp2_dragOut(){return(
-(moduleName, dataTransfer) => {
-  const res = window.lopecode.contentSync(moduleName);
-  const text = res && res.bytes ? new TextDecoder().decode(res.bytes) : '';
-  const mime = res && res.mime || 'application/javascript';
-  const fname = moduleName.replace(/^@/, '').replace(/\//g, '_') + '.js';
-  dataTransfer.setData('text/plain', text);
-  dataTransfer.setData('application/javascript', text);
-  dataTransfer.setData('DownloadURL', mime + ':' + fname + ':data:' + mime + ';base64,' + btoa(unescape(encodeURIComponent(text))));
-  dataTransfer.effectAllowed = 'copy';
-  return {
-    fname,
-    len: text.length,
-    mime
-  };
-}
-)};
-const _1194mfy = function _lp2_view(lp2_host,lp2Model,lp2_installAnchor,lp2_anchor,$0,Event,lp2_getPane,lp2_dragOut,lp2_ops,linkTo,lp2_paneRegistry,lp2_renderNode,lp2_burger,lp2_add_module)
-{
-  const host = lp2_host;
-  lp2Model;
-  lp2_installAnchor;
-  lp2_anchor;
-  const vmEl = $0;
-  const commit = newRoot => {
-    vmEl.value = newRoot;
-    vmEl.dispatchEvent(new Event('input', { bubbles: true }));
-  };
-  const ctx = {
-    getPane: lp2_getPane,
-    dragOut: lp2_dragOut,
-    ops: lp2_ops,
-    commit,
-    getRoot: () => lp2Model,
-    linkTo
-  };
-  const rerender = () => {
-    const saved = new Map();
-    for (const [name, entry] of lp2_paneRegistry) {
-      lp2_installAnchor(entry);
-      const anc = lp2_anchor.capture(entry.el);
-      saved.set(name, anc || { raw: entry.el.scrollTop });
-    }
-    host.replaceChildren(lp2_renderNode(ctx)(lp2Model));
-    // dock immortal controls into the top-left tab bar; a rerender moves them so any
-    // open popover is anchored stale — close both before reparenting
-    lp2_burger.close();
-    lp2_add_module.close();
-    const firstTabs = host.querySelector('.lp2-tabs');
-    if (firstTabs) {
-      firstTabs.prepend(lp2_burger.button);
-      firstTabs.appendChild(lp2_add_module.button);
-    }
-    for (const [name, anc] of saved) {
-      const entry = lp2_paneRegistry.get(name);
-      if (!entry || !entry.el.isConnected)
-        continue;
-      if (entry.pendingDeepLink)
-        continue;
-      if (anc.pid) {
-        if (!lp2_anchor.restore(entry.el, anc) && anc.raw)
-          entry.el.scrollTop = anc.raw;
-      } else if (anc.raw)
-        entry.el.scrollTop = anc.raw;
-      entry.anchor = anc.pid ? anc : entry.anchor;
-    }
-  };
-  rerender();
-  return host;
-};
-const _1bytrbx = function _lp2_probe(lp2_view,lp2_paneRegistry)
-{
-  lp2_view;
-  return 'lp2 mounted, panes=' + lp2_paneRegistry.size;
-};
-const _orvfgz = function _lp2_doc_hash(md){return(
-md`### Hash ownership
-
-\`lp2_hash\` observes \`location.hash\`. \`lp2_syncFromUrl\` parses it into the model when it changes externally; \`lp2_syncToUrl\` serialises the model back. \`lp2_setHash\` writes via \`history.replaceState\`, which updates the URL without firing \`hashchange\`.
-
-\`view=\` is the layout (the \`R\`/\`S\`/\`C\` DSL) and is lopepage-2's to own. \`open=@mod[#cell]\` and \`close=@mod\` are one-shot intents: \`lp2_syncFromUrl\` overlays a module into the layout (setting a leaf's deep-link \`cell\` when \`#cell\` is given) or removes one — merging into the live layout when there is no \`view=\` — and \`lp2_syncToUrl\` drops the intent once the layout reflects it. The tab close \`×\` writes \`close=\` via \`linkTo\`, so closing exercises the same path.
-
-Invariants:
-
-- \`lp2_syncToUrl\` writes only when the model round-trips: \`serialize(parse(serialize(model))) === serialize(model)\`. A layout that does not round-trip never reaches the URL.
-- Writing is gated on \`window.__lp2_owns_hash\`, set only while lopepage-2 is the mounted page, so the URL is left untouched when the module is imported as a dependency.
-- Only \`view=\` and the intents it consumes (\`open\`) are managed; every other hash param (e.g. \`cc=\`) is preserved verbatim, because a decoupled module cannot assume it owns them.
-- Because \`replaceState\` is silent and the read path is driven by \`hashchange\`, a write does not re-trigger a read.`
-)};
-const _y2r8d1 = function _lp2_hash(Generators,location){return(
-Generators.observe(notify => {
-  const update = () => notify(location.hash);
-  update();
-  window.addEventListener('hashchange', update);
-  return () => window.removeEventListener('hashchange', update);
-})
-)};
-const _1cb1nyc = function _lp2_setHash(history,location){return(
-newHash => {
-    const h = newHash.startsWith('#') ? newHash : '#' + newHash;
-    // Bare relative fragment preserves path+search everywhere and, unlike
-    // location.pathname+search+h, does not throw on opaque origins (blob:
-    // forks), where that absolute form fails the same-origin check and drops
-    // every layout-to-URL update.
-    try {
-      history.replaceState(null, '', h);
-      return true;
-    } catch (e) {
-      try {
-        location.hash = h;
-        return true;
-      } catch (e2) {
-        return false;
-      }
-    }
-  }
-)};
-const _1vcr15c = function _lp2_syncFromUrl($0,lp2_hash,lp2_parseDSL,lp2_ops,lp2_serializeDSL,Event)
-{
-  const el = $0;
-  // element ref (NOT value) -> only re-runs on hash change, no loop
-  const hash = lp2_hash;
-  // re-run on external hashchange / initial load
-  let view = null, open = null, close = null;
-  for (const part of String(hash).replace(/^#/, '').split('&').filter(Boolean)) {
-    const eq = part.indexOf('=');
-    const key = eq >= 0 ? part.slice(0, eq) : part;
-    const val = eq >= 0 ? part.slice(eq + 1) : '';
-    if (key === 'view')
-      view = decodeURIComponent(val);
-    else if (key === 'open')
-      open = decodeURIComponent(val);
-    else if (key === 'close')
-      close = decodeURIComponent(val);  // every other param (cc=, and anything other modules own) is ignored here
-  }
-  if (!view && !open && !close)
-    return { status: 'skipped' };
-  // base model: parse view= when present, else clone the live layout so
-  // `open` / `close` apply to it rather than replacing it
-  let model;
-  try {
-    model = view ? lp2_parseDSL(view) : JSON.parse(JSON.stringify(el.value));
-  } catch (e) {
-    return {
-      status: 'error',
-      error: String(e)
-    };
-  }
-  // apply the one-shot open=@mod[#cell] intent
-  let openApplied = false;
-  if (open) {
-    const [modRaw, cellRaw] = open.split('#');
-    const module = (modRaw || '').trim();
-    const cell = (cellRaw || '').trim() || null;
-    if (module) {
-      const findLeaf = n => {
-        if (!n)
-          return null;
-        if (n.t === 'stack') {
-          for (const leaf of n.tabs || [])
-            if (leaf.module === module)
-              return {
-                stack: n,
-                leaf
-              };
-          return null;
-        }
-        for (const c of n.children || []) {
-          const f = findLeaf(c);
-          if (f)
-            return f;
-        }
-        return null;
-      };
-      const firstStack = n => {
-        if (!n)
-          return null;
-        if (n.t === 'stack')
-          return n;
-        for (const c of n.children || []) {
-          const f = firstStack(c);
-          if (f)
-            return f;
-        }
-        return null;
-      };
-      const found = findLeaf(model);
-      if (found) {
-        if (cell)
-          found.leaf.cell = cell;
-        found.stack.active = found.stack.tabs.indexOf(found.leaf);
-      } else {
-        let st = firstStack(model);
-        if (!st)
-          model = st = {
-            t: 'stack',
-            active: 0,
-            tabs: []
-          };
-        st.tabs = st.tabs || [];
-        st.tabs.push(cell ? {
-          module,
-          cell
-        } : { module });
-        st.active = st.tabs.length - 1;
-      }
-      openApplied = true;
-    }
-  }
-  // apply the one-shot close=@mod intent (remove the leaf, collapse via normalize)
-  let closeApplied = false;
-  if (close) {
-    const r = lp2_ops.removeLeaf(model, close);
-    if (r.leaf) {
-      model = r.root;
-      closeApplied = true;
-    }
-  }
-  const reser = lp2_serializeDSL(model);
-  // republish when the layout changed, or when open set active/cell on an
-  // already-present module (active is not serialized, so compare by intent)
-  const applied = openApplied || closeApplied || reser !== lp2_serializeDSL(el.value);
-  if (applied) {
-    el.value = model;
-    el.dispatchEvent(new Event('input'));
-  }
-  return {
-    status: 'ok',
-    view,
-    open,
-    close,
-    openApplied,
-    closeApplied,
-    reser,
-    applied
-  };
-};
-const _1rf2mk0 = function _lp2_syncToUrl(lp2Model,lp2_serializeDSL,lp2_parseDSL,location,lp2_setHash)
-{
-  const model = lp2Model;
-  // re-run on model change
-  if (!window.__lp2_owns_hash)
-    return { status: 'dormant' };
-  // armed only when lopepage-2 is the page
-  let dsl;
-  try {
-    dsl = lp2_serializeDSL(model);
-  } catch (e) {
-    return {
-      status: 'serialize-failed',
-      error: String(e)
-    };
-  }
-  // loop protection: only write if the DSL round-trips stably
-  let ok = false;
-  try {
-    ok = lp2_serializeDSL(lp2_parseDSL(dsl)) === dsl;
-  } catch (e) {
-    ok = false;
-  }
-  if (!ok)
-    return {
-      status: 'blocked-roundtrip',
-      dsl
-    };
-  // preserve unknown params (cc=...), strip one-shot intents
-  const raw = String(location.hash || '').replace(/^#/, '');
-  const intents = new Set([
-    'open',
-    'close',
-    'focus',
-    'from'
-  ]);
-  const extra = [];
-  let currentView = null;
-  for (const part of raw.split('&').filter(Boolean)) {
-    const eq = part.indexOf('=');
-    const key = eq >= 0 ? part.slice(0, eq) : part;
-    if (key === 'view')
-      currentView = decodeURIComponent(part.slice(eq + 1));
-    else if (!intents.has(key))
-      extra.push(part);
-  }
-  const newHash = '#view=' + dsl + (extra.length ? '&' + extra.join('&') : '');
-  if (newHash !== location.hash) {
-    lp2_setHash(newHash);
-    return {
-      status: 'written',
-      dsl
-    };
-  }
-  return {
-    status: 'no-change',
-    dsl
-  };
-};
-const _6e8yep = function _lp2_doc_mount(md){return(
-md`### Page mount, theme, and orthogonal features
-
-\`lp2_page\` builds the fullscreen \`#lopepage-2\` container, adopts the [\`themes\`](https://observablehq.com/@tomlarkworthy/themes) stylesheets via \`apply_theme\`, and appends the [\`command-palette\`](https://observablehq.com/@tomlarkworthy/command-palette) chrome (\`commandPaletteStyles\` + the hidden \`commandPaletteOverlay\`) so ⌘K has a node to reveal.
-
-\`lp2_background_jobs\` holds references to the main-loop cells of orthogonal feature modules so the runtime instantiates them while lopepage-2 is the page: \`commandPaletteKeybinding\` (installs the ⌘K listener), \`cc_chat\` (opens the [\`claude-code-pairing\`](https://observablehq.com/@tomlarkworthy/claude-code-pairing) connection), \`change_listener\`/\`commit_history\`/\`replay_git\` (the [\`local-change-history\`](https://observablehq.com/@tomlarkworthy/local-change-history) edit recorder/replayer), and \`auto_attach\` (the [\`editor-5\`](https://observablehq.com/@tomlarkworthy/editor-5) editor that attaches CodeMirror to rendered cells for inline editing). These modules are composed by import, not added to \`mains\`.
-
-\`lp2_append_to_body\` is the keystone cell: reachable only when lopepage-2 is booted as a main, it appends the page to \`document.body\`, references \`lp2_background_jobs\`, and sets \`window.__lp2_owns_hash\`. With \`bootconf.headless\` set, the runtime observes this cell as the page's single output.`
-)};
-const _1y1ubko = function _lp2_page(apply_theme,lp2_host,commandPaletteStyles,commandPaletteOverlay)
-{
-  apply_theme;
-  // adopt theme stylesheets into the document
-  const root = document.createElement('div');
-  root.id = 'lopepage-2';
-  Object.assign(root.style, {
-    position: 'fixed',
-    inset: '0',
-    height: '100vh',
-    width: '100vw',
-    overflow: 'hidden',
-    background: 'var(--theme-background-a, #fff)'
-  });
-  const style = document.createElement('style');
-  style.textContent = [
-    'html,body{margin:0;padding:0;max-width:100vw;}',
-    '#lopepage-2 .lope-viz .observablehq{position:relative;min-height:17px;}',
-    '#lopepage-2 .lope-viz .observablehq:not(.observablehq--running):empty::after{content:\'<detached>\';font-style:oblique;opacity:.5;}',
-    '#lopepage-2 .lp2-tabs button:hover{background:rgba(0,0,0,.06);}',
-    '#lopepage-2 .lp2-splitter:hover{background:#bbb;}'
-  ].join('\n');
-  root.appendChild(style);
-  root.appendChild(lp2_host);
-  // command-palette chrome: a <style> and a fixed overlay, hidden until ⌘K
-  root.appendChild(commandPaletteStyles);
-  root.appendChild(commandPaletteOverlay);
-  return root;
-};
-const _9clfn3 = function _lp2_background_jobs(commandPaletteKeybinding,cc_chat,change_listener,commit_history,replay_git,auto_attach,lp2_watchModules,lp2_menu_sync,lp2_menu_defaults,lp2_menu_clear_history)
-{
-  // hold references so these orthogonal features' main-loop cells instantiate
-  commandPaletteKeybinding;
-  // installs the ⌘K keydown listener
-  cc_chat;
-  // instantiates the pairing connection
-  change_listener;
-  // records cell edits into local-change-history
-  commit_history;
-  // commits runtime edit history
-  replay_git;
-  // replays git commits on load
-  auto_attach;
-  // attaches editor-5 CodeMirror editors to rendered cells
-  lp2_watchModules;
-  // keeps the layout-relevant module watcher running
-  lp2_menu_sync;
-  // keeps the burger menu populated from the plugin registry
-  lp2_menu_defaults;
-  // registers the built-in menu items (download, fork)
-  lp2_menu_clear_history;
-  // registers the per-notebook history wipe menu item
-  return 'background jobs: command-palette, claude-code-pairing, local-change-history, editor-5, module-watcher, burger-menu';
-};
-const _1yumqn = function _lp2_append_to_body(lp2_view,lp2_syncFromUrl,lp2_syncToUrl,lp2_page)
-{
-  lp2_view;
-  // ensure the layout renders into the host
-  lp2_syncFromUrl;
-  // keep hash -> model live
-  lp2_syncToUrl;
-  // keep model -> hash live (dormant until armed below)
-  // background jobs (⌘K palette, pairing, history) run under their own observer;
-  // not a dep so their failure (e.g. no IndexedDB in a blob: fork tab) cannot block mount
-  window.__lp2_owns_hash = true;
-  // arm hash ownership; only reachable when lopepage-2 is the page
-  const page = lp2_page;
-  if (!page.isConnected)
-    document.body.appendChild(page);
-  return 'lopepage-2 mounted';
-};
-const _z83rug = function _29(currentModules){return(
-currentModules
-)};
-const _1s8yfis = function _lp2_renderTab(location){return(
-(node, i, ctx) => {
-    const leaf = node.tabs[i];
-    const active = node.active || 0;
-    const tab = document.createElement('button');
-    tab.textContent = leaf.module.split('/').pop();
-    tab.title = leaf.module + '  (drag to a pane edge to dock, or out to save as .js)';
-    Object.assign(tab.style, {
-      border: 'none',
-      padding: '4px 8px',
-      cursor: 'grab',
-      fontSize: '11px',
-      background: i === active ? 'var(--theme-background-a)' : 'transparent',
-      color: i === active ? 'var(--theme-foreground)' : 'var(--theme-foreground-faint)'
-    });
-    tab.onclick = () => {
-      node.active = i;
-      ctx.commit(ctx.getRoot());
-    };
-    tab.draggable = true;
-    tab.addEventListener('dragstart', ev => {
-      window.__lp2_drag = { module: leaf.module };
-      try {
-        ev.dataTransfer.setData('application/x-lp2-leaf', leaf.module);
-      } catch (_) {
-      }
-      try {
-        ctx.dragOut(leaf.module, ev.dataTransfer);
-      } catch (_) {
-      }
-    });
-    tab.addEventListener('dragend', () => {
-      window.__lp2_drag = null;
-      if (window.__lp2_dropZone) {
-        window.__lp2_dropZone.style.display = 'none';
-        window.__lp2_dropZone = null;
-      }
-    });
-    const close = document.createElement('span');
-    close.textContent = '\xD7';
-    close.title = 'Close';
-    Object.assign(close.style, {
-      marginLeft: '6px',
-      opacity: '.45',
-      fontWeight: '700',
-      cursor: 'pointer'
-    });
-    close.onmouseenter = () => close.style.opacity = '1';
-    close.onmouseleave = () => close.style.opacity = '.45';
-    // don't let a grab on × start a tab drag or activate the tab
-    close.addEventListener('mousedown', ev => ev.stopPropagation());
-    close.addEventListener('click', ev => {
-      ev.stopPropagation();
-      // route through the URL intent system: close=<module>. Write via the
-      // History API + a synthetic hashchange rather than `location.hash =`,
-      // which is a silent no-op in blob: forks (fragment navigation is dropped
-      // on the opaque origin); pushState/replaceState still work there.
-      const target = ctx.linkTo({ close: leaf.module }, { baseURI: location.href });
-      window.history.pushState(null, '', target);
-      window.dispatchEvent(new window.HashChangeEvent('hashchange'));
-    });
-    tab.appendChild(close);
-    return tab;
-  }
-)};
-const _13y25bb = function _lp2_dropZone(){return(
-(body, tabsEl, node, ctx) => {
-    // which edge/centre of `el` the pointer is over: centre = merge, edge = split that side
-    const sideOf = (ev, el) => {
-      const r = el.getBoundingClientRect();
-      const x = (ev.clientX - r.left) / r.width, y = (ev.clientY - r.top) / r.height;
-      if (x > 0.3 && x < 0.7 && y > 0.3 && y < 0.7)
-        return 'center';
-      const d = {
-        left: x,
-        right: 1 - x,
-        top: y,
-        bottom: 1 - y
-      };
-      return Object.keys(d).reduce((a, b) => d[b] < d[a] ? b : a);
-    };
-    const zone = document.createElement('div');
-    Object.assign(zone.style, {
-      position: 'absolute',
-      pointerEvents: 'none',
-      display: 'none',
-      background: 'rgba(40,120,255,.18)',
-      outline: '2px solid rgba(40,120,255,.6)',
-      outlineOffset: '-2px',
-      zIndex: 5,
-      boxSizing: 'border-box'
-    });
-    body.appendChild(zone);
-    const showZone = side => {
-      const f = {
-        left: [
-          '0',
-          '0',
-          '50%',
-          '100%'
-        ],
-        right: [
-          '50%',
-          '0',
-          '50%',
-          '100%'
-        ],
-        top: [
-          '0',
-          '0',
-          '100%',
-          '50%'
-        ],
-        bottom: [
-          '0',
-          '50%',
-          '100%',
-          '50%'
-        ],
-        center: [
-          '15%',
-          '15%',
-          '70%',
-          '70%'
-        ]
-      }[side];
-      Object.assign(zone.style, {
-        display: 'block',
-        left: f[0],
-        top: f[1],
-        width: f[2],
-        height: f[3]
-      });
-    };
-    body.addEventListener('dragover', ev => {
-      if (!window.__lp2_drag)
-        return;
-      ev.preventDefault();
-      try {
-        ev.dataTransfer.dropEffect = 'copy';
-      } catch (_) {
-      }
-      // only one zone visible: hide whichever was last shown elsewhere
-      if (window.__lp2_dropZone && window.__lp2_dropZone !== zone)
-        window.__lp2_dropZone.style.display = 'none';
-      window.__lp2_dropZone = zone;
-      showZone(sideOf(ev, body));
-    });
-    body.addEventListener('dragleave', ev => {
-      // ignore moves between this body's own descendants
-      if (ev.relatedTarget && body.contains(ev.relatedTarget))
-        return;
-      zone.style.display = 'none';
-      if (window.__lp2_dropZone === zone)
-        window.__lp2_dropZone = null;
-    });
-    body.addEventListener('drop', ev => {
-      if (!window.__lp2_drag)
-        return;
-      ev.preventDefault();
-      const side = sideOf(ev, body);
-      zone.style.display = 'none';
-      window.__lp2_dropZone = null;
-      const m = window.__lp2_drag.module;
-      window.__lp2_drag = null;
-      ctx.commit(ctx.ops.move(ctx.getRoot(), m, node, side));
-    });
-    // the tab header is also a drop target: dropping a tab onto it merges into this
-    // stack (the natural "combine into tabs" gesture); always a centre merge.
-    if (tabsEl) {
-      tabsEl.addEventListener('dragover', ev => {
-        if (!window.__lp2_drag)
-          return;
-        ev.preventDefault();
-        try {
-          ev.dataTransfer.dropEffect = 'copy';
-        } catch (_) {
-        }
-        if (window.__lp2_dropZone && window.__lp2_dropZone !== zone)
-          window.__lp2_dropZone.style.display = 'none';
-        window.__lp2_dropZone = zone;
-        showZone('center');
-      });
-      tabsEl.addEventListener('dragleave', ev => {
-        if (ev.relatedTarget && (tabsEl.contains(ev.relatedTarget) || body.contains(ev.relatedTarget)))
-          return;
-        zone.style.display = 'none';
-        if (window.__lp2_dropZone === zone)
-          window.__lp2_dropZone = null;
-      });
-      tabsEl.addEventListener('drop', ev => {
-        if (!window.__lp2_drag)
-          return;
-        ev.preventDefault();
-        zone.style.display = 'none';
-        window.__lp2_dropZone = null;
-        const m = window.__lp2_drag.module;
-        window.__lp2_drag = null;
-        ctx.commit(ctx.ops.move(ctx.getRoot(), m, node, 'center'));
-      });
-    }
-    return zone;
-  }
-)};
-const _b408jx = function _lp2_splitter(){return(
-(node, i, row, wrap, slots, ctx) => {
-    const sp = document.createElement('div');
-    sp.className = 'lp2-splitter';
-    Object.assign(sp.style, {
-      flex: '0 0 6px',
-      cursor: row ? 'col-resize' : 'row-resize',
-      background: '#ddd',
-      flexShrink: 0
-    });
-    sp.addEventListener('pointerdown', e => {
-      e.preventDefault();
-      try {
-        sp.setPointerCapture(e.pointerId);
-      } catch (_) {
-      }
-      const startPos = row ? e.clientX : e.clientY;
-      const wrapSize = row ? wrap.clientWidth : wrap.clientHeight;
-      const s0 = node.sizes[i], s1 = node.sizes[i + 1], total = s0 + s1;
-      const onMove = ev => {
-        const delta = ((row ? ev.clientX : ev.clientY) - startPos) / wrapSize * 100;
-        // integer percentages so the layout round-trips through the integer-only #view= DSL
-        const n0 = Math.round(Math.max(5, Math.min(total - 5, s0 + delta)));
-        node.sizes[i] = n0;
-        node.sizes[i + 1] = total - n0;
-        slots[i].style.flex = node.sizes[i] + ' 1 0';
-        slots[i + 1].style.flex = node.sizes[i + 1] + ' 1 0';
-      };
-      const onUp = () => {
-        document.removeEventListener('pointermove', onMove);
-        document.removeEventListener('pointerup', onUp);
-        ctx.commit(ctx.getRoot());
-      };
-      document.addEventListener('pointermove', onMove);
-      document.addEventListener('pointerup', onUp);
-    });
-    return sp;
-  }
-)};
-const _nj1uts = function _lp2_renderStack(lp2_renderTab,lp2_dropZone){return(
-(node, ctx) => {
-  const wrap = document.createElement('div');
-  wrap.className = 'lp2-stack';
-  Object.assign(wrap.style, {
-    display: 'flex',
-    flexDirection: 'column',
-    minWidth: 0,
-    minHeight: 0,
-    height: '100%',
-    width: '100%'
-  });
-  const tabsEl = document.createElement('div');
-  tabsEl.className = 'lp2-tabs';
-  Object.assign(tabsEl.style, {
-    display: 'flex',
-    gap: '2px',
-    flex: '0 0 auto',
-    background: 'var(--theme-background-b)',
-    borderBottom: '1px solid var(--theme-foreground-fainter)',
-    overflow: 'hidden'
-  });
-  const body = document.createElement('div');
-  Object.assign(body.style, {
-    flex: '1 1 auto',
-    minHeight: 0,
-    position: 'relative',
-    display: 'flex'
-  });
-  const active = node.active || 0;
-  (node.tabs || []).forEach((leaf, i) => {
-    const pane = ctx.getPane(leaf.module, leaf.cell).el;
-    pane.style.display = i === active ? 'block' : 'none';
-    pane.style.flex = '1 1 auto';
-    body.appendChild(pane);
-    tabsEl.appendChild(lp2_renderTab(node, i, ctx));
-  });
-  lp2_dropZone(body, tabsEl, node, ctx);
-  wrap.append(tabsEl, body);
-  return wrap;
-}
-)};
-const _a9rn1a = function _lp2_renderSplit(lp2_splitter){return(
-(node, ctx, make) => {
-  const row = node.t === 'row';
-  const wrap = document.createElement('div');
-  Object.assign(wrap.style, {
-    display: 'flex',
-    flexDirection: row ? 'row' : 'column',
-    minWidth: 0,
-    minHeight: 0,
-    height: '100%',
-    width: '100%'
-  });
-  const kids = node.children || [];
-  if (!node.sizes || node.sizes.length !== kids.length)
-    node.sizes = kids.map(() => Math.round(100 / kids.length));
-  const slots = [];
-  kids.forEach((child, i) => {
-    const slot = document.createElement('div');
-    Object.assign(slot.style, {
-      flex: node.sizes[i] + ' 1 0',
-      minWidth: 0,
-      minHeight: 0,
-      display: 'flex',
-      overflow: 'hidden'
-    });
-    slot.appendChild(make(child));
-    wrap.appendChild(slot);
-    slots.push(slot);
-    if (i < kids.length - 1)
-      wrap.appendChild(lp2_splitter(node, i, row, wrap, slots, ctx));
-  });
-  return wrap;
-}
-)};
-const _6vp46e = function _lp2_watchedModules(Inputs){return(
-Inputs.input(new Map())
-)};
-const _1hxhexc = (G, _) => G.input(_);
-const _16ptruj = function _lp2_watchModules(lp2Model,currentModules,$0,Event)
-{
-  // Collect the module names the current layout actually references.
-  const names = new Set();
-  const walk = n => {
-    if (!n)
-      return;
-    if (n.t === 'stack')
-      (n.tabs || []).forEach(leaf => leaf?.module && names.add(leaf.module));
-    else
-      (n.children || []).forEach(walk);
-  };
-  walk(lp2Model);
-  // Resolve those names against the (churning) currentModules map.
-  const byName = new Map();
-  for (const [mod, info] of currentModules)
-    if (info?.name)
-      byName.set(info.name, info.module ?? mod);
-  const next = new Map();
-  for (const name of names) {
-    const m = byName.get(name);
-    if (m)
-      next.set(name, m);
-  }
-  // Only republish when the relevant resolved set actually changed — this is what
-  // decouples the repaint from raw currentModules churn.
-  const prev = $0.value;
-  let changed = !(prev instanceof Map) || prev.size !== next.size;
-  if (!changed)
-    for (const [k, v] of next)
-      if (prev.get(k) !== v) {
-        changed = true;
-        break;
-      }
-  if (changed) {
-    $0.value = next;
-    $0.dispatchEvent(new Event('input', { bubbles: true }));
-  }
-  return `watch ${ names.size } / resolved ${ next.size }${ changed ? ' (updated)' : '' }`;
-};
-const _322aeb = function _lp2_scrollToCell(lp2_anchor){return(
-(entry, cellName) => {
-    // One-shot deep-link: scroll the pane so `cellName` (a variable name, e.g. from @mod#cell) sits at
-    // the top, then seed the pane's pid anchor so the ResizeObserver re-pins it through later reflow.
-    // Right after a reparent the immortal pane's content is momentarily short, which clamps scrollTop
-    // back to 0, so retry until the scroll lands — or until content height settles (target is genuinely
-    // past the last full page, so we can only scroll as far as it goes).
-    if (!cellName || !entry || entry.transient)
-      return;
-    // Own the pane scroll until the deep-link lands, so a concurrent rerender's scroll-restore
-    // (which captured the pre-deep-link scrollTop) does not clobber it. Cleared on land or give-up.
-    entry.pendingDeepLink = true;
-    const done = () => entry.pendingDeepLink = false;
-    let tries = 0, lastSH = -1, stable = 0;
-    const attempt = () => {
-      const el = entry.el;
-      const again = () => {
-        if (tries++ < 60)
-          window.setTimeout(attempt, 80);
-        else
-          done();
-      };
-      if (!el || !el.isConnected || !el.clientHeight)
-        return again();
-      const node = lp2_anchor.cellNodes(el).find(n => n.getAttribute('cell') === cellName);
-      if (!node)
-        return again();
-      const targetTop = node.offsetTop;
-      el.__lp2_pinning = true;
-      el.scrollTop = targetTop;
-      const pid = lp2_anchor.pidOf(node);
-      if (pid)
-        entry.anchor = {
-          pid,
-          offset: 0
-        };
-      window.requestAnimationFrame(() => {
-        el.__lp2_pinning = false;
-      });
-      if (Math.abs(el.scrollTop - targetTop) <= 2)
-        return done();
-      if (el.scrollHeight === lastSH) {
-        if (++stable >= 3)
-          return done();
-      } else {
-        stable = 0;
-        lastSH = el.scrollHeight;
-      }
-      return again();
-    };
-    // Defer so the first attempt runs AFTER this rerender's synchronous scroll-restore and after
-    // getPane reparents the (immortal) pane; pendingDeepLink stays true across that window so the
-    // restore skips this pane, then the deferred attempt scrolls the now-settled pane to the cell.
-    window.setTimeout(attempt, 0);
-  }
-)};
-const _13649ph = function _lp2_doc_menu(md){return(
-md`### Burger menu (plugin registry)
-
-A hamburger button docked at the left of the top-left tab bar opens a menu of pluggable items. The registry is the [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) set named \`"lp2-menu"\`; \`lp2MenuItems\` is \`plugins.get("lp2-menu")\`, a reactive array of \`{id, label, svg, action, children, order}\`. \`svg\` is an SVG string, an \`Element\`, or a function returning one; \`children\` nests a submenu; lower \`order\` sorts first.
-
-Plugins (this module's defaults, or any other notebook) register through \`lp2_registerMenuItem(item)\` — an id-keyed wrapper over \`plugins.add("lp2-menu", item)\` that replaces by \`id\` and returns a disposer (call it from \`invalidation\` so a re-run replaces rather than duplicates). Any notebook can equally \`plugins.add("lp2-menu", item)\` directly without importing lopepage-2. Only \`lp2_menu_sync\` consumes \`lp2MenuItems\`, so adding an item repopulates the popover in place — the layout, panes, and scroll state are untouched.
-
-The button and popover are built once by \`lp2_burger\` (immortal, like panes) and reparented into the current top-left tab bar on each layout render. \`lp2_menu_defaults\` registers the built-ins: **Download** and **Fork** via [\`exporter-3\`](https://observablehq.com/@tomlarkworthy/exporter-3)'s \`downloadAnchor\`/\`forkAnchor\`, which serialise every booted main. \`lp2_menu_clear_history\` registers **Clear local history…**: it deletes only the current file's branch in the shared [\`local-change-history\`](https://observablehq.com/@tomlarkworthy/local-change-history) repo (other notebooks' branches are untouched) and reloads, so the notebook reboots from the file on disk.`
-)};
-const _1uvdt3f = function _lp2MenuItems(plugins){return(
-plugins.get('lp2-menu')
-)};
-const _qcv0dp = function _lp2_registerMenuItem(plugins)
-{
-  // id-keyed adapter over the shared plugins bus (set name "lp2-menu"): re-registering an id replaces
-  // the prior value; the returned disposer removes only if this exact registration is still current.
-  const handles = new Map();
-  // id -> remove()
-  return item => {
-    if (!item || !item.id)
-      throw new Error('menu item needs an id');
-    const prev = handles.get(item.id);
-    if (prev)
-      prev();
-    // replace-by-id
-    const remove = plugins.add('lp2-menu', item);
-    handles.set(item.id, remove);
-    return () => {
-      if (handles.get(item.id) === remove) {
-        remove();
-        handles.delete(item.id);
-      }
-    };
-  };
-};
-const _bt1fe2 = function _lp2_burger(invalidation)
-{
-  const button = document.createElement('button');
-  button.className = 'lp2-burger';
-  button.title = 'Menu';
-  button.setAttribute('aria-haspopup', 'true');
-  button.setAttribute('aria-expanded', 'false');
-  button.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M2 4h12M2 8h12M2 12h12"/></svg>';
-  Object.assign(button.style, {
-    border: 'none',
-    background: 'transparent',
-    padding: '4px 8px',
-    cursor: 'pointer',
-    color: 'var(--theme-foreground)',
-    display: 'inline-flex',
-    alignItems: 'center'
-  });
-  const popover = document.createElement('div');
-  popover.className = 'lp2-menu';
-  Object.assign(popover.style, {
-    position: 'fixed',
-    display: 'none',
-    zIndex: 1000,
-    minWidth: '190px',
-    background: 'var(--theme-background-a, #fff)',
-    color: 'var(--theme-foreground)',
-    border: '1px solid var(--theme-foreground-fainter)',
-    borderRadius: '4px',
-    boxShadow: '0 4px 16px rgba(0,0,0,.18)',
-    padding: '4px',
-    font: '12px var(--sans-serif, sans-serif)'
-  });
-  const style = document.createElement('style');
-  style.textContent = [
-    '.lp2-menu button.lp2-menu-item{display:flex;align-items:center;gap:8px;width:100%;text-align:left;background:transparent;border:none;cursor:pointer;padding:6px 10px;font:inherit;color:inherit;border-radius:3px;}',
-    '.lp2-menu button.lp2-menu-item:hover{background:rgba(128,128,128,.15);}'
-  ].join('\n');
-  popover.appendChild(style);
-  const list = document.createElement('div');
-  popover.appendChild(list);
-  document.body.appendChild(popover);
-  const close = () => {
-    popover.style.display = 'none';
-    button.setAttribute('aria-expanded', 'false');
-  };
-  const open = () => {
-    const r = button.getBoundingClientRect();
-    popover.style.left = Math.round(r.left) + 'px';
-    popover.style.top = Math.round(r.bottom + 2) + 'px';
-    popover.style.display = 'block';
-    button.setAttribute('aria-expanded', 'true');
-  };
-  button.addEventListener('click', ev => {
-    ev.stopPropagation();
-    popover.style.display === 'none' ? open() : close();
-  });
-  // a click that lands outside the popover/button dismisses; so does Escape
-  const onDocDown = ev => {
-    if (popover.style.display === 'none')
-      return;
-    if (popover.contains(ev.target) || button.contains(ev.target))
-      return;
-    close();
-  };
-  const onKey = ev => {
-    if (ev.key === 'Escape')
-      close();
-  };
-  document.addEventListener('mousedown', onDocDown);
-  document.addEventListener('keydown', onKey);
-  invalidation.then(() => {
-    document.removeEventListener('mousedown', onDocDown);
-    document.removeEventListener('keydown', onKey);
-    popover.remove();
-    button.remove();
-  });
-  return {
-    button,
-    popover,
-    list,
-    open,
-    close
-  };
-};
-const _1gv42y9 = function _lp2_menu_sync(lp2_burger,Element,lp2MenuItems)
-{
-  const {list, close} = lp2_burger;
-  const bySort = arr => [...arr || []].sort((a, b) => (a.order ?? 100) - (b.order ?? 100) || String(a.label ?? a.id).localeCompare(String(b.label ?? b.id)));
-  const icon = svg => {
-    const span = document.createElement('span');
-    Object.assign(span.style, {
-      width: '16px',
-      height: '16px',
-      flex: '0 0 16px',
-      display: 'inline-flex',
-      alignItems: 'center',
-      justifyContent: 'center'
-    });
-    let node = typeof svg === 'function' ? svg() : svg;
-    if (typeof node === 'string') {
-      const t = document.createElement('template');
-      t.innerHTML = node.trim();
-      node = t.content.firstElementChild;
-    }
-    if (node instanceof Element) {
-      node = node.cloneNode(true);
-      node.setAttribute('width', '16');
-      node.setAttribute('height', '16');
-      span.appendChild(node);
-    }
-    return span;
-  };
-  let count = 0;
-  const addItems = (arr, depth, container) => {
-    for (const item of bySort(arr)) {
-      count++;
-      if (item.element) {
-        // full-HTML item: the plugin owns its DOM, state and events; we only place it.
-        // pass a live node to keep state across menu rebuilds (reparented, not recreated).
-        const el = typeof item.element === 'function' ? item.element() : item.element;
-        if (el) {
-          el.style.paddingLeft = 10 + depth * 16 + 'px';
-          container.appendChild(el);
-        }
-        continue;
-      }
-      const btn = document.createElement('button');
-      btn.className = 'lp2-menu-item';
-      btn.style.paddingLeft = 10 + depth * 16 + 'px';
-      btn.appendChild(icon(item.svg));
-      const lbl = document.createElement('span');
-      lbl.textContent = item.label ?? item.id;
-      lbl.style.flex = '1 1 auto';
-      btn.appendChild(lbl);
-      container.appendChild(btn);
-      if (item.children && item.children.length) {
-        const caret = document.createElement('span');
-        caret.textContent = '\u25B8';
-        caret.style.opacity = '.6';
-        btn.appendChild(caret);
-        const sub = document.createElement('div');
-        sub.style.display = 'none';
-        container.appendChild(sub);
-        addItems(item.children, depth + 1, sub);
-        btn.addEventListener('click', ev => {
-          ev.stopPropagation();
-          const opening = sub.style.display === 'none';
-          sub.style.display = opening ? 'block' : 'none';
-          caret.textContent = opening ? '\u25BE' : '\u25B8';
-        });
-      } else
-        btn.addEventListener('click', ev => {
-          ev.stopPropagation();
-          close();
-          try {
-            item.action && item.action();
-          } catch (err) {
-            console.error('lp2 menu item', item.id, err);
-          }
-        });
-    }
-  };
-  list.replaceChildren();
-  addItems(lp2MenuItems, 0, list);
-  if (!count) {
-    const empty = document.createElement('div');
-    empty.textContent = 'no menu items';
-    Object.assign(empty.style, {
-      padding: '6px 10px',
-      color: 'var(--theme-foreground-faint)'
-    });
-    list.appendChild(empty);
-  }
-  return `menu: ${ count } item${ count === 1 ? '' : 's' }`;
-};
-const _1vx778a = function _lp2_menu_defaults($0,lp2_registerMenuItem,disk_svg,downloadAnchor,forkAnchor,Event,invalidation)
-{
-  const $attachToggle = $0;
-  // viewof attachContextManu (editor-5): drives inline-editor attach/detach
-  // built-in items, registered through the same plugin path any other notebook uses;
-  // the anchors carry exporter-3's export behaviour, so acting = clicking a fresh one
-  const disposers = [
-    lp2_registerMenuItem({
-      id: 'download',
-      order: 10,
-      label: 'Download',
-      svg: () => disk_svg('currentColor'),
-      action: () => downloadAnchor({}, 'download').click()
-    }),
-    lp2_registerMenuItem({
-      id: 'fork',
-      order: 20,
-      label: 'Fork (new tab)',
-      svg: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="4" cy="3.5" r="1.8"/><circle cx="12" cy="3.5" r="1.8"/><circle cx="8" cy="12.5" r="1.8"/><path d="M4 5.3v1.2a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V5.3M8 8.5v2.2"/></svg>',
-      action: () => forkAnchor({}, 'fork').click()
-    })
-  ];
-  // Edit-mode toggle: a full-HTML menu item (the `element` contract). It drives
-  // editor-5's `attachContextManu` view directly — off detaches all inline editors
-  // for a clean reading view. The node is immortal and owns its own state, so
-  // toggling never re-registers and the menu never rebuilds/reorders.
-  const row = document.createElement('label');
-  row.className = 'lp2-menu-item';
-  Object.assign(row.style, {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    width: '100%',
-    padding: '6px 10px',
-    borderRadius: '3px',
-    cursor: 'pointer',
-    font: 'inherit'
-  });
-  row.addEventListener('mouseenter', () => row.style.background = 'rgba(128,128,128,.15)');
-  row.addEventListener('mouseleave', () => row.style.background = 'transparent');
-  const box = document.createElement('input');
-  box.type = 'checkbox';
-  box.checked = !!$attachToggle.value;
-  Object.assign(box.style, {
-    flex: '0 0 16px',
-    margin: '0',
-    cursor: 'pointer'
-  });
-  const lbl = document.createElement('span');
-  lbl.textContent = 'Edit mode';
-  lbl.style.flex = '1 1 auto';
-  row.append(box, lbl);
-  const set = on => {
-    if (!!$attachToggle.value === on)
-      return;
-    $attachToggle.value = on;
-    $attachToggle.dispatchEvent(new Event('input', { bubbles: true }));
-  };
-  box.addEventListener('change', () => set(box.checked));
-  const onExt = () => {
-    box.checked = !!$attachToggle.value;
-  };
-  // reflect external changes in place
-  $attachToggle.addEventListener('input', onExt);
-  disposers.push(lp2_registerMenuItem({
-    id: 'edit-mode',
-    order: 15,
-    element: row
-  }));
-  invalidation.then(() => {
-    $attachToggle.removeEventListener('input', onExt);
-    disposers.forEach(d => d());
-  });
-  return 'menu defaults: download, edit-mode, fork';
-};
-const _1mz2n05 = function _lp2_menu_clear_history(lp2_registerMenuItem,lch_git,lch_fs,lch_config,invalidation)
-{
-  // wipes only THIS file's branch in the shared change-history repo (other
-  // notebooks' branches are untouched), then reboots from the file on disk
-  const dispose = lp2_registerMenuItem({
-    id: 'clear-history',
-    order: 90,
-    label: 'Clear local history…',
-    svg: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 4h10M6.5 4V2.5h3V4M4.5 4l.7 9a1.5 1.5 0 0 0 1.4 1.5h2.8a1.5 1.5 0 0 0 1.4-1.5l.7-9M6.7 7v4.5M9.3 7v4.5"/></svg>',
-    action: async () => {
-      if (!window.confirm('Clear this notebook\'s local change history and reload from disk? Unsaved edits are lost.'))
-        return;
-      try {
-        await lch_git.deleteBranch({ fs: lch_fs, dir: lch_config.repo, ref: lch_config.branch });
-      } catch (err) {
-        console.warn('clear history: branch delete failed (may not exist)', err);
-      }
-      window.location.reload();
-    }
-  });
-  invalidation.then(dispose);
-  return 'menu: clear-history';
-};
-const _1af1qr1 = function _lp2_add_module(createModule,runtime,realize,location,linkTo,invalidation)
-{
-  const button = document.createElement('button');
-  button.className = 'lp2-add-module';
-  button.title = 'Create module';
-  button.setAttribute('aria-haspopup', 'true');
-  button.setAttribute('aria-expanded', 'false');
-  button.textContent = '+';
-  Object.assign(button.style, {
-    border: 'none',
-    background: 'transparent',
-    padding: '4px 10px',
-    cursor: 'pointer',
-    color: 'var(--theme-foreground)',
-    font: '15px var(--sans-serif, sans-serif)',
-    lineHeight: '1'
-  });
-  const popover = document.createElement('div');
-  popover.className = 'lp2-menu';
-  Object.assign(popover.style, {
-    position: 'fixed',
-    display: 'none',
-    zIndex: 1000,
-    background: 'var(--theme-background-a, #fff)',
-    color: 'var(--theme-foreground)',
-    border: '1px solid var(--theme-foreground-fainter)',
-    borderRadius: '4px',
-    boxShadow: '0 4px 16px rgba(0,0,0,.18)',
-    padding: '8px',
-    font: '12px var(--sans-serif, sans-serif)'
-  });
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.placeholder = '@user/module-name';
-  input.title = 'Enter a module name and press \u21B5 to create';
-  input.spellcheck = false;
-  Object.assign(input.style, {
-    padding: '4px 8px',
-    border: '1px solid var(--theme-foreground-fainter)',
-    borderRadius: '3px',
-    font: '12px var(--monospace, monospace)',
-    width: '210px',
-    outline: 'none',
-    boxSizing: 'border-box',
-    background: 'var(--theme-background, #fff)',
-    color: 'var(--theme-foreground)'
-  });
-  const hint = document.createElement('div');
-  hint.textContent = '\u21B5 create \xB7 esc cancel';
-  Object.assign(hint.style, {
-    marginTop: '5px',
-    color: 'var(--theme-foreground-faint)',
-    fontSize: '11px'
-  });
-  popover.append(input, hint);
-  document.body.appendChild(popover);
-  const close = () => {
-    popover.style.display = 'none';
-    button.setAttribute('aria-expanded', 'false');
-  };
-  const resetBorder = () => {
-    input.style.borderColor = 'var(--theme-foreground-fainter)';
-  };
-  const open = () => {
-    const r = button.getBoundingClientRect();
-    popover.style.left = Math.round(Math.min(r.left, window.innerWidth - 240)) + 'px';
-    popover.style.top = Math.round(r.bottom + 2) + 'px';
-    popover.style.display = 'block';
-    button.setAttribute('aria-expanded', 'true');
-    input.value = '';
-    resetBorder();
-    input.focus();
-  };
-  const create = async () => {
-    let name = input.value.trim().split('#')[0].replace(/\/+$/, '');
-    if (!name) {
-      input.style.borderColor = '#e5533d';
-      return;
-    }
-    if (!name.includes('/'))
-      name = '@user/' + name.replace(/^@+/, '');
-    const src = 'function intro(md){ return md`# ' + name.split('/').pop() + '`; }';
-    const mod = createModule(name, runtime);
-    const [fn] = await realize([src], runtime);
-    mod.variable({}).define('intro', ['md'], fn);
-    close();
-    location.hash = linkTo({ open: name }, { baseURI: location.href });
-  };
-  button.addEventListener('click', ev => {
-    ev.stopPropagation();
-    popover.style.display === 'none' ? open() : close();
-  });
-  input.addEventListener('input', resetBorder);
-  input.addEventListener('keydown', ev => {
-    if (ev.key === 'Enter') {
-      ev.preventDefault();
-      create().catch(e => {
-        input.style.borderColor = '#e5533d';
-        console.error('lp2 create module failed', e);
-      });
-    } else if (ev.key === 'Escape') {
-      ev.preventDefault();
-      close();
-    }
-  });
-  const onDocDown = ev => {
-    if (popover.style.display !== 'none' && !popover.contains(ev.target) && !button.contains(ev.target))
-      close();
-  };
-  document.addEventListener('mousedown', onDocDown);
-  invalidation.then(() => {
-    document.removeEventListener('mousedown', onDocDown);
-    popover.remove();
-    button.remove();
-  });
-  return {
-    button,
-    close
-  };
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  main.define("module @tomlarkworthy/visualizer", async () => runtime.module((await import("/@tomlarkworthy/visualizer.js?v=4")).default));  
-  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));  
-  main.define("module @tomlarkworthy/claude-code-pairing", async () => runtime.module((await import("/@tomlarkworthy/claude-code-pairing.js?v=4")).default));  
-  main.define("module @tomlarkworthy/command-palette", async () => runtime.module((await import("/@tomlarkworthy/command-palette.js?v=4")).default));  
-  main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
-  main.define("module @tomlarkworthy/local-change-history", async () => runtime.module((await import("/@tomlarkworthy/local-change-history.js?v=4")).default));  
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
-  main.define("module @tomlarkworthy/editor-5", async () => runtime.module((await import("/@tomlarkworthy/editor-5.js?v=4")).default));  
-  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
-  $def("_1pg70e1", "lp2_doc_overview", ["md"], _1pg70e1);  
-  $def("_1ov8ye5", "lp2_doc_model", ["md"], _1ov8ye5);  
-  $def("_1rihrff", "viewof lp2Model", ["Inputs"], _1rihrff);  
-  $def("_1ow4sob", "lp2Model", ["Generators","viewof lp2Model"], _1ow4sob);  
-  $def("_l8xp7u", "lp2_parseDSL", [], _l8xp7u);  
-  $def("_15gufbj", "lp2_serializeDSL", [], _15gufbj);  
-  $def("_14hgn59", "lp2_doc_panes", ["md"], _14hgn59);  
-  $def("_r14r4j", "lp2_moduleByName", ["lp2_watchedModules"], _r14r4j);  
-  $def("_j3eb9x", "lp2_paneRegistry", [], _j3eb9x);  
-  $def("_193se86", "lp2_getPane", ["lp2_scrollToCell","lp2_paneRegistry","lp2_moduleByName","visualizer","runtime","lp2_installAnchor"], _193se86);  
-  $def("_88b5go", "lp2_doc_scroll", ["md"], _88b5go);  
-  $def("_78h40x", "lp2_anchor", ["persistentId"], _78h40x);  
-  $def("_d4xe91", "lp2_installAnchor", ["lp2_anchor","ResizeObserver"], _d4xe91);  
-  $def("_xwsg4w", "lp2_doc_layout", ["md"], _xwsg4w);  
-  $def("_1fxe40f", "lp2_host", [], _1fxe40f);  
-  $def("_inou6n", "lp2_renderNode", ["lp2_renderStack","lp2_renderSplit"], _inou6n);  
-  $def("_1r0c4er", "lp2_ops", [], _1r0c4er);  
-  $def("_sx484g", "lp2_dragOut", [], _sx484g);  
-  $def("_1194mfy", "lp2_view", ["lp2_host","lp2Model","lp2_installAnchor","lp2_anchor","viewof lp2Model","Event","lp2_getPane","lp2_dragOut","lp2_ops","linkTo","lp2_paneRegistry","lp2_renderNode","lp2_burger","lp2_add_module"], _1194mfy);  
-  $def("_1bytrbx", "lp2_probe", ["lp2_view","lp2_paneRegistry"], _1bytrbx);  
-  $def("_orvfgz", "lp2_doc_hash", ["md"], _orvfgz);  
-  $def("_y2r8d1", "lp2_hash", ["Generators","location"], _y2r8d1);  
-  $def("_1cb1nyc", "lp2_setHash", ["history","location"], _1cb1nyc);  
-  $def("_1vcr15c", "lp2_syncFromUrl", ["viewof lp2Model","lp2_hash","lp2_parseDSL","lp2_ops","lp2_serializeDSL","Event"], _1vcr15c);  
-  $def("_1rf2mk0", "lp2_syncToUrl", ["lp2Model","lp2_serializeDSL","lp2_parseDSL","location","lp2_setHash"], _1rf2mk0);  
-  $def("_6e8yep", "lp2_doc_mount", ["md"], _6e8yep);  
-  $def("_1y1ubko", "lp2_page", ["apply_theme","lp2_host","commandPaletteStyles","commandPaletteOverlay"], _1y1ubko);  
-  $def("_9clfn3", "lp2_background_jobs", ["commandPaletteKeybinding","cc_chat","change_listener","commit_history","replay_git","auto_attach","lp2_watchModules","lp2_menu_sync","lp2_menu_defaults","lp2_menu_clear_history"], _9clfn3);  
-  $def("_1yumqn", "lp2_append_to_body", ["lp2_view","lp2_syncFromUrl","lp2_syncToUrl","lp2_page"], _1yumqn);  
-  $def("_z83rug", null, ["currentModules"], _z83rug);  
-  $def("_1s8yfis", "lp2_renderTab", ["location"], _1s8yfis);  
-  $def("_13y25bb", "lp2_dropZone", [], _13y25bb);  
-  $def("_b408jx", "lp2_splitter", [], _b408jx);  
-  $def("_nj1uts", "lp2_renderStack", ["lp2_renderTab","lp2_dropZone"], _nj1uts);  
-  $def("_a9rn1a", "lp2_renderSplit", ["lp2_splitter"], _a9rn1a);  
-  $def("_6vp46e", "viewof lp2_watchedModules", ["Inputs"], _6vp46e);  
-  $def("_1hxhexc", "lp2_watchedModules", ["Generators","viewof lp2_watchedModules"], _1hxhexc);  
-  $def("_16ptruj", "lp2_watchModules", ["lp2Model","currentModules","viewof lp2_watchedModules","Event"], _16ptruj);  
-  $def("_322aeb", "lp2_scrollToCell", ["lp2_anchor"], _322aeb);  
-  $def("_13649ph", "lp2_doc_menu", ["md"], _13649ph);  
-  $def("_1uvdt3f", "lp2MenuItems", ["plugins"], _1uvdt3f);  
-  $def("_qcv0dp", "lp2_registerMenuItem", ["plugins"], _qcv0dp);  
-  $def("_bt1fe2", "lp2_burger", ["invalidation"], _bt1fe2);  
-  $def("_1gv42y9", "lp2_menu_sync", ["lp2_burger","Element","lp2MenuItems"], _1gv42y9);  
-  $def("_1vx778a", "lp2_menu_defaults", ["viewof attachContextManu","lp2_registerMenuItem","disk_svg","downloadAnchor","forkAnchor","Event","invalidation"], _1vx778a);  
-  $def("_1mz2n05", "lp2_menu_clear_history", ["lp2_registerMenuItem","lch_git","lch_fs","lch_config","invalidation"], _1mz2n05);  
-  $def("_1af1qr1", "lp2_add_module", ["createModule","runtime","realize","location","linkTo","invalidation"], _1af1qr1);  
-  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));  
-  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
-  main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
-  main.define("persistentId", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("persistentId", _));  
-  main.define("createModule", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("createModule", _));  
-  main.define("realize", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("realize", _));  
-  main.define("visualizer", ["module @tomlarkworthy/visualizer", "@variable"], (_, v) => v.import("visualizer", _));  
-  main.define("currentModules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", _));  
-  main.define("cc_chat", ["module @tomlarkworthy/claude-code-pairing", "@variable"], (_, v) => v.import("cc_chat", _));  
-  main.define("commandPaletteKeybinding", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteKeybinding", _));  
-  main.define("commandPaletteOverlay", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteOverlay", _));  
-  main.define("commandPaletteStyles", ["module @tomlarkworthy/command-palette", "@variable"], (_, v) => v.import("commandPaletteStyles", _));  
-  main.define("apply_theme", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("apply_theme", _));  
-  main.define("current_theme", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("current_theme", _));  
-  main.define("change_listener", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("change_listener", _));  
-  main.define("commit_history", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("commit_history", _));  
-  main.define("replay_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("replay_git", _));  
-  main.define("lch_config", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("config", "lch_config", _));  
-  main.define("lch_git", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("git", "lch_git", _));  
-  main.define("lch_fs", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("fs", "lch_fs", _));  
-  main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
-  main.define("auto_attach", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("auto_attach", _));  
-  main.define("viewof attachContextManu", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("viewof attachContextManu", _));  
-  main.define("attachContextManu", ["module @tomlarkworthy/editor-5", "@variable"], (_, v) => v.import("attachContextManu", _));  
-  main.define("disk_svg", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("disk_svg", _));  
-  main.define("downloadAnchor", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("downloadAnchor", _));  
-  main.define("forkAnchor", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("forkAnchor", _));
-  return main;
-}</script>
-
-<script id="@tomlarkworthy/save-in-place" 
-  type="text/plain"
-  data-mime="application/javascript"
->
-const _3p04iq = function _sip_doc(md){return(
-md`# Save in place
-
-A lopepage-2 menu plugin that writes the current notebook back to its own file on
-disk via the File System Access API, instead of downloading a fresh copy.
-
-It carries its own dependencies — [\`exporter-3\`](https://observablehq.com/@tomlarkworthy/exporter-3) (\`exportToHTML\`) for the bytes and the FSA/IndexedDB handle machinery here — and composes into lopepage-2 purely by \`plugins.add("lp2-menu", …)\` on the shared [\`@tomlarkworthy/plugin-registry\`](https://observablehq.com/@tomlarkworthy/plugin-registry) bus. It imports NEITHER lopepage-2 (they meet only at the \`"lp2-menu"\` name) nor anything lopepage-specific; a notebook opts in by adding \`@tomlarkworthy/save-in-place\` to its bootconf \`mains\`.
-
-Mechanics:
-
-- **Handle persistence** — the picked \`FileSystemFileHandle\` is stored in IndexedDB keyed by the notebook's path (\`sip_notebookId\`), so subsequent saves skip the picker while read-write permission holds; permission is re-requested on demand.
-- **Export** — \`exportToHTML\` re-serialises the live runtime. The saved boot hash keeps the current \`view=\` layout but strips volatile params (\`cc\`, \`open\`, \`close\`, \`filesync\`) so a pairing token is never baked into the file.
-- **Feedback** — \`sip_toast\` surfaces Saving / Saved / failure in place, since the menu closes on click.
-
-Constraints (shared with [\`file-sync\`](https://observablehq.com/@tomlarkworthy/file-sync)): Chromium only, secure context (\`file://\` or \`https://\`), and the write happens in the user's own browser — not the headless QA browser, whose picker is not driven.`
-)};
-const _fx6mmk = function _sip_notebookId(location){return(
-(location.pathname || '') + (location.search || '')
-)};
-const _ez9ia7 = function _sip_handleStore(sip_notebookId)
-{
-  const IDB_NAME = 'lopecode-save-in-place';
-  const STORE = 'handles';
-  const key = sip_notebookId || 'default';
-  const openDB = () => new Promise((resolve, reject) => {
-    const req = window.indexedDB.open(IDB_NAME, 1);
-    req.onupgradeneeded = () => req.result.createObjectStore(STORE);
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-  });
-  const get = async () => {
-    const db = await openDB();
-    return new Promise((resolve, reject) => {
-      const r = db.transaction(STORE, 'readonly').objectStore(STORE).get(key);
-      r.onsuccess = () => resolve(r.result);
-      r.onerror = () => reject(r.error);
-    });
-  };
-  const put = async handle => {
-    const db = await openDB();
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE, 'readwrite');
-      tx.objectStore(STORE).put(handle, key);
-      tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(tx.error);
-    });
-  };
-  const del = async () => {
-    const db = await openDB();
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE, 'readwrite');
-      tx.objectStore(STORE).delete(key);
-      tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(tx.error);
-    });
-  };
-  return {
-    get,
-    put,
-    del,
-    key
-  };
-};
-const _8yf35i = function _sip_toast()
-{
-  // a single fixed toast, bottom-left; returns a handle to update + auto-dismiss
-  return (msg, kind) => {
-    let el = document.querySelector('.sip-toast');
-    if (!el) {
-      el = document.createElement('div');
-      el.className = 'sip-toast';
-      Object.assign(el.style, {
-        position: 'fixed',
-        left: '12px',
-        bottom: '12px',
-        zIndex: 2000,
-        padding: '8px 12px',
-        borderRadius: '5px',
-        font: '12px var(--sans-serif, sans-serif)',
-        boxShadow: '0 3px 12px rgba(0,0,0,.22)',
-        border: '1px solid var(--theme-foreground-faint, rgba(128,128,128,.3))',
-        borderLeft: '3px solid transparent',
-        maxWidth: '60vw',
-        pointerEvents: 'none'
-      });
-      document.body.appendChild(el);
-    }
-    if (el.__sipTimer) {
-      window.clearTimeout(el.__sipTimer);
-      el.__sipTimer = 0;
-    }
-    const paint = (text, k) => {
-      el.textContent = text;
-      // solid themed surface + themed foreground = guaranteed contrast in any theme;
-      // status is carried by the left-border accent, not the background tint
-      const accent = {
-        ok: 'var(--theme-green, #3fb950)',
-        err: 'var(--theme-error, var(--theme-red, #e5534b))',
-        busy: 'var(--theme-foreground-focus, #6cb0ff)',
-        muted: 'var(--theme-foreground-muted, #888)'
-      };
-      el.style.background = 'var(--theme-background-raised, var(--theme-background-b, #fff))';
-      el.style.color = 'var(--theme-foreground, #000)';
-      el.style.borderLeftColor = accent[k] || accent.busy;
-      el.style.opacity = '1';
-    };
-    const hide = ms => {
-      el.__sipTimer = window.setTimeout(() => {
-        el.style.opacity = '0';
-        el.style.transition = 'opacity .4s';
-      }, ms);
-    };
-    paint(msg, kind);
-    if (kind && kind !== 'busy')
-      hide(kind === 'err' ? 5000 : 2200);
-    return {
-      done: (text, k) => {
-        paint(text, k);
-        hide(k === 'err' ? 5000 : 2200);
-      }
-    };
-  };
-};
-const _1a1j664 = function _sip_svg(){return(
-'<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3"><path d="M2.5 2.5h8.3L13.5 5.2v8.3a.7.7 0 0 1-.7.7H3.2a.7.7 0 0 1-.7-.7V3.2a.7.7 0 0 1 .7-.7Z"/><path d="M5 2.5h5v3H5z" fill="currentColor" stroke="none"/><rect x="4.5" y="8.5" width="7" height="4" rx=".4"/></svg>'
-)};
-const _1c9i265 = function _sip_save(sip_handleStore,location,sip_toast,exportToHTML,runtime)
-{
-  const store = sip_handleStore;
-  // current layout, minus volatile params, becomes the saved file's boot hash
-  const cleanHash = () => {
-    const raw = String(location.hash || '').replace(/^#/, '');
-    const drop = new Set([
-      'cc',
-      'open',
-      'close',
-      'filesync',
-      'from',
-      'focus'
-    ]);
-    const kept = raw.split('&').filter(Boolean).filter(p => !drop.has(p.split('=')[0]));
-    return kept.length ? '#' + kept.join('&') : '';
-  };
-  const acquire = async () => {
-    const saved = await store.get().catch(() => null);
-    if (saved) {
-      let perm = 'granted';
-      if (saved.queryPermission)
-        perm = await saved.queryPermission({ mode: 'readwrite' }).catch(() => 'denied');
-      if (perm !== 'granted' && saved.requestPermission)
-        perm = await saved.requestPermission({ mode: 'readwrite' }).catch(() => 'denied');
-      if (perm === 'granted')
-        return saved;
-    }
-    if (!window.showSaveFilePicker)
-      throw new Error('File System Access API unavailable (needs Chromium + a secure context)');
-    const suggested = (document.title || 'notebook').replace(/[^\w.-]+/g, '_').replace(/^_+|_+$/g, '') || 'notebook';
-    const handle = await window.showSaveFilePicker({
-      suggestedName: suggested + '.html',
-      types: [{
-          description: 'HTML',
-          accept: { 'text/html': ['.html'] }
-        }]
-    });
-    await store.put(handle).catch(() => {
-    });
-    return handle;
-  };
-  const save = async () => {
-    const toast = sip_toast('Saving\u2026', 'busy');
-    try {
-      const handle = await acquire();
-      // pass mains explicitly (like exporter-3's exportAnchor) — a bare call leaves
-      // bootconf mains empty and the saved file boots blank. runtime.mains re-includes
-      // every booted main, so the saved copy keeps save-in-place too.
-      const resp = await exportToHTML({
-        mains: new Map(runtime.mains),
-        runtime,
-        options: { hash: cleanHash() }
-      });
-      const html = resp?.source ?? resp;
-      if (typeof html !== 'string' || html.length < 1000)
-        throw new Error('export produced no source');
-      const writable = await handle.createWritable();
-      await writable.write(html);
-      await writable.close();
-      toast.done('Saved \u2713 ' + handle.name, 'ok');
-      return {
-        ok: true,
-        name: handle.name,
-        bytes: html.length
-      };
-    } catch (e) {
-      if (e && e.name === 'AbortError') {
-        toast.done('Save cancelled', 'muted');
-        return {
-          ok: false,
-          cancelled: true
-        };
-      }
-      toast.done('Save failed: ' + (e && e.message || e), 'err');
-      throw e;
-    }
-  };
-  return save;
-};
-const _1uj52bj = function _sip_register(plugins,sip_svg,sip_save,invalidation)
-{
-  // Register straight onto the shared plugin-registry "lp2-menu" set — no import of lopepage-2.
-  // {invalidation} auto-removes the item if this cell re-runs.
-  plugins.add('lp2-menu', {
-    id: 'save-in-place',
-    order: 5,
-    label: 'Save in place',
-    svg: sip_svg,
-    action: () => {
-      sip_save();
-    }
-  }, { invalidation });
-  return 'registered: save-in-place';
-};
-
-export default function define(runtime, observer) {
-  const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  main.define("module @tomlarkworthy/exporter-3", async () => runtime.module((await import("/@tomlarkworthy/exporter-3.js?v=4")).default));  
-  main.define("module @tomlarkworthy/plugin-registry", async () => runtime.module((await import("/@tomlarkworthy/plugin-registry.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
-  $def("_3p04iq", "sip_doc", ["md"], _3p04iq);  
-  $def("_fx6mmk", "sip_notebookId", ["location"], _fx6mmk);  
-  $def("_ez9ia7", "sip_handleStore", ["sip_notebookId"], _ez9ia7);  
-  $def("_8yf35i", "sip_toast", [], _8yf35i);  
-  $def("_1a1j664", "sip_svg", [], _1a1j664);  
-  $def("_1c9i265", "sip_save", ["sip_handleStore","location","sip_toast","exportToHTML","runtime"], _1c9i265);  
-  $def("_1uj52bj", "sip_register", ["plugins","sip_svg","sip_save","invalidation"], _1uj52bj);  
-  main.define("exportToHTML", ["module @tomlarkworthy/exporter-3", "@variable"], (_, v) => v.import("exportToHTML", _));  
-  main.define("plugins", ["module @tomlarkworthy/plugin-registry", "@variable"], (_, v) => v.import("plugins", _));  
-  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));
-  return main;
-}</script>
-
 <!-- Bootloader -->
 <script id="bootconf.json"
         type="text/plain"
         data-mime="application/json"
 >
 {
-  "mains": ["@tomlarkworthy/lopepage-2","@tomlarkworthy/claude-code-pairing","@tomlarkworthy/save-in-place"],
+  "mains": ["@tomlarkworthy/lopepage","@tomlarkworthy/claude-code-pairing"],
   "hash": "#view=S100(@tomlarkworthy/claude-code-pairing,@tomlarkworthy/module-selection)",
-  "headless": true
+  "headless": true,
+  "prerender": true
 }
 </script>
 <script id="@tomlarkworthy/bootloader" 
   type="text/plain"
   data-mime="application/javascript"
->
-const _1lvaqpj = function _title()
+>function _title()
 {
   const title = document.createElement("h1");
   title.innerText = "Bootloader - Notebook 1.0 stdlib";
   return title;
-};
-const _5vw2f8 = async function _conf(){return(
+}
+
+
+async function _conf(){return(
 (await import("file://bootconf.json")).default
-)};
-const _1kn6xro = function _library(highlight,marked,stdlib)
+)}
+
+function _library(highlight,marked,stdlib)
 {
   highlight;
   marked;
   return new stdlib.Library();
-};
-const _1d3syxm = function _define_builtins(__ojs_runtime,stdlib,library,inputs)
+}
+
+
+function _define_builtins(__ojs_runtime,stdlib,library,inputs)
 {
   if (window.importShim)
     __ojs_runtime._builtin.define("importShim", [], () => window.importShim);
@@ -29872,8 +29470,10 @@ const _1d3syxm = function _define_builtins(__ojs_runtime,stdlib,library,inputs)
     }
   });
   __ojs_runtime.fileAttachments = stdlib.FileAttachments;
-};
-const _liwyd1 = function _boot(define_builtins,conf,__ojs_runtime,location,__ojs_observer)
+}
+
+
+function _boot(define_builtins,conf,__ojs_runtime,location,__ojs_observer)
 {
     define_builtins;
     const tickMode = conf.tick;
@@ -29937,11 +29537,14 @@ const _liwyd1 = function _boot(define_builtins,conf,__ojs_runtime,location,__ojs
         }
         __ojs_runtime.mains.set(name, ojs_module);
     });
-};
-const _1o3uuqr = function _stdlib_5_8_9(){return(
+}
+
+
+function _stdlib_5_8_9(){return(
 "H4sIAL05WGkAA+V9e18bSZLg3+tPUdZ516VGCD0A8Wi3B9t4mj0begB374zM4FJVCaqtV6sKbA/mu1+88lklAd3u2/3d9W/GqPIRGRkZGRkZGRl5Hc2D8/MkHf40n86CZ8HR4Nc0LpqQkE1STEvnxZfdR9dULP08m84LKBUW0fwiLRpBNBrVg2c/BDePgmA4nQchFpxE4zTIJpQJ6YFpQNfDIo3gJoCPHSzXx4SzRpBOrsbpPBqM0p2gmF+lwW1999Ht7qNHa2vBZJqk5+NpcjVK87Wku5rk12v5PF6Dv81fc0Jx/+gNYHdzuytfr62vv707Ot2H7+46fx/u//Lm4BBT2i1OOd4/fXd8iAnd3UfDq0lcZNNJMCWKvJxOroEU6TyMp6Or8SSvU5/naXE1nwST9FPwWiqEtaTWCGqSc1MLVgKp0hxHs1DBDZkEGcPRkP7z5OiwmRfzbHKRDb9QoTpAqO0ESR9BZfD/p2fB169BrfZ0F2re1pu/TjNotVGjgrc1pJhBP77Ki+m4hH4jGHLL2HHuInR8UV93TVc1/vPppzL6w5BBYG4dshuBDeLWwSybDNP5S87G8rlBiCudpIjT2nfBX87Pf3p3vH9+Hny3pjg0nqdRkYaTK2Ay3QoU758RsgCuCQy5H8WXoY2ywlczK9dEdrVygyAbBuHj0GRqjOqmTKAHdnaVX4a6SJ9/nQE2/Is6j//dPlL/3to0FTAOdWZRAviNroBHPmVJcdkx1MFuUhaON/DaKJ1cFJeQmDf5pwVa8r4XIMFz4tW9+Tz6EkrSqiq0ErSFmVrISnmwE7g4AdHGUfH3NJqHX+AfZwpgAjTTghZqq8ip2IFVTG0Em3UARQV+CLbhPyyzospYRczner2i4Vc44An8Y0hxOb2aIzkwtQnC5N3pyx8xKQSeGGeTqyL1ct9yIubnaTydJF7+CSdy/dEoqyz01soJ7YHM8sPoUFCEPh5MYJiyJEDEa9A/i34WtNfAwpRWx37jmGr62W1OJ8VliNntRtBZWIxoVJcSodMFQOhU1SC6KTg7KlUoVkoXCCq9acob8I2gS5n/wI5+8yYJqhpQEH487g8GT2BqnoSE9QPXp+hqVIRJOsrGGYg+w2Lz9DUNG7AATp3j9GL/8yx82q89BYi6PEJ/P3k/P6sB8V/tvzl4e3C6f4xso0o048sIxF2S7hUwv5BprLk+z9OwSD8X61ouK0FIolgLuAZJNgBLVY7ht65WLZdZkgmYuhE49C1lQQK0tYgykpQypSR8DoHc/mJCRYY4df2VA4Upg7yVvySSDXT1CwaTRbaeRFiQVosSiZz+2mQSovRBg8D1m4qILGwEB5DSApWD/wAt0+kQfh8G31NCOh1h76JRnjIaSDCGYI3YIREpePbsmVIc6sHq6uH9arBiYVXQ3SqmH9NJ6A4WoKcHClSYXSdrpLMsvBuo+KhySA9Yd3+FzAMYP7t6CcdfGT9Sjex17dNlNkqD8GBlBUT6YfAf/xGUqh7Ug8eqKg5iqcDKyoEDfVdDR1TCDPGrBz8APesyIqjwmVIpdIyLxnpI7fZXVureeDBFFkCJnZEwXQ0qqy2g14HXIvTR1LnVv2SEuHo+yuI0/JUFN8+15jydjSJIXavV1i4awdPaU09FMEOAA2Dju5giRNH/eVSxG0OO0cKxjsKlAAFttVBFOZRmPnX0HFB80/DrHCrx88iiZoiCTOYc8y9MMNNvESVai7RqFlL6DU0GUxWKs/ZXgNy3oNvTboh1QgY8ZJk5kXEKSH8tEYJkJYG15OjdMnKesobxYpp8IY3aqN+umk7wnd2Io/y6aqlbUDRai1eU6k9N/4x6KUJTSrAZOtEtzRJrrw9ORxhUdQ94OZNVxNBPLSvlTYWztvSdPhmMS7idwVI1iQGJZURVW6/3k9qiTiweij/WkWVo3Y0VLaRmy1XBF6rY/YDZ7GNA3UnkBQCZh2iH4wHlXY9QC9U/1Oc4MZvkRTSJUSKgDgyZ1qZBYO1oZa4JSmERyibqGaqEUOEpqXSUaEloFtAgoXHnDSWkQYW72ucTmqSlNMxPpHND7TehWfs3Dpz97ZeFb/uTiKL20MvMIbExh8BP1EAt/RatBLsq7ydEEVUxqEHoujnHrFTp3GOSOVJC68SYzRh6edg/Jx8TvDJWE4YI5TJ+Ea/Ez8wVVpmfeYSWkakwZCrKZPo3RabCkKlwyVS4ZCrKZCosMhUemQqPTEUFmQqPTEUFmQqXTEWZTIVPpuIhZIquiunpl1mKtNLTVCWKsafumv8+pl/QYmLn8dIqs1dy+lDurFnMszHuVydX40EKG/+x0agfy6xV1XDOc67WKJQ8gBmMSkDNFDaKS1Vh0pqt0pb2X1UcNvVWYfjyij7mfT/3AUqsMOY26pjj1RorMw7IySK+DNf+GfZXV87eJzed2/pz+LN+G67Sl/ypP68/D0/p5w6ny5/3Tfjb5fx/fNVAdnStJ2t1d48xzD4X/0K15PHjcX/9jH6N+70zg7InBldRDNbWapbueroGKUFNL/C6s7BLtqSurPLcb1fRsRhBteiJVS6BIg8ZiLF+FoS+TVA3Weu02turrTb877TV2mm1arBIX6SFGIVwo3Jn5d6CyjxRyOKcztJJkk7iL860MMli3IW9cA4ZwNVRNnGsZWpVy6ej6zScRWS+M6WsJe/DkxsEdvuXJzcC7nbtyQ3WuP1gFEO9KjjoZWmuZFzSJVuERrCWdNFK3WtuN1v4I8nyAuZ9c5xNoIqSftlkdlXkXs2/TAd5Or9GI/3lb2tcBEG0mu22BYwzPICz0bRYCg4LMLDNZntTA8Pk5tU48cBdzKPZ5XX2r6UgVSEG22m2NVSV40G9zC4uR/D/5ZjqUlgTIHaaLe69yXDBfgQe+7wUJJXQpDR4UroHbTRNovzSA8eJWG+92e41OwSCE/0+FiOvLqRw012rZUj0Kv6a/yubeVUpDetA1ZZVm9K9+uNo/jFNPACcqJvv4C9O82rnv/loQ4oMQLu5ZbEfpK9+ivKxVfk6vYi82piEVTaaHWGMwVU2StYw3Wsak0agtlZAWMV0BrPJKBgolLcA1N4sWwRtNZplDLFVCRHzPajRHHTudQ9gNIviSyiNecwXMkB7mNJMc5B5G1WAtu8AtK0QW0nzsVOz3b6jKoqJqrq/XaXzqV+XUxn1reaWHl/J8FAvprPpr/l04kFRyavxKEsnhbCqxS1eAQ9q+jlOR7/6clBSGbWuBUwyfMZPQeXKSpzPqUzRTrOjgUiGP+vTaDhKfcEkqTwJtptdDUQyLADJVfwxGfhSiFPX+A9NG4bVWXfHqUpTnKe/XWXzlLTFDCCCoJI1Z5wWUV5xgocL7lvYGgpKMI6kN6DNhSUEyhdKxR2kTPzpONWp+CFiLMqPPk3UObUu4CbLWgadLbJhls6PERJoW+Hznb/0/7n2l7OV92v15/yrjokh/IafoE0933m/Fja/q6MKpeYuLcIC432ygsoX/xOu9t9/Wm2uQFVdPP1cpBNTAQE2Efp3X6FNVeiYSbgPEwTVx3gU5TnXTPKAU1ErAOUpB702LqbzcJzmeXSh98f5FfRUJ7ISBTqBDbg5m0+LaYG6PB3QP3OapbTdR669/UCTLDTUqxtcAlJc0Vhh0baZfk5ju7x1PsblQdlkrLHNHU7st894tyv0VcmdM7WdLi5VWvesdJYsmtTr+XQcTufZRYYSAJa0YpbvrK3FCc4htDtcQ0fTYm0yG6/VWC2jc4Pa1WT28QI5XRUjkYvmkHTOi1E2qZ1x10njX3u/9mSNrQjcHijYxSXa+JC7iaRhTTABdfljDjuSKBtlk4sgH+Ea7Z4AIfwQ54tzPs1Exv3UdMjIGvUQpYDSuLEiadGOsR9GGqpZ2xh2K6j51mTW9PMimhf5L1lxGdaaoOf7OwE2rHa0tm9ssIbDLasK2lMYwA6qsPTzFgbhQ8VRuE0IGci30CNxFlHoMjGu5qMO4AQgmbi3T264GDGw+RI2Aiw+/MVPvP1Ap4C3a7AufYT50kTJL4ghWZGcQtUc9f8QG61bG1MeKM7PJb+hqg1T3MxRlWZxmU7CEPo0A+RT7SmjAamc5vSjzT72xAyBN1E9hKUNdL4oCWykzeYLwWlo8zSB6nEBehZt7AhRkImmBKBXt3tgZ3BPNGRlz1MlsF1l376tu1ZJrOjt4KL8yyQujW9HdkiDKE9tgyim2qyo55aILM6/GjArS7ac9FkjBML9/aeVnToI2fdraxnzJfnS6OMzlnemQr95dtNqdG4XlodxeXf8xsLbskOOpnFE3dvhHjUv5+nQYhhCW7wsYAsKrb3Pm+dna1ZDlP4+f7LmNL6IJ7LRCHVI6oViAp4gzOrqhNiS4ATRwknNLrPP1DOKptKHUlk9qYCpiACPhQDyXTlwit9lwQAGwfkbfYqywpnsProMcMFI1zV3epjxrO007S0woldO7Vtig/ypuMgsTeevKiv7OQ4A+4iGhC/n0cYep2BJSFoFcJit4miORoVtdxGw8mBoncSBLan1yiG2hWZZQK7pFNvQYIawcgSFoRyBYDeJFXWD9FHdHA2GWQ/R1Y31SiAKo3KrDEKieyJHyU/SAGxtAFnFkj6lQo4+E+NGZbnGqooKqBckCNTXcToCOXAtbmm77sJGJfYG0OpVkfICYUk+Wa5pfXvsrNZCSsyx1ihSwFFZRJSrVykqUpcS1jqlqmKvQEceZ3kaKnJA/jxlw621WHGX83iezWjvMY2vxrhNYie8/VGKX7AXpwJmUeLv5nRCC9ezIHSAwuSdf3HOnPXiwFr8bAoUD33SUjfrlh5yCz1EtTJMUTbWPYjkjVghQMU1i4lRc+DpX4L/PB1PoWFzklnqXyqau9/Bhc17a3oFFvdsm5dX96BesmBDBhmGbYLgE8wj2PSzcy/tAfGHytWjeplGSTOaoah7eZmNkpABLlrzCffSUZ4/bPZKLzVl4QOKCRc2lUFUzU1bSxBtyptH5TNEVWCUgcIT4b9p6ZjTEgOOIuLpZ8aR2YGC/4k+IjnKfZnVAuukwpvdVKtydht1pOTkUEWMhUfn0rWu0NbpNohYGmDlJhr8ELRBeVHEj0ajEPbbzRh/6LINW9KpQRin8ws5T9V5RsFg7Y/xaBKFjISkYdm1C0j3qAh31NowqlLOZo9aD8UEYYtvNB7d0Ayxtk9j2jzZhd3dFQ7w2D0dcc0HTJBxI/hY97dO4/7HM3N4X+k7H06honZ1h3/QO46Aac84/I9OR6YELkCo1dskdSrikENg8lEJu9Y7Zw0slOSsRbQV2w07R9NikU0slrG0bfIxtkaEs5CF+TZAXsMV2qSKKHM9LIkiwr+2EtYIhhGaM77Yo4hanM+qu7LvngTfoyun1BIUXZjae0cftGGlrl3JRcGrbE9Ve9sMM6V/BiyvZqqsUeikg/Yo5hIXsiYt7oaV5OpaYoY7LITUzKs1LbVQ3+git47orZy5LgpE9I4j2ShFSNfRw2uBlQLOGD/XKOzY+TLakC3I7rgSqGMWDdkM2+i5eMn44Moz+kIalDs2HX9Lyk02BTFHJAIeVfS+P9105bvxVj5rzDeay+icWWYAEuju7qGHOBdy+kLeyjyFmtE4ETZRh32CqHb5SEqWL3PEdAU/8ASWVLfpmM1gu7Ym/YodIIy87ljaM6iQki/KjEXiGyPSSzC6nqmOEueeAu4tdtbm2gO7E1Rq8fYBaP4bHboASTzrw8nf3kCGhzZPtn42yUB6otn8TG9vbEbpa8bGIyelqdTrjdJS5hRgQzyodmfORQFoLLxhu0H6OsPrTuEwG7EKApsmrARbJky6/SAsgMPEHXgVFRGqAS/psEJbjM8rc33LcTJQq1jVegWMGBaXGcwAxd7nyWAHJBBZ8HaCZKCWJL3Uw66/yGIx9ACQCcjDq3mcuoa7PiAHysvVcJjOOwso7A6PDDgQ2FcPBT7PTFSg62euTooKdyU1SBWHjKZKDgWjuu4O9wMPl76E9G8DTSnR2FciGX8ydiPBmkCnRuBWqACJznLLoIYMliBW4VDvt8haoVRMAx7E4Ah3zZXQZc/KfkSlJj7s/9dPb/YODoO/vds//nsAvw+DJzeUd/vB6Y2x+qo932yOJ583zIKHZNCv2Yfaq6vZJJ8Bn9WC20bQV2ab9DP7d5KPILsPAufPaXdSRNnI9jvkS4RnHjmTFLclg/QU28lhMuWwzR1HIPtRQHpktTt7sv9m/+VpcPjuzZuD1yHXagRP0eTwtB7snQQqiVSA18dHb4PZPLoYR+cFNnU+grkJOtUvP+4f75PUhwafUtbTJzeChOei+CHYO3ylEHwWPP9wSwnUwOHRafDm4H/vB09ZbJ3/+9Pg6PjV/nHw4u8OKjASJeikkfQ5eRGBlBPpjYZGyHqEYkMTpmt91j/P+ACTMMcTDCr3wTE7LmQtoTbraUitRlCbTAtsoVZB3GwynIbPF9KxgbSrG/rEWVJJFgJGtKFfqsiZbR8h9hODYrmvTAvAFDYLV5NkJ0Ab1QDFsTsRDBPfOJ2UPoKcRMZ2MncCHmlyocMEEHGJyKNTyhcQUJ+vwj420BYMcui621UMSqhueQKZrqdZQlf1FowUD4zw4zjK8YJTFb9/QJ2lAsZ3C0e2DsPVZ0zO6vcejdqhGgfX2H2jHaaRmZVTfFlIEQYkpmQZI8pY8siUROMHlOybFDwAtN3Gw5iG1KqC5UmixbAQ4UrfKIEdTJMvtYbFLXMPyJ2tJLqVeT8+o4YWSEYYt3Cx/Gs2m+brNLoQhZQXfb3vMnymyoW8D4JCAKFy7epLCRHdz/EqHBc8Y2CgtlbvkauWanNeTd4M0QjXkIZcy6NBrDGD1h7d2jZef25RjfxTRiZCkwIshMaaGi4DtR1Xla+RdNq1Sh0cnkoh/b3/1/1jJ+304PDvfrmTt3uwyniJb/dfHbx766e+OPirn/Tu8OTgr4f7rwLICypQ6PgJW6WeZKDtX6RzpzOn+//lgnr55uhFqaZse+2Kx/t7b5yKr47evXizX5EU/HS8//Lg5ODo0Ml8/eZoz2368N3b/eODlxUjgB6zTusvqrBk9c0p92rv1EMJEk4P3u4v7yLsHU6PXh3pG4/CzGijpQsF6oJBjgYj9jqjeuIz7sFe+2f4fIf/9/PeMfDFX78e7p0e/LxfD+rPX/64d7z38nT/+CtkH36FAl8P4Z86ptffh3IEyLz63BggdhjqK6AssNVXIV1FBSEennJPQaAxeW7tTRgqzY6a7m5iOcc3f/DJdln5xgu/XMG6hHEs58WorJZzX4ymA4DIGc0Ir6O/oJEM7wS8ZwrLbfZ3wORbfKVddUlVxH2Ttwckjb2sq9tbQdhnwIiaTUoyYKeWsnavTvFxn6LF4Jk5JdILVIOFlixUVME6S+J1mku4GrHIyyHsgPYnMBIp3dvhMhIeIKOC6mZTPzuTts7klKT64q1tZKV10+IOteiwygJyeIa3i/AoYJ5OjBNMyZ6M/NKp65J4CM116U+g9A7TcWmou/hMSRuVsUEG81grMHXbkDvDeUkl6hpuf3amkICfCozGbwGkGC3GprsKmHMkEtu7eVXCISIt1dYlJinr9fMUSh1OE+MsX325h2YIX8jIY0ACZqR7I0OlhqDeD5wGjV4MM3FgKcmH0SHMkyj4PsCpuNqmjx/oQ34/o48WfNCdh7tQu6Ae5YWDmUrkDtIttTFMIDo8UUgzvnSsGX3elZ+sIiQd+3oG35mj+jbPtdWSLiB+VjcJHEu/ZjblFWUd6HAJ5fEkTYSqhuNlo/F6blFdpqJquw50RLKVCgg/INIt+zABKkK7ho+s9J9tNyyTY5HHPvuzzgvYAF468OBOVtDA65wiguma6pWXs7xPD0bbcC4xw11MN0/Ri8C9nyRpod1D3yUu7598GQ+moybeRIyK6fyMD+a0ydbehaA2KTsREeNZTntDqox7C1sc0FJEIlth0FQYOWZK5cJso57le5xKZo0K+cHDh24gVmeaxZT8uWVZdG3PbpO4evgNQtrDmrtICxKDvpW7Eq2oZAxHlxV2KuSNO3wzzQgZWMbt3OYwS0dJXvfPvAzaJ1SOrReuNoMpLhhaOVXt15jEtavBWwVCql9xiYedWCmXvFt478f7fI0m7ka4CO/3uabe30tt+eZc1yJwwm5QFoxHvg+s01j11odqHiTODqhzjy1Dd0epyK9BMStMRu9uvX1d132RTaL5F5PT3rhbmy8VKW9LNktQptNRGk3sMlsaCdTlTfq2Tj/NxlZ6u+UDxRg7NsR2R1d9k+UWSdolfEhYOXUNPU/ILG9lrfu12VjiVG/r6gcwVnOYLVZmT2e+jWZLdije1sDTklH/Jm4KXWWC9OFsjCdu4YcnN3GCnl1y7cMcipCRzLqQRvcK1BHVjK35fO70CrJevfAPMpzUP/0AwzLPw3Ck0XiZDR3+naRMI8fcCa00JU9566A2AuASvNc6QBclTra9nkirpVaeG6cMZxUV16sC2G/MNOJGDR7N2Tyl9Ziwdhy0sW1dQ8No5qCUhMaKoxdhW2OoAGA1SRDc9pTXykDuBCgHQQTRnKAy7KhRVKyZTCdphblPGZqH2Rw6T0WV4W+Rt1cJxXg0zS3HKW6DKu0+Mvg6ojwQM/FO5frCGPMSqQx8zDrfYS8ppoI9cr53m0QSeWz33M4Pgi8o3QOrHbWAhtao3pPG9pAg1WCKRKORi9FdNDMQZMrc+4xM+UjmfBDsHwtUTrPdUk3jy8EarBiyrU0zaBpctGmGwFDV0npx8LGwFfOCh5/a8WOt2AqpKaTPb6RJ/nZPA7joQw7+/jipZJKWCFEWN8oogcwnijsZJJbwkd62TsiUw5fylax6zntJCYnRbyk/6BK3OQ0wSH2H4JFvu7YNzdH8ovrg1bJoV5idqdqfYMEOgjSPo1la5V73oSae87UPS08q3YEnHXXB0dmPR78Ep3sv3uyfeIdOXMk+dnLPmRafE5nDwKpDQLXEKVtRGadX+ycvjw9e7ONxGCYLOVj39s/GnPMMZQo7Z6uSfJiTrh2tD+u+CPOwhm3XVjJdKdmsL5Dia8HVUtoo2roJ2usdHtVUEVfbtoCIrrDA22EoFkd23qJwecPsooKmdOdS5C1ZRBhlNQkkSB/UZUI/b4IyV6BOCu2NZ6dTMkE/s+xV1pSWFpGr+Utsmzt2WlMkSAVcFWpXeZfdLkHpRXYBOifUm17xWfG3wcgFW42QtsWSjwnDEPKVfUkEF9EQUzGdymDViSN5CMM+8yNnnXkO3EiEsgkaHXb2iiKKL1GdqlesqVAYdFEsR6ZmuwnHc137KDrbcCm4GLBV9n7g3e31feBDsftjblks7gHbKn2/JnDzFdXo3MXxLNL8xosaFCLRPp2hMsOmdnUMYIqXqI316r4qdie1uTVpytW6fDX6LuouAVVJDfQKu5MaWOge1FjCrgyhjFZF/0reE+p6BTeIzhP8S68Qdu9u+Ri7woXL3gfivk82q4uOke3i9zg+5m0pHx9721+bILIyVJPFOjaSq6lMUSyFlylDfXiB2c4t28FoOtip1d11QtzRXDjO+Zgt8RRuoFJdZOilgRhLQarJKHuHZK7Lmz2aS6Di3UcfJCTxlSJ1/5EvPnL4Zh7fhZtm3YizaTbKqjJbUZtjWLBOraN7dbKLZywY8Eyf7FrJAH41x40xrHDJKhtiazuO7m+pk9YmiMf+5cnP6GD6UwRDZfXb5npbFSGUZfPIt8XtHDMNDfPXm7SRVcuQbGed1UeCvtL9/GIqJsA6IBiPrkChC2svp1ewYURDtJxa10qCzDXcUNfeTXBaJNDD0HRbMbZ1TdSXQRWbaO6JbwLgUUC/koz5Yo0uK+/ck/QYA/9Ppr3C2DONyWXg902yaD1RN4E1DvUqWWumrDfPFs1gh7zLScFWaKDFwU8vZScozTW8cfYJsowklUQJnPsotz5FZnRaUdxJk0X94f2Dg8SHl8f7e6f7wc8H+78ET2Xz9BQ9MD03Mm76HLYak/Ape0XzRdKn9Q8WxEr0S0vT1eTjZPppQuMiOwgBqaSMXqT4GM3dyy6zmVTYUe8746x15F62vkc2AWmPuIyCuPE+Bzl5jpH7wueNYO/Nm/Of947R4eTZ6fG7faKjfYZVaTI0Y17hV1HWlbyFUzwxK1bO37E8LJsv3Lw0Z28i1RyonhnenFA3Sb7B8Lsqr0cWW4ljcpDw0ZSwLPG7jxyrAd2TwvM8+hIpIQq4eyIoMqdiLbhrvJaONGqxXiUSdJWD/Pt7hetBSIB/by9sNbbyqEPtxi189e2r6jMPOdNwjzzMkjBJrLpyUSlPUQl9QXli3Bhfz4xKgtz4lopSzJTKdiRQHwdqgtpNCtYErTcsIL9M5x/T+T2BSJQbBkYVKVzULUvWW4abXv4BNNPLb4clwioj+UhNVyb/aHpxQSZRFPtC/JeQMx2lbyjLebTjRoo0ZNgaqv5tBbO4xhvtWSBnWo49RKc5HGawXNyuZhx9VKbqcN87PmcxVkzQkKE1DYmtNskMZVFlD3snqHHrDdUG1dI2F7Z+FBnGybQaYD6wqZkM/ENpyzh3H4fcCj/YH9/9db/kG+uUsw5/MdqEc1xa5aVa8mS1PVOXeqFWef5WevlWuQO/qyz5rgrmO7f+co/eF0dHb/b3DsvEKJ+El91j0TX25HTv7U/VqcEvB6c/BvgZ/OPosOxE6x+M10SvcHvz7uDVne63JTdfnYYEOv5ZD5lOt7x6PU2eg/qIq6zrIVtfQMpFJ+PqFJu9SeQQe/LyMsWoXs+CTmvX9qbx7psp76lpssCvxnFKalJ8S9dZBt/WsIuo04wKp5qwXPBe0Hhn4RUFOiFIxJyt5XyJogTBO1nwoWhnHwJyfk4NehfQkWaW449DqArHIEYsy/9G52p06nWSFnJKa7sOUfAYv5w6AeGCOig/lCQVA9aJAiOtsYUpVy362T/NMYZ9dp0uLIGWdZUpiKAMTOyOOHRY1rxRS1BFfgsbYwwMGQoXylGeHQeLjj7RAQEjjLZ24c/3wWQ3WFnJXHvTtXLR62dn5ijimkZROY2q4WY2EH8UPYu0c6bluTchT0EYJS78Y5Tv64f9/nf6RbrVb525FFha2ooyzqifowlUstS5mLgUuqg5vFbJNMwu+RLG0yWgU/K7iT59X4APmaOq/MgW8V7VG4Jue7oEtKeO0bg9EzVlUaQCHwcbv1DNDKtl44Wn3P/ZY64cAqFUhK+DWUXKHH1g5krF9K6YFH9wri2eU2U4D55W/CwgsXe9PANwviFF1O/LyLRpuzH/8clZ+W6MbKJMDItrU0kPlH9apxUxx+mIVlfRfna8ZKVU+OnCAaXirJCZ5EBdIixsO9gAlqCPJqFkmPMnNaeJm4Y5HOGneQrHVlyuyNW84VHCw5JjdonFfGVz35/BUoAFH//+6RzEuFz7j6lU4BVYWFUTDjM9QVSe6iWNyGr5QBlScbpX5bY3l2Z3O4uzjZV2cfbLUTRW+C4stQwHzF+GBPnS3llgc50KqAgQokEF+qneKM+ziwkaBOUkgQ1AaPJAx3a0ejQCOY+L2O6oVxA5apHbXpZphmwpqJadUJ6YshVkL5RkSenVZ8Dqfgz2DNjhb+yuI1DG0UdOOU3HsxFuLG2MBYaLeqlR7zxb2jvnK8cVlLBvHCvD20LvQzQlCR7K+7BUVh10lsqS4UToiz5NgkrVQHhyyrU4OC6FlfQ0o3by22j5mFkXfCsJG9geF7ePyueiZMkwTeihhE2C3Ru1qJhtj1oN8Nm4wt8JItSXmFECrTzd+FiPNiAVdX1ureBTWaJ+G1XVd+lWqm3JNXOr0Nw3pqSXGGSRbi2elOy5y6JK/gKrno4sqWKAOBiYeWpxraWWS4Krm9+fT3mJEUNTxwko6QwBNa6L0XamNAFJOWbzszgIIlaqUvMcFIpjxwHTataQrmr4gjIU7c5ghQjjkVbhLhUcVdU61bHeUeM8GmclYyv4UbfGA+2IWj1ED/EWUlNE+nDvE26PFZuQh858uLLuBDU836lZB3l3nocvgFrcA+rd57sCzIkYXSlGP1xN8qsZGtjTxD2Y88gjVvaqGVnf1WPnyYNlY+dNsv+uEfwmA/Ytxqeq8udVjqnQXQiB890xlnPjkA5zvsoZbl2fH0tNN8i2MZQ7moQjCr4F7yzyuGO5Vu3Pdm8UF2gnKBxLG2IF3RZJ1vVBBVupy+zhK37bzple1TRwlrX/YZPgvnx+X1a+D+f8/8Tbi5XjEh6sJ0bl6aCVRo+1/6R5U8HJnvbp4Cgnzb73xNJjZh0I15uGfLiMN7rdk2eiIDrLc9zUHa6J/uk7Sw+pvUgbC/utJ+XiiQZIgS6GaTyPMcSaFeaiJnudmrOXdhwhp0OrA9Lcbem+q9cCByO0QGrfD/MA4F/wzZvnz943vz6p41uA9uOA75vvP6084dSqIByVO0K8teHtS7RA+h3bNevKt0yXBWcnrs0kGsB8Q9vOfDoa6WPkPTdVyQMJPCw+tujzjrvxaLTjg2lyutpg2Z2UCKMkf/1a9K3Vd5SQNTtsVkX3qg9zSpvMOL4aX430EGjhVwaFNwU9+knMKHvc6sbHQmCVJGYFsnehaZd9MB72VrYKg/Jhm3ejx5SrakgJ3BJDyhxLpqkECRjPOLCDCjljERewpVftqmbJd6VR4ptkKfzJCxM0A9kHw5ykc3rWdYJLj+tYI/UkIo8SjjY0U1YCHKibdxKUhu5/WQZISVaB71U4SknWN+Wchq0Lc8aRa+G9Prdq1fU+crzwOx2sMj1+CNobLX34mC+4Xcs3LrmIMT4vI6hh6eqoGv4NQ2meLhjaD6K6VwxdKpvIGD5+1bdfvcGw/HNL9Z046vcxwFlLK9/1mpvzBZkfnF6OeOxm74DqQCIuM7wG0pJ8onbkb6cRoN5LnpEF+gbx3w5iMy/gX3yEivxjDKbaho41eT2uV9vq9K1iKBgUJmwH6bvcvo6ThJYMN8kOONNa0EJU4At9uCBMUjm2C8ZX6BCWCrhUIhjKEQGsp7ksMGgFMr2ipTZ/7l6da9hX/fp2msRS9O/v+b16XuoUhxqkj1Jc8uk1cFKWqEjw/BaWlN215aQu+ByduYRNVMlbdEc1qapsnV7h8soSi6rQr6A7kIbzXc10DQUviiZqva/CTT65ke7csrvrkxt+35oVRcMXDdUeNI5vyJ0tOkoRtlOWJftchYNAwdYqzLC7jzCOK/bkwyMOkPnBWh1U6V8u03mK4bu+hAKZonSxuqNQUstJFT7I/fdApiGY6PCoVcgczZN0/gLXsnmxBA2zCWzK7RmJ+J7jamWiurm503kUa2VUgOCcbRZTsgUqlwJOpIn4WJ9F2XL9sdVl/9WFxx4T13VueUpaWUGwdH5i/OQszorRlwDjFeMrVEkzOE7jFHYISfD0u6fNmgXNcjY3o7CQ9GXyW6DU9N7xZ2e/dYYRyefsagxTYe/kZU25ZApQHDzrW4ZRp5TWLAfZ169P9nH6WMMBg9O6DY6Pfjnxe2BqaugfHr3eP335Y3C4/18GjD3UzwOdtqpYQTeDs7udbnNrwdHhm79/MF3BpsuKpHNb6fdxV2U33hy8PfgDPbgTbxvZO/H6EFQMzK07HF6oLMxxdnS2APRkn95SySquoj7b5weMFEohwvaZfiRCh4luKkdr9QpcnYuuPNNC3S1Xx6cmmiUwoireAUR5rVggqgsqp3UsoXauUHDX5x11kmZX1k78xuCgxwSEXkcGwLmqwTFC6cGSXOIfSKKOJSB6w2rQPkN8EdJuuRElF8xaryc+Bip2hTShYDFMxaKLbwhIfeDdd1B2/hLj3dctRiohYS1UNxKEmlQSfIe2GgkcSFVE9fR7DMhX0o0O5ARKSgdc2GhgPhQK7KfOuZg9r2vu9+S65q6ERwxDwyIBWl7fqt2PtduLZ3yc2KZ7e5YenFAQ+bKkZ+ZyjY4TH+wyqEen94JccpJZSHRWO4zWXKvYHFcNgPNEXb+Gt2WgK/gWrrmFKE61XM5yxenXYiodLyz84GFbNHD6dNlxM7KpShH2y/Qs+R3JYC0GpMP13wnstrKPo+xjWupv+6y+qMP2iHs3r78x8dLfFnb62QNIly6E8v0P9wdzUSwE8wAoo8VQvn8ILov79MMDSDNaAuf7e8Gp8Ip78JRfxJgWM96LF0VyPIgJF9/6yIx4dIThYRD6dLFoIiy3oDJO1TsAeAR9IDFN/zEEoNAgN4KU38xu2/GIDH61em3xQqzpuXjRtXxvedGvlXeFetOtwpZZlkvn3j+ksolKldzV6TCUnFWrLVKQvN7ntqJEOiSFcTN2LctuNp2h0YyCNpuFhsrXdTXL6ZBwtmjYqLk7XNOP2cM6UiGW3ViffD2UMhoqgsSHf39yI2nc2u2/f/CCckq823JY5tCJy/w4pHDLGIcEdhkDN2tAkZjrHp+o0MKvFrXgNg2QwoWxnlt1D+nfBfwHG/j3HnA8lM7yn3E2HZJfMQysdaxdfq1eBbHH55O5RjPLD6NDbUW1IB7wRR4XpK4kudblkTsBcqyFu1DUPu9WzRfsHX1XVXMzy65LrtJ3VlU33Kya4olr1Ss5k1IR7PvCTqvowUvBWOH3ncoS6NeuW3V1x6lzJC/SLO+vbErdi0R84GDDwjtbVbg/VoXt0048M/+ZT9SmtGkyTgtqjXISF/i460sMFtPYK5Pn++4W59F2inue9V55znVWPtdD3y3PPG4XV/fdqsvLNLEr0N2+6tLs3m3hzqF7F6Au/GKKc0zc6tLi72wKCwdUl2YmcorT9b3Ka4FeVSyolgKKRrt3un9+un9yit6a/wzD/urK2fvkpnNbfw5/1m/DVfqSP/X61xB+tBvw8/2a97PTWIcCYf80YAg7XFP+vG/C3y6ArT8P//FVN7MjjdWfP1mzGDaepvM4PZ3SHVq5UXifq7TV3LpQjhkfdGP84m8df9peU6t51o+z7t5MsjcdfFtlno1/tiPcNzEFXwGZvpl+UjYLfwNsV6OriaBY4IkThY3b8XNJf+AnOFF92HHeZ769iziqg8uoI1OzijyVEmChUF/WSGk9WzyQKOZtaurXHlZEOj4POOKekpY71tMc1dKCgvAXsLAXoEvJPSdS5Ig5yZt9cIW+zhM0pmcTmO/zNKmQVf4R/+KV33TdJYl3A/WeXWfyOUN0WxJ1zhlE9RLqj5D2cKLU3aXTQHpmXv2GnQYC9U6Gy1PDmX7Ss+VN2fTQkEzD1gzwcdFCUO5Mm8rPLZzoTZAKOtqCvUJ6VywWZaEdVJD0jp3ah3cTMmMXU5GW+Es5yxW2h5zr9qRuRZYOu92n5UzgPNzPOG9Nmiw6m1p6w1RbvrSDBE0UB4nG3bdGn2vc1Lx1Ld7mpUc1D1VETbVrXVKQheStvykdfcHVJ9dIWndqLKplk9kVPedTTTDTDpGuRP9dDQiHLO9YR+Ny4bT00qI6DTcpchauTZp8nk4AFfmtDagLizej1ZUCQYruFphKzjzUL1E+E1Lokws94tIRtg14Ux6G9WCSpJ9NMdhlJZREp/TUVfhrruY67q0cslVA/AA7MdVsX6WeqbCsfroigD2h9b0w5WyKtE8EB5xjGNM6aQhZ1BubTlhBchiVIde8/0fAOrwrrKgmY5ll0ZVxMcvSfPVdLrSINBzsekPkLwjsEq8N7tFE+LKp/TTOKjy2qSyRRUhQ8eCXJH3Eq/AJx64NPzqhAkv+Gh6y5Lnx0bPjBX1V6jnz0/PnwcdGkPQ/nqk43uSY7toGltyts12FUCjnC+486ftOC2WGkQH43Ply6UN2RcVSVKXpCh898yRTO6F5EiJJ59m192o1pyXahV5Foy9VcwWT8tC3xwhRYVbYV8RR0II7uFU/CYfyE2arFyaS35mgoEmJ0ZT95wdUCaVoO+HuF7+rwLQwaLMJ7YYRafBAO5ED3ZYsrdIIFiWrHOr2CeKZ23JVCSXCqvIa2tFZI3Fr97EUudYBovpWhlEvd+HWF7uGRMpthWeBtV7YpZTu5DgSE4u+YpxczncQrbjSWilVmWXUvRGgGSXgC7BWOzJd+tmZulNi6Sd9vVZU1OM3lZVcdhZV//DYW1jZnu7Otb5+o0U8c27PlKMfgLCppF1US5Z2NQ3tCWjr1tUnYLC3YTN/OMY5AKBBGVVYqMeWqHl1clvax/bFXHSmppflTipijm0OrPZU259MFX80mV5qmRRQYSI+gGd2SNHKM0jZvUkv0TN58hSfykNiLO3r5L+9s48f3ltznllGnfCtQnzhjq8q5muRkQaw4uz57u7Liu4DKW8Ipb5UPC0H50Jz95C2rF1CpEn6ICLdF5/HFfgswSL+FkhYZBN8ZFfsksneGesc46DAWGtY98N/8t/Vgcffqgd4hFrqASxcoubCLlS9ZXhfZoDKzcsof/C0nXx7VB7/blwcTO4/GdkwdL8mfl8bjx/SBrpB/AmT/PuHTPFR8edImu8fJGgu/hxK/PAwHP4cSvxwT0rc6TVmh8hGr4cKM5rx/3C0vgrXRX6ii18/tRRAdO/2nj4wDwOb6iTv8DgarcGlY2n7hV1JYuSsG8zGFFMvUdKxwag0vG8nx9pkkeC3biNFZshwhcjtI2Xj4qsrxdS7oMLNYFHxpeU/2r6PT+pynKjoc9jiGzAEGSA9o3900YMJdDIrvng1iqm2eBFsDL6HRvIpTFFVZZH1hWlQar/hN+D0dQjonCw2aHkba/ZqN6EWb8wYWcHoDCNwasnMYlsAczau5PIyQG4JdL11WYiBXHrhVcpqi++31C0Gr95WSUOLDTb3arkfo60lPjurW8+f3JapJ1Ype6Z8M1NU9Sj4pkqL4r7UusPklDcd+6TrTcPvsFl3h27kpS+VxFapWzmwMxv5W2eEiOs1P1qP/9k8aj7+h/dG89tyi5DNK1LlsSXoyjNMzXZ3aBUYtbJUk8xY2Jrarsc/SuZMx1RorLl8BFQy6doxkqgsbhhviDLWsgJMG+iIk97jeRJIkO3ycj3NHiX7cuYziS/aV2XOVBlq2iQLRF585tEn+yRy4VG8IqV++o6AuvSgKN1Y8+X0alK4L+tyt+SweSdo8Y0SOYPV33yAqD8Ter1NPnhboD/pIE5/cdf1Jx83m086jzNgeS2F70dWVCSisly+06fiWEGfFNOHnHHSbzpUpV9yvk2/+YiQfsrZIBfhQ8FHZK04nGLP5FQwwPsCetuDOgK2OEGi0tMM03FWFEBs2CWkwSAdTT89fnTmOvzsjUYUStZcz2XWQKP6AjM1bjTqHi9WPCOKswxNqUbwmOIAHYPUOtlcQ1YN/UgVbk+OPk3UU1bNGB+xI2sdwPCeWEGcm1GShJhVYZh09LNyUBms7tr0qw4hzSVSi3o6qIchoLEU0nSSxAivvJ9k/8JZ1261/Bxf/QAVw1TxTgFpruRLBIOnV+g8qihzmYHgFMfZXZqITEQLdEISh1AytEfNR4kSEhfafG9sRwsCa9od6pgL1JUuAx2O5VbhMrOyorolL59Z5v7yK3+8GajbtSLjWYX/6SO6BXYvuz3t7rW8ouUe6NQfWB5gDgShiOMdYTO7BWNiObSZTi9w83Raz2zXNpodPgLZRLOMXbNPuXqcSxY6xQ62x4k7Jo/Fw8bnh+WjaeXlllehArr2zxDP87/SWb2JO6R6voB+A9uB0KMCd8R3D/2jQ7HywLHwXE8qatt8aAdQkDdbsoma9Xr70m4EPp2D74JWc7t08IKyjiQDNC1N0JqnLncyq6gzeJs/cO+t235eyiVfGVby8ZA19MbWq60XOr3+OYcyckglOOm3ce03cdVvy/vji37J1lNUlCJo3jn4PMo/q2cO8AERYJuPKDRHUZ4bwT+/itGa/0kKKE6pepgRt0T4WLB5jOkcH4KVwx4Fwdxrzi/TtCDVd8efaqY4PQNDJXNbpRcd3dzHTXUoefaBcXlHU4MgySmd83iRXrgkXlMp6LrxVqMHkQ3yfIqI7ohuurHUEpAVvFyLPj30ZTsnkv4uDcmqUjLVnCBYOtsZAvskaKahR8A+ONxNjSPyiMk5Ksq/KOpxC67/UPq5mEcxZGEBN54Ovb5pwji5BW+CeTS5AELTn24juKQHv3PnlWlcRfv9GJb8OV4S6scwQeftM1yXZ9E8T4+xbqggEGRLI2CIxxTiS0F/zqWa56iW9eetlZUzi47YnoqzsUjN69f+V+3M6HpUBVm+tQt/v4cfbfixsuLF1hbZb1CSbcLRMNRp5MDzMgVlbhKsBO163RlhhZtaQYyP+wowBdtw2PsrVCE3Pl1iGLiQd/do05Yoc5qXzuV+NJdANdEJZGuHHJGnBlp1fGUtjorQ0hLZ7GBRfnpVwObSqTlvB6switQxh3j0HD0Qb47EmwPx5j7xOEgbw+zPCQxygIgPVtBCJBRyFYyOJTDm2B4+Du2w+DlDZE4ABsdt51xjxpMJyyDNfubjA1tfJ+8MGfJYDXlssC4PuxpqAqpHOeZRdpdr5yJCHftOsgH0USx9po2+9sKG/2fyNI0qzmOqDMB8RDS/csLncR1HvVeYxqmKN0CKCX+aO33KiCtn50iMlBnVURCWXtB4vECVtDdLrCthgIKrUaTdaUFAwsYuec3JpUBgXGZOLpF6lsi3BD5Sjr52lm8okrwsvjwF2VVqRWVUeAmb2oVTk02/mLZD/64T5cqKPWZZDXPRZ6ZFSvA9tLjBS6D4fJRNPpqOmyR67oCAUfAdLxvjAFAuRduhX3anfDdbSy+QNIuNPOLYxguXrLZHX8LkkpA+3tMklrxXIVdQctR28KFm2deRVtTAOcP6kawipvyKCk7BoWFUepOcG0BT7u+t/uPsu/fJdzv615O1+oIATm+jETImqIi0AJlm7KhNuHoBmrSC4V9exXC+GIwx3AOuazjECvVVmesGx3w2yooQ+suOKyh4UYocp6C3pZPYmdh9wlgvnPLFi+cjimVkUVYvG7FZdHOUb0wqEGz4J5lqd2TtY07SH4Nfv5wmabi5DhIKhNq/B51NnKqdTVTHoTxxi1qMYqVvD0dToCJ8r2IIiDUqbtsIYzdGid/d0DHN9NFOCP+fE830eIY8jPUQBhK2PnW1xiMSLcUHeVw3W3o/mFKsQyllIODV/hwZiToxg5Wjs9kw5aA3GffoO4TcjIU6ewVGNFsNNtedcYpxB4DltXc2dgISV/K5k3xma91DJ+on6t9eyMx5Op4W6fkwRTKY8JyynPqx/biY/xa5Pp15rCo0UXVf4kyP4UsJgH4l11IvldQUWM7gphOgfZx6VqWy4fePO3oLFu5zGA/0LW5YPv31inilSX4d8mu9STrCqLH4UOKNhIOVG8oN7bAqLvSW0it9FaFvDQsm2c6wJBLRvqSa4SX232ocnBZag31Gfv0TSU6MlLijP4MdXSJ2S6hPNfqCJwLm0O64cksMXGfPow4jCCtniVI7hcpRrrInyoAoY52/DbVaUHTEeNmAnTiLsQ16b5DTjgOj1S7ckzKH+KGoq3amX2RfWsMqtOiIjskg/L2jVjmRiAo++zrJq0pLG1E17IY0FFT4F7ZIgQaIIwej6UA/CaKvkhM/OQICm6zXm1zcBeG8RX5vSE4tFyDz8L0hGZY3IDgE/b1BmIj1BkTOwWofQJtp8sUFgZH4vc2/uu4OOTKKGHLA3RFrOtyn+r8trJ6NI1CEZnMrGAJPQxDd5sVX2sKTMHcmIkrPn/gtizAUv2WQb/MU+bHirkAmEveAGnVcmekV++M3ITYL8m4a04MxTYzh9e74oN6czvEsh29hS9HRlMOpq0zntAN2c9M8P+JaKHIm08mX8fQqr7mGvMAT4Rm93DEzbl5Zczqh9ehZwHsf1U9Yhu0yKg6qKoRAw7tXN6KsrG4WPFicARYSY9ezGenpBGsKTOh0nvML5uuO6DdOx1LCize1XuELRCHLG3phPdOjL0PcxNOh/jz97Sqbp6/Yn4eD0a+bF6nrjQq2PysfX1NjTQoVx1t/1WzdHx/Cd/t34+s/oU0IbztPaD8IZefZ8+VIt9vfFut2+89G+z5eWuZtAI56LwyGzCw/S+5aIivlTQNXSp387Q2kum95YcyTSVghPt1J8K9sFrpCq/+fJ//IZg05Wu7cj4V/zQGQw8E0KZ2156ws+KChvXl8SZH8qQ1qu0nB/xG9UJDwsf48Hpll/Jn3MMR45IcDpxuyR29JlQJEmqSz4EDK7VxLQPMaZykhbsOXBbTsQad6iBG/ioFFaj6+o/yzT+b9z3E6+s+TBxI6xVq/5g8ntToQkM4SOzIGTZ1Vb9IRApLfp/wtx+zwnjhQihz0O8XbIo6W52t3vCxV63gwIdKS/rd7t/p3DkBtrYxWXF/Q06Lrjpk14giClLiylfxw6vZXbLYEqjSrqc/V9nxrd+UDVCuhY5UpPRAYBObxWFcdEMPaM7OkWmcTtnKgCi48kFiCv4EiNkQNzDUi1nA0yG+C8ssm2BscCx4lM8606NpWP49zXZJVs5EvhBdX54acx1vk/Oom0E4dO14t4+4hLcDe31hKH8lVS5wgRqIt3OVEnH+v7c25zdxSUW9miH1RCVJHA/Z9UylM+Xldm541Gz12CvCRVzPJrHDWkB7OIhPFWU4TVOgfOZLSxRye4xu6XPTrV6lE4MuMNywxHoLTjFe5XHCoUwbrSiivzMNElAB0hJLgbvHL/UdMKHD7IFH2aZ4VSzaSFdLMyDGM52W+ZJB4L8mPlYDSL4c0jAx8+4tr1U5VBpsKhDUs4S9xSzanbmUqKC5j99iPupWxhF+raguKj/rwMl9e3A2/KBNeMh2v0TVUdXoOCefpZ1TRlP/SuXyHVhYfi8fR5DrKd2TTwl8N5itsr5PoLJWAucn0E22JVKb6xryUHx1RWfLZwSzyE1UZ9IGpcngr2yb8wFT1QkMot3rwi9KvL3Ti9QWm8CGIHEshiph4lWnk4Ce96mTTizuKBDNukpQUfsqS4rKDZ8jZxaVMJiQqZ+OGWG9NmRP3uYNhjUuIxZ5LNwka1GGodg7Dp3Nc/GFZFKWEbaUllNUAuFirVA9x2EHPMnPqBh9m8aQP0PSvszj9Kfucjo5R99z9hh0NvsNGlnS3XCAvvsBG0AMDis3sc01jxn1FoSiVLlJ6tAgnRq1jnrjAhGYeRyDboRUmhU1gLuETWDGxQ1+VqJxu5di8djUpsmKUJiDzRtEgRWlVO4mu1RsE8mzEEiJG9tHOALXnJgeYfHmZjZJwUbXBVVFgHFCqPCCZQBQgdZYwwYyoqfCW09tdLW8swz5eENfBO7Vercw5c36hZ2+SjWlr8npu1hCUw/P0evrRyOEwal7O06EUiJq4d7tGJWSeAc5pWMNctcAuRByzkizHBURbtLW8bE4nMWyU0CtI3hFMr+lNQK1XOpXNczY4AwQ96/Ag1R6YPjo4krCzen/VaXU2xVxkxzXwdAl5R6h8Qm2/SsPBD+rqoFjrfKW2X8nIaTMVYw5ZFaufrURYwRRA8Z7OLRfSJfQ2x8xEzCb9+9MlRc6vplXl+FjTK/InliwBankifW8WxaT0IYbAX5c7Qe2yKGY7a2ufPn1qfuo2p/OLtfb29tYaHo7RP2/f1PQCUFG402q11iCTCn3GfewimNtrlM0F8bh6SUHM5oIL4P3X2zeMp+6WKj7JF+NJ2Ws116tJVkrZSEZq6uRmEZoBI2SfZU6zytogmypnNEkNOBrS0W7DnK9TOBx096OXqUIHinGFzup1dgEm5Gp1JeusUpn2bEFsBOGu8hChMfU8yqUxdDSrFmmHJ6Gp3OfSZ+p9xZ1F4tN5GtKmFJ28InLiA+9TMTA0hBJ3EQ8ntwbQhwpnRqBUERRKLKEnomSXyTw/oTuJWNckx+AeWrYuICH1zxY25O9aCSH0ylonZKq8P6lJfXOWSkqxQlxQlFQVZGfRekYF3HcTjceSxLKyrttYYoYzfbRIf3TQopRwnE1gwx19bgR5kc6MYqQfpnfef6hj0YDcY3GbjtZ189TcA3vFfWAg1r/OPcwVSLILc+PmX124TYWjz1Zh7A96KtAfXbAWTb6gK6/kruBfq5KQtEbEqd1JVblOaJOVk9SVeD3g8pTQEtpwCSYOO/6Z2ygwe/ej+JKvoTDohtZYbAcgbowPtJa0xQWU1sFfTX0tiz/dldHyoFKvItlqGdfhOeK4mHDZEt2uL1yiXV8s3GBA3mKWgim+dMkLaviHMEI47uSuXWfppxfTz1CsD3IJ/uficLaoHhWrqeKLSjGQmu6RTRYo7dOElHObKLR/qfDu8iiBLl6H6BykxJQLFnZ5SsGIxRe/ZS2ukG2ZPy2rzEES1o5Wa+hvZPs84xTC+cMLbVBbraEDEt4IwKsajlEUIGSJMqvCPp3iz2R0q4K+RXtTh5Yf/teTmyzB53D08aUYcG8fHSTWZCimOhy4ngIO+miwDBFz0wwAqiOkXcfBJ3ftA5S0yELgZLKNQF3T4+00f1VtvLu08UYTqWy85yNn482ocH2HAzip/PivvR3RJCifMhuBMCf/ZyE22siOKcEcWuOXOc71yMpFxBAtZcUWLLqyB0ad+DIiTib+2cuta0ncOyU4bj2iVE6K7v+DFCFPzqWkAK5xKIFM/v8eHfC4E6XBAlJcpBO8dD2de1PXpC+av+USPIlh1zab5myZFaOdTsF5q54+5Tz+qrbZkX1tHM1UIvykpOkgT+fXGrx8Ys5vV+mVTqePTrXhj5JJvu/pNuUTc/DujcGRvxwJU1xG3jSCBFdooqxcQGlDENcEpJOVEYhTUuPj6j9TbB02SVneCZRefC55AqviWS5xr00VTzFnAP2TL+PBdNREnz3sxdkO9VmubVsCmlDE8AD4Qxnn8XVc6/Hfhs4Wz0IVz67xyFinFUC3ouAti3PDa0cAUG91fVXEggMlH8nV74rxYaa0x+Y7YdRQdb8RFPqNap72fF6WSXjb1TZSUfyHH+tjxUDVb07YyE5PItu3B+h2nvj9CxesrHBUTCMi+Nlju5SxsdxW90lmicNwkhZiAJUsGuHdZONNXUQjh9X07WD1oeSU+VYiSO4YC4dh2AYFP4wvcfrpbZhhWlaGzP2Lh7GzW6nJD1z7lrGa+KFpbOY5XbZH/teuJnQt0SoizJgmQT4dpzCpJxccCZ5njUKzPHuM5Zy6HH52LtTr82wt7T+Tlw1/aIFu7QdlW63GxRgd7TsKkPG5hMCk4ryoav7tCPDnQeiMfkO7Wih3CnVxdafkl0dLIk87pzN5w/QIS9TLsbrvFjPV09qZ+a7oUPOlgs2UHPFO/3k5L/nU1f6qZpLmh1r9zgErUdsEKdfH6Tg4S0TRAutHJ7RDoairUTKdtU4hk83STsjoCjjS3+lQQTFWKPprMhhVt22YJJa2Itzt1XOvFrEpIEqSfWwWX9PCDrIduKGBWgYqdaHMOB7bzbgn3hUalDTIJwP3afPWKEburTLTI76VI56OlnFDH/tT7DM2c9hx/xc8YcMAWOXIyy/ZVD5M49Tx36eJL9P44wD23tW1KFvdwOcaqBEuKD2GdSWbkSiQFFKZYb7bn/IerH6NhUwTq6quD9q6e6kMSvJi/BG7CzeCcMoKnfO02YIXbixi7D7y3j3wuPt+QycHXvbY5VeDcea+7LCIzDU6MKrdRd8a83FtWdfEqKd6VSEUQBF2lRPUjG3VBNgwx3te31g/YbVDQ1+gpixBnFRyR5qxkl6pgdj6BWsUVBhtV3Yslko1A2MI/H+lZFDQBK1iMKGakmjkaoXaIUXzy2xYhN6SZlYyYc0/oltIQ2L9fl7SKTxEfN3i3PGIB+TO/++oEFXco3WHBduPO9b00tHBd7IpRbVrXuDJwXRmnx9QMhvX4QdZR6EEJ0xn/E3W9xBt1P5JQz34PuiwUjdlA740wkBbDTyG2MFAAEFXWf6VFZ8OIUhcNChigB00kX7HaTYKGfIqg8R7kYR6PfjKFxZFyoB8gCYmrjBhLFagke8C1egC4SH7c0d8SJol+yxflMdZ/honGR6AAa0yescRcWjxD4ooF9Az9+aW+DfdzIlI5CCd5dvYD9m/sRHC6TwnVbztIxdqqo7xcU69QM+1Plc7a0gwexBI5Jf9a3Qd5fE8mxU1FS6fgXJr6ibjL9w2tmTb4S0ThpRvOKq4JDaBcONsgjEQljh6aOCuyapIx7MRVPXMmJwIgwMUBz74NMfjlLmjIGtVUZ6utzXjXJnA1fP2eO15FrHhqy+/8Z72VOn4MCOmScr/gvLyKRp9xIYzSGkEvzaCcSP4qJlHruoiI8pU8qcpX96d7OI6alhlxpNUF+5nTlAuyraCEeC5he1PTB3or6x8lPAjluuwdBjP9r9/vLo63UED/0c6glj9wVxdMsGL3OhbCMyJn0T9+5UFylha0137Fbo2xq796oZcQtpJ2f6vZ7tWDp1TY+6S3ulljQZFu525BTwiyAB6Zz6v5PP1PLqgE736rgfkfuQSojlf2KJztofdcuBXBMYPbE5zoRtMEJAD51H5VwWYUnMGos0iCobJVVND8aAEWeAWeOLJ1LJ0DqA7Buw1w0LzJbDjrJiXe3gSlcfndJ6mv1AeDXaDWOE1m+lOfjz65fzl0du3+4enDZmZHDhMQ2XJzcBJWNP5nsO+wolSJr6az/E01CEwRyab7qxx9C6s0cR/fq6IJUad7K+4ZcQdo1NHRnQH79YjupYWcqn/oycXrAnyTBrLzsoooHOv9APEK0jIOGUe5DmRnbH4qi9CxAmjQYwcY3WE5zoygOJA2bzn5jYogR65pm9UMigJWzxVAUjbWDVUPRGpjWupPWOwWl1QFSi7voKFnlbq9AJ/o41MLQqe4DfbIlVimR+BKsNat67RzCawOP94+vaNXjSsAHn+0TLfsiO2MxBi9gZoqCA3t40FB7ALXRxmEW0G7KOJURoNYftUEWFBcjqhXJbq2jrDG+1fqHJDBclcolI7qsdvmufkR+teeqCALYsJSS5uwmr4GwCTOytBosBGNStTTrNdnDQuPm54nlHovsd5XlM2KIWqjRiGr3IYDFv0zz3e2Nw1dr11x4lHRK3SCe3GESg6iUU6vlegh5fzO74Xv2JYJQWq+Jb/Iz21ci3T9E6y65o1s2nu2UwrOAhwVARHsA35idy6dtAr4dZ/ilO5R9NcJXi/4UuOJ2TImc73RqOwNpunVKJPF0rObAz4ISkQRSI5nGWBySDku8wuLkfo5LGYgpellZ5Ai2ePKTcYTeOPZaXAcryepGE5PwguR02NxgsEIqB8zSAIKN0WtdR1tDlSfLIaG2ZRK778bXV1nKwCjWolOLfeN1ILcLhIizcwLFd4j50bIuiHHBatjDb3pwS8SsW4g+RsylgdSevmhLimBiOseq7N7QHXwUBu90GeMXKn0j0QQ12MG8IY2aWGFLaqwkKE8T8g+Ty9QHvxfBHdG4GGVGYGonZluj/AAU0wxAzHrEEjdwdXuICrnm1zVmutyjV8gWIT/45FxhEj3EzFrmwMO7qIXaO8ZUdyqpedMWl73sKjYLkLzxhDrxoT302Qp6CmZcWXN+l1ij7To+k0x+AjQFIMGlqbpFfFPBrVXA86H6+ud+P4/kK1LFDJ64LUYHQDqzezpKHCTs2jT02KeR+eiLjVezq1Utlq1jI9qqT6jK+KkjPBW06z3d0oihTZnxHCfSKZavvDjn1Zj0+ZxCJHBzRy0kRWubriNil/gwG2HR+LBr52BCksOOyTHTy+rJu7oynoy5NiVe4BrMIH2lFXoTZMzlUm1yM1De51bmRoNpl+ck1wkCCcINsFUsocYxWeuTSpnG+mmrGZ0nOiUamLXGj8fHGgSUcY2F68KfCDfOCy+KP2gYPf5KYCskM7qcBvRw/UKBEI19EEU8Lkil9bUP7Y93Z70hc/0+I0G6fTqyKskCvawuzEGgQpJ81WyBCNMnZGEbHgJu54bNUYggQjGKZOg1+gM9q+7Drv7JlqE2YHTBpQ2c1DdnTvEelHYc7xmbxVZJ2O2fA+DiUf1ZvyRd5aNrmmtwOxsn0RWNfqtNd761vdzfVeRe1iimFdYD9eTAOUmjp4shkM457GIC0vYt0xvGiDH0AiWzi6gTVxGKSUxSJ0tUZ6rKIQ4bfQg8BfCHi0uxLxKAAwFJKV2Hq4El2DpLqZX3W880AAygcFulrFUJfBV/IXTiDXfAgJSycEkcKyeBtU6W5FsGb4Gq8cepBsJKQb7tUB6RpfyBlEyuVLYqG//7SyU//6fu39moqELkFx1WyVi3dcvN88u2k1OrcLS4t/sGnM8kVWrsJAXkKDtmF620c3dER5//o1gLbe583zszWrGUp/nz9Zc5ouT4LRKL2IRoR6zeZA8j7Pd9bWriazjxewRR6TdsddNFQUh3fxZ+/ca7O/dGW/2/Fd3N5Lq/6ivT8rYA/c098TDccX0Sw4oGQEzyyNw5KLtAcO+WrifQV9lX/rn7HHVzwmqdVerZIlfrP24XBwr429690BRKvewTtRZUQtE7X0Y4SktkLKONk6wy3GhglOG2cTMU2wnGITCkA58ze39m0XpjtB6CgPHT6ekBRWOY2PsSVWJMOL2rbMd+b3WBYYN6X6LtN0+QDFjRBX2rXcqfySJmGboKl5gWkRZNdk0g7OptUNnVXB8vgWNuxe+ENtjfncKSsp1yi3Mj5+8nY616PKPU7/GtYBjMYSzbIF4YsQKBQS0ObXHtSwg3xqXrQ3R06YUGhD719DbthBn67YuMeImOLKpnt4ksnF+WdKwzZx9KbJF9gqY3CtX7BMmSlz2L7ZLmQEzuY2H4Qac1yDPpF6LxeFVOMaGfXiO7PFJ9DGQc0vOZ7VGIdaQyFzp0eZQKryKFsE7LbMOqNsMI/mX5S0fsOfwTMvktGinZkmoVTsKEE9t7lNsQgxO/2cm3J3b/xmJoE774b4UduNUswnFoay61Sl5FO8IqafGjIsMFoNtck7jS4u0kQv38GITtVHuQh23aJm/Yt5NLu8zv5VksSXxahUGNIqyo11QfzNqWMdx8M27srTY04skE5DyRXrUpJfBXp2nIL2MkaBkwQ89EBVlanUHNs2SNrOX+wU0BY1jFUXxnmpr6NpEuWXpe5Gv/klQeZkEYwvRoSD8UtXKbxebSfwQywC/4bRHG280xJYHLqjV0fB1QwGJKFwkza0v2xTKQoJWMK0HMrxASCTbgle0i3BenUVf3z1goP8qfJ2Gpc6QFe7vASPPPDyku055OLKd6jZbHJCQ2Js8hc5Rx4NQzuEElJSEHujWisfxwgjsl1Kc2PJfMbFfhpVzI3ZaFqUSHF+TlZ6VVg+He3FB6QyCZDJpE89Vkk6A/aM6GW6K9hF8GooIBQWdH4PWhlV4giMCh5/+f2qitLo1nDzZDJOZ1OMcFSiiMooUeVaywB72dadO+GH3BJoC/bKD522/LTaqlM7ima6yYqIa3rjkxewA4ubBh7Qdi5HhdQUX1/rxvFwuN0bJp1ku5tEve562tvc6mwPOoPW5ibwVhJF8WbUHsKvNG7Bn810EK+vdzu9djyM263tpLOdbrWSpNPurW9uDeNBJxoO2+nmYDhM4l532N3YjOP1rWE62NzowVe3t5VuRgP4b7M72K7VmxhPmL2HEs8DLhrNLqOBsft9g/72NpKNTroZd9vd1qAdR+lWN06ire1uayNt9wYbrWG3m/bWO6102GltbGz1onZ3I93a2OwMYiBSJ12HCsP1YdQZDjaS4WYyHG5uDrfjjaS93VtvDVKgSjRch5+bna3NtEO9Xh+sbw+H8ebWRrK0v3E0z79hX1vrW2ncTYbQ4612uxXDgALKUXezC6O1NYg32pvD4aDXWe91uu1hNxp0NlqtjVZ3s9fuDTfi9bjT7UQb6TDuDQbQh7jVbXV77Y2NGOoM2jAwWxtRt5tANwfbwzb83Gxvb0Ih4I5Buj7cXN7XrPjyCY9dviUzb291eyn0q9MexnF7Ewa5nQzizjDdittRJ20NuuudbgRjlW5vDjbiFLqTdqK4k3ZaUWe7lfS2Br12tD4ctLagS9Fm1Gq3er3eJrAGEGorGgLEwVYa9VrD9Tje3AS2jpLNrSQZtjaHvWhph5MsGk8nybfs71Zvex1GYriRtDahfzBJ1weDrWGnvdlJBuvraTcdtoa97jbwenu4tdmLBhuDqNfeGnQ6G9Fmt7XdjoDLN3sbw9ZgmPaG2x2o19ruDWAuD7q9HrB+p9WNemkEhNvcAFq1o62ktT0E0L3ORmdpf4ejyKwI36Cz0eaglWyvR8CaW52tYdLudnubG9F2dx3GAubeZtKB0Uo7QxjjpNvd2O50t7eBrduD9nq700p4yAfrw/ZmK9kAubWVxJud3hCHOAGgMPd7raSDk6LVTtfjLZjyG4N1INtGt9tqtZZ2FhT7q5yetf6Wsmpz2O721tvtzlZ3vRXHWzDeW3Erag16w2gj6iRDYPfWcKO3sbEOCPZ66xEwZ7odpb2tjeEQORoGvhUDi0LP1re728DA6Xbc7qUg7LbSXgpCL+kMuluDrfUtmAYgz6MWSIkI/m1tDJf2GHedFIL/m07gdrLdAskBjJbAKK5vb3bTGDDeghVkOEh6KIwGSbzeWh8MN9rtQdzb3oaZ14rag3Rza7AB8zXd7m4MgVc7IMZaadICVt2Ioy2Q9N24M9he7w63OoPhFswPENrRZi/eAqYYbEBCixiaAxzKc8CjL+NZFk2+bRfjqLO+sQ64gqxM4rS1vZ0A36Zb22m6AUPXgQUVhhcWHRC8MawbsM6kCSxE8VYXqiRbrSFQCSg0XIfVKx201uM2VIa1p9fZ6iXt3jaIOyq4BUKrPYRVbLjehYnRRh6Jlw7qLJ1cXGXftL+wYCSDdqfTTUHQDHF9afW2kFlBIYg343QwSGDM4/ZGO+mC/O22YURanV4XRBQswJ1o0EpxJEG09+BjO+71ks10uL2dbgw3gIaweg26G0kSb21vRe14ezuG6Q6re9TtAbdvtZbL5Fn2r39F37Cz8eZGt93aigbt3mZrC5gOWKvbhQVj2OmurwMPb/S22ptb7V6rM0g2Ixjajc3tXtQdbrcHwM+womzBkry+uQ3ztBt1enGPZnYLhHu3u54MEpjC6+vbMMLrIMxa0dYAmBoXraQzhMHeWNrZT2mE72R+w+5ubncjQKQDIqQL82fYWu8gD7ZaaQs0P1CtNoegPiUgnkA6D7e2QQyDbgnf3e52vJkMenEM49hbx5HvDjvrKXzDnAZ1Ioq3ozYIqHZrHf6mG5241YqArGkPctutDixpcXu5gNLPY0OncVuBt2dU2CkJhgdbLnwzu7i8wpC1eBkjgWUadiPF6EswJ2rhpY+JgjdI0YWVvQsTCtelrTzN4PQyy0FjHeFjMspEo+975rgL9Xc+VgswGmmCwMfT5GqUsjd/k7egR2937BipDW1PgWnqhj+hHNPmTkX8Bdn1yRHWTulwmaxN7ETIljzZu6mTfH+zKKHSm07f/PdZROObTobZxZX7yiid8uvt4x2tNNQZ5Q7+I4nHXOThLT+6rTudxBj1Fjb4SSck5naUMWrZlnU3jjheTcRgyFhKklL5lEpkiRVYX+rugYJKDvsmxNmZ0wxn3CgfCDd+cdXTOPR+Fo8uwbENCtjdCgucWAbx5/k5gYddeUDWeNw10yMYR7OUTyepBsUZPsh/muNzTBnzAb6IjgYXKs7vHEmy84E+vD/jUTbdvHkU2O8i0We+x7ajU2UEpMsDApe/EStyAjef7tYez3sw9YTfWXqEEUE+pn9DC8apmAytmCAYkOj/AOWG1o3zRQEA"
-)};
-const _wlval9 = function _stdlib(stdlib_5_8_9)
+)}
+
+function _stdlib(stdlib_5_8_9)
 {
   // We push the source into a DOM element so es-module-shims picks it up
   const script = document.createElement("script");
@@ -29952,11 +29555,14 @@ const _wlval9 = function _stdlib(stdlib_5_8_9)
   script.textContent = stdlib_5_8_9;
   document.body.appendChild(script);
   return import("https://unpkg.com/@observablehq/stdlib?module");
-};
-const _1g34bkz = function _marked_0_3_12(){return(
+}
+
+
+function _marked_0_3_12(){return(
 "H4sICLVeLmcAA21hcmtlZC5taW4uanMA7Ttdj+M2ku/7K2RO0C1astSeyeUustVKMNgFcsgiQZJ9stQ9ss22lZElhZLTM2t5kP9w93AH3L3eD8svuSqSkihb7ukk+3LAJRg3RdUXi8VisVhyx+M/GWNjF/O3bG1MjFg01/ljZhQxLxnHt6/z4j1PNtvKMFfUeHkznU7g51PbeL3lSVnlxZZx41/ZwwNn7x3D/OtXPxhfJyuWlWxNEX9bVUXpue4mqbb7pbPKd+5q++OPruQKEO6fzId9tqqSPDPpgexLZpQVT1YVmTX9BjMZPVTbpHSq/C3Q9heRrT06aZK9Lf3DUXbmBSKVPqvrwlmzh3ifVqV8xfcpK/29k+V8F6c9cGfzsLu6MntdVbwE+KCHKvu8Xh+g0mMrbWUyu6KH5KFHzK/OxZFyM122VU82zrI144z7PbGa3rrO2KOR9UE7fhqKPer40WrLc0AD1D9znnOT/CC0aMScx+8Nzn7aJ5zBo/FGwL8xCp4XjFfvHUJnpyoLeh1LzuK3PYWtVJ/X6wNEr4dYsHWcVcmqmYEGsOnX1Ju1xqBN9OHYAfAnrcXP9mn6UUM5VfVvmIBh0GdMUjeCUloQZ9Weg/UDWpHGK2ZWgXvlbjz3ygxGL4Lw0ZpRd2OTq3hXzAhtwdy56E2rXuet6Nz0O4no/Gmf97uvRfeLV59DbydWgoo9EwqkeWEGXri2aA1/X7xb3Ew+/3Lyl3jyEMkuEJTSWQA+wG6Xuj7Ayq9gbr7OHxl/HZfMpDZZ5WmeEd/3q4B48P8L0XZW25h/WZk3NCDvej1TGnwPXiPbOA88372Gztf5mpnCj32VVWbllPtlKSDMl9SefkapN4Rg6YBTACLkqGkg7U+Mz5wy3/MVdOLyJsTWrJTbZQvJA7P0SwVc16WNT60Czbt6cRcuIhreod4/mRJqI+0GACnZGfXQ2L5jmz+/K4QYmsnnPbk2C2IQi0V1bbp3izsvsrzQHQMLNxp/4joVK8FF0aAB85lFXOJ1j51kDY5NCEWZGhibuK7Uf5mCtzdv7Jc00PC8RViG30djQPQItSqPuKcTqEGbnXi0Q0Q1ACazqm6cW9giuqcY7fEBPNjPMTcqO7O5P53xecw3+x3LKvB3LNtU2xm3LHAIftu/4NEM0cCiwfjoN8sf2apywMtVefW+YM42Lr95zL5tvN4qTlMTyFNwTmyRRX4FP/TYGEEnT4FQdiJcfwLm0LyAoSPd/MHI4B3MSuJntnREMK9+bMLOpTmgDN0ZneGgUju3t37mbGEHTnEXtvf+zazi7w8pTFPK3gm5jqu4Wm1hf24MIIH2MffTRgFIauN3a09IyKiC1sj7WxsXuUCoBJ/K545YRWbacQLDZn55HMRnAVLwElP6WXqcAa/Rtq63Spr5q4bxxqT4cs1SVjGdjD3KdRicq9l+3g5nD/M50kcjYcFprBkZ+aAZVHcwmeR1Dfje1oQe9q6yQWVxtumcECqvdULBxqxgjYHUvg9TkPmCEKB1hBQdmD3msHIVw+7kj27sn/NkbTZAlILDMNPFHkyEpRDNoBYbTYEFDcw3LK1Gyd2k9uYVtLRydqws4w2zfBJm36YMPCVs1kXOKwN3EaPKPxJsOcQ2M32ro06ZgEorpWsyL26/BIPGoMDIV6s952ztzd3idl5wdkusUhMCfN3ohloEXuO7mQwqVscjms7eP4CvguiBee5dmFmujVMDbdM4fHqElZ5FVpiNKbx4YNkKwqmtveXi/XgxGd9H9PDKPhpj3Dsyq/6EuvaWxWvwyQAD3S8OU/uzI4WWpBVA88W4B58VIlADwmmHqsBpmAGsX0/o4eUJm2War97idiilHd9KDDPMYMsFvVFFYazETyEGlpDUXOJ6NqQDswIguuU1oNRhhmwA36DwE04RzgAZxnVYjsXYql0qBxZ4MGfoo5RQEqJepTnE06oPiWn9MLKzF0ATGAuS4QIHHeGgI88YzwN8LG/h+RZFNKwFMaNGLwtCIxr0FNJoEcwz3vC42OJo4X0ziUBkBONUOq4bZdedIusq3qAeKEXFg2fHJeThxoQU3ONs76BGWOW7SHdsTaIagonQAe57J6nYzu8rGPGkiJo6ZS8dtzipKRs22ewINV0Eg921YUYhytg7OH0CEhtDQGTLiU1C0IYZ+GE4RZ0JCwV50EZRDKkqCkwIDLMDJ9Yel5ra9S2CEMi0U41g3T02BASahL0H5fkExgmM4prtaghNclBvCUeEtC7rFQyx/qleP2R1vFyCvcVVXFfJjtW44mpYjHUJ0WH9drmuIbCBf0Wd1Mt6X6NPqPl++b7mVc2LermG/nVel0Wc1UDpEf4lWQkzl9bJbkPDcAn/HmFgI8/FeCV8DMPyi2j8Bb5CodGMxYiwAWNRpkxsdz6aTNTGDs701sWXwqTxnQlDpM2qmYduOG0BwJAQAgBg+GRxR6Ixqa8Xd9fR+BpEuCa3ER0HCO4CjJg4VJhUXWuxQqb2Sc0pSMmxKc1VPMsmdKZab9p1dxNF7JNpA6Yw73OccSnA2UTKU530/XvsgCOQempOfAflC4UneIPWVX/AX7owQgcsPvzewsUJZt/oksJqD6e99aqv0wte07roNY9KsCd0B9MPI8VfS4JKoZWRtzEdrIGpWAkvIYgjNQLjErsI9kqCSV3JI3ajHWBiHxp3LgYSfu+Mw9oZSz++mECAC2qpF5Pa8CLsRQclQaQXhdU5Vr6npRLWpiN3AmjhtgNU+hSMIQqgItac+22xW/v9cAL3P+5jqM7MjM6aA4Dc1+kRcLpAs4fNeueKNjgOOW4DHA8GYaaf0cIK+wz4r9e7v7mJb8SbfvfLT19+2hDRjsNwcIB9vC+WPCfrRzUcWBNow2nETmwRmdqxXdir3lkFVGt94m52eGKYsRmFyAXC3e5M76jAwGHv2ArGLIJqPEe1p65kcROpSI/a2sPt9OpKT/oU+3JrHlBgj4DTWjE4qQGCzgt9YMvoKS6+eNTGAGGKGoR9iaeINuVmNpjKCBIv0SYgs+QxCiJ7ERbiGUGXVa2jZ0j7tEAY4XrJ4mUkRUsWryI8mV5iqzzEH+Hbess1K6otcJw2OI0ILyONfQUz3rcIubZbEaSpPSHI1lecBR4RXo5xyVibw3GNK9iA4+sGFe+URZpUpis7XWrHcNbIhHR9rKdwVixNS6FUfWrlzCpgscIgwIeDWjHfOoJLc3Ip4OSCPCaWZ7RHcQWzKCD26to+EWlXIpyV9yyEFey2jLcYH0dI2QMw0Hrw9COOW430Yry69KoLgbvmqZpmZ6ayVYehU/NL//H2R3xMNeC0BlPvZWOC0+jiCuB/iDm/uLS6COGPMOio3JdVzCtgN+CvxrdGcO6wzARcN7j35xBn2friSMTW3YzhY6sz9aX3ucASaamR2DnHbOjaS1sX3w1uJ86+mhAYzMNB2R9N7ZWfNB5GGupK2iZgFpEd+02qATzFtqclUz9eGJZYtvaHrZNka/bumwdcu7BtgoOKJzqRYf/eIw2xVbtleN0bLWVHBBCxYosciTyVyLRajzoE9rz6GnRUXl0VI99fTWDbM3O/OZLIaYBxWtOIgp5A3b6f13Wq7ZJ5265rmKlEJekAhTo/5kkmXZTFQHlAHiQofV7X4MfkiUocSpXjoHYnBMfEA66tbZPGa1QEROwSeAEdetHYyoCkOQT99ziRygKUOWg9x579bm2Y7eyy/XbYynyfBJQww44Izyx/YJn25zDOkir5OwtIGznDSJEDsQvOvNEgNAcVE3gtvdcUd+1yxZOi0juq92kLQBvfdqP7tlEGYdLpFovH0HZ7feboxOXPQmyqveR85B+2nD2oGCOpIJ7G/fB4eYP/v729q5MAHPiD/9/pe6pEpTw9CU8GAmd20q6W32yr+lLv1pxcH8ppCfNRfksLUcF1BeKxuciAjifDBaT5R/ZzxCeDK5ed38x+lT0k4B2YAZ6zMPLMWL6vmIdXMGIoeGUlblPac6bG9Siy+Cv/IDPVmIkNzUUYvhkfjuEijEz6wgonzuj+NqKuHe+rHFc8gM3NxZ0xv40s84vaC12qnuita+956kFUH2NG4SSpU9/NQzcQCaKBVM28zdXYissoCBdmkpXJmtEwCk30KSEIAn+GIco2lwkn8ci1s1yHw2P6Qr4NI3GdBk0qIWXODCDv780m0UShHYzuaX0XjsNx1y2eYBMcgyhsh0pb3st8531U399TxAyXiCVYAnQtcalAblCbfPcbi7bZmsXdm4iGUwB5g5lmzHcbmLPVdl0IYYWCVYa0TSX7MG/zUbi4H7+JaoUkEjazlXMvVSSyp5oKQtAA6qDRRQ0zDnTwnhFeU8yUAi5q3XeBOSaGm6ySyAyHpbW4JlHXi0/gAkuBiKr3U1M2qEmkDMRuxRFpNsyBKSaY2Vk5anIFpmoPIyOwnjJbYUcTeamuNm+mz2/gh993Kod2f57PXp/N9xCJlsIQvsI+ooRtUq8TTq0+HLFswoAjCgHghzpSGWGO2X9TXN6A3t0Qr13LeWTBsnFsb0auhflHyjzcuw8fzuX48EEl1pERNpBNjWwiTKsRbNaKheuKTJuQWFZnNEKLXBtYJhJZYn4UTQ0wx0LQlj7m/RQPHQBjt6ZyA1r5vir2lZ5HymwuE2SlSJBVJnY0rqtUCOAHj7Z+HXtG5+TSF7NRPiEq29Rz1lLjz3HXqSV2iGGf3zjH5xAiX7THTzPzSxMiv5Pd5zMqC2R2cbZJmdyMOmL/TKl3+hovCH29k+ziJK1yvFvPqCf4yIiQ+5kYS7/aBGU3uS1uZDMtE4NASfY1vK3rUX/IYJRaxHa2CcbdiX2kkbm6gn0hNtxERiOoGDVY+d4f3Xin4KEb3/YQmhqgBmUqqyEuT9xw8D0cZF/olpy9Uv3F30tH4eeZQX/QnZTClrEXzubDcfQJ7rSVoy+Icp+tLKKsQM+q9S1WXvk/Ia9voiB1LexIS26VlkomY41LW0S2OKnYiexRBTZUOcLXH8Rquom6cg+YQdGhF9dYbLbKwZ9ne3Z8jrqqU80Mn+TkbvDMNd9fJxLV1FjrSrkQELLd7+LFdr+Rz3OT2WecEBFv9cxScHEAZwfefHRzidPyWRmxMz5Lbl4gCNvW76IIeCdKuqye58blZ0wQEVQjOkX25T3oqlKegP5jwnNpqU9I1fPgH3XgasdMh/ZJsTb6ZXa4UyIDtTpxL3GEwwmwT7Rk4YsiTEaiiqa3gIMBgXDv1aeHienx+pDJLt4wAVoqgL7UmsqH7sLOk2MSVq8fm0wm6KN+/eXf9SuvpvPf9E4stZuEeyxhDl0zXBwIBlbXsuzu11/+46wI8tdf/vNJfNH+FyRCGiL/dVZg+esv/927jHMOr46y/38I9VhfIXKLP63W6ueMJExTI8VmWjwEkRBMMGuSlyUc78s5n5Vwoq/8nl2W1P5rXG0dHmfrHDzCrfNPuPX65B2x0L1/rxz1ZxB+ZJZPrl5Av0VmpLG/7GhnmuDoZ85uDU+qoLsar+amdPitMNwZ2uTI51dXHO1RFE/B5sB83lbfVcG1KE6aI3NjlcZl6ZNrq0cUb8S+BcNP3llg76JsCU6j15aZBcwr5QUotUiYzV2kcitLmsIMIreO9i35CDzpK0Mr8hioVJt3r5GRxbCQqt/XJydqK4auik/A5FXI2Sw0bLc4g9dGsj5TkkyyKTVl/c29Vw/6GImAYEKUFoXogi4ZEJv7WnH/0JJ+hyMLQDLuKpVv+TkdUacz5NSqgOQpYO3TxiqxCiOTskjZ2sdzkqJQaGh60uRWYUPrDLWrjhjCLRrU4hxTZDT9oSJoMhfvAGVe4Vx08jeP82qZr9+L/kr0q0doKcwhZrBjDUpZcY3DgMYFMmb9htWu7CUgFaa2qzURm4rILgZyBq4Nkaz2RcJrIpOxYHMSRpiO10xV61D4kzMmo7PB0chXjeKbpz76halmuwYNW+ceDSOnQUTlFQSqbJ94gGfb/hJsHy1/yU9pQAA0yBv6G9aieWraJyHAkCNujj70gAWq0hevGQ7kb9999TrfFXnGMgi5MJzqOwAvUsnenpPoSoPb3QFY3sDZl3fXaz/GP8fyUgOOrnV98vbn5eV3WNgG/W3N8rH/3QmI8DeeXl2NHprydlFXkptDYDYMSZZX+9dwWhU5MIKe7Jpct4lUwIcw7NoQ4ZFwl/haxI9gsWihczi4nmheBDtnqv9HiMpB1GS3MUq+amQ14rTCdnYqNx+Sm5+ck5XxCcs7HYYoch7ebVSh8tkYu6wOF3VQXVZHFTZTgav70LK/NaqzHRYHqeyQtOT+Fzn972h6aXZRhfQzQ260jYgwHpK3EBnG+XRGM6UIQDKpFsro0mU9BfRXr6yO6qX388I8HR5jb58kACdo/a5N3UXAEfBmQE8/nIjTDI5pYohJm8nrBfzUAl+gFLB9I6EZlYXjxNKUIXF02aT+9Uwc7xeG6WKUj0l7R69kACh6WIHtqpIsT3ksMhOdW970GP1TwhbPjhJEVXNcgJNvzQFhT1Shm4YjKkPsUwjJUJRNDXPDV6d0dSriawLtWX0ToAjL60tPTJQtM5WlnWB8LtKV4gsUfGIQorO5Rkburc1dHIPInfsHdQsK8a/cSzV4eanHoqOdnR1um238IxqT1IEGtZ/FSS6wZJAdhBxmRs+H1bthxFEJO678UxCgL48x8uxSNSh4hPmNA1yU+oCmlwZU4oDOEwPdYI6D5iEAzMRO1YSflep4zUIVE35abTNSq7RZi2KVpkPe6STP0pIxG85aUU2Pp53r2lXlNrOuGuL3ioAEzNTOdfZ6WUd/3P0qjUs8+66r8ycy89D6QZN6z5EO2XXqOas7+T0C/ma2ouJDrP+tPig4LdZ1by9uS4pOfI339KKVTmzYTwJrc6vk0KpQBoHb989xq41zw8l6Fjlt5ujxqL5FOxztB9+9+6S+W8STv0f4czP53HIm0diDvuBF5CYzWQfgb+2i/V62cEpWfaMeBiKU2NQ+rGLULvQvrfwDfncMfk19ww0t9XEyuIZmDrDdxMZ6m4sMmS0zL4jaVWoJMPElFbbaHIZE6LIPHsH2hNhaGksgaEdvD7M3SpGe/LhYBGoIp0JCQRaH9a34SN/n0CxUUzag47vmY+QMHr4GNXIfu1PZwr/w9JWYaPm2gudEf1bz3xD3C5vsgeYDQOASUR807vL1PmVXVyQXH1F2Xzqyd/hlWhlIAEc9+oU38FWkpHp1Jf868W4dyKZ5HkEVx/Z6DL9p8+FZfqA5HGzVtTkk9iOcK/LHQP7xNmm+jFN6BAOd/S868FJGFUEAAA=="
-)};
-const _1xdoc65 = function _marked(marked_0_3_12)
+)}
+
+function _marked(marked_0_3_12)
 {
   // We push the source into a DOM element so es-module-shims picks it up
   const script = document.createElement("script");
@@ -29966,11 +29572,14 @@ const _1xdoc65 = function _marked(marked_0_3_12)
   script.setAttribute("data-mime", "application/javascript");
   script.textContent = marked_0_3_12;
   document.body.appendChild(script);
-};
-const _hpy1m5 = function _highlight_2_0_0(){return(
+}
+
+
+function _highlight_2_0_0(){return(
 "H4sICIUbNWcAA2hpZ2hsaWdodC5qc0AyLjAuMC5taW4uanMArVt5d9s4kv9/PwWNTsukRUv29L7Zacq01nbUHW98pCVn0rui4qEoWGJMkRoQ9DGm9rPvrwBespze422eJeEoFAqFusl093aMRThfRPjIzrfUePhT56BzYOTG6ej9T8ZFGPA45ejOQ9kJk+4i+pZGxeBe95927rI4kGESm9x6efCFIVyWTL/xQDLXlc8rntwZj2E8Sx5bLf2b51sAKY/uWi367rEsnvG7MOYztlNO86dVImTa52bRshzRapmiQ7S43HxZWzYr6aixajytlv7t+MtZ2TbHE7ui23oRXGYiNjS+tWWtzWrS14e6c7Eica8V3Z17/pzal+7L2k7pS7jdr2ac7PcrNuaryA/jXPInab3rhnbkdr1p5Mdzs+9k/pxb/X1z7D3uT9qWN8W8dLum+dU8Gn89nrSPc0/mVjsHrBdbltWdL+3YfQn8lN+G4HqchjJ84A4Lzpkd8Se+5KnDImYHSSyxLToBs0HjYyJm6NwzO82mF9idtnZYegHQyE/TK39JWK6YPeXzMHbYtGh9rNZOPzKbxzOHcfWbfgnl4pMveCwx9IXZYRTxuR85LMT8UxBlM36qcfHTamSgEAyYrflcAIjTckDNCzUf8Qc/DkCVYDb4HvqxBBUPzD5/P7i6uR0OHHY+ZPbnq/eD4ejseji4rSc+08zV58vTwVD1r9A9u20MnNHI6fnVyfDfm8OnNAxMo5uT4Q3QqsHhiGBPzj6OLk5GH24Ho7OTTwQLKk8+XY8APDy/+vX28vo9Rk9Gl8z+7fP1zWBz/Dca//RheDI6ubj9cj18PyomPn25JNouzq8Gt2fXl5d0BD1zdnGmpk4vrs8+vp47pbkPRM/mxAcaL06kR64uG2cvVtPY5un1xKkCHo1egY9GND4c/Dr4/VMxNsTAzfnNxaDo31xuXEVz6jPNFVQCWSFYQ9zsdKhEiZp8WEkQdcNhJc/UjdCVXCzD2JeJgBjIZv9WiaUcsLU9c9lRN1358TGzF1AUku1PAor+5DDS6H2s86dDDqWEaMVZFNlZyk+Hzs6hHRVqkToPSTgzDta9UvWNW7JohWngHaGXm91Wd26zlr9c9ZhVjx6p0UhuDB6rwTkNriu00w20cTLjpIcdmVwkj1ycQcvNBvTS5LbQNki6sGW8AwYFprB6BQrZah24MHkd2Fb+VC/MGtuIjuSpxEA9PajMNYwPbFjsngjhP3dWIpEJ2c+OMvKdwI8i0xfzbAmdT+1Dq3eXCFMYIYi35FhMXI6vkpi4g9mBHyzMpld4awUstqypmZfU+LCzJbJqlpsgUqMhmNgVnbtQpPJsEUazXtyL3bgTw9SOwmkUxnPrJ/AjVpy9wUH6sl30/upHGe9EPJ7LhXO4AQRv4ndWWbowX/iDsm6p9AUELrm7S7l0pE2QTkxkw+HEoMeemrHVWfoSp+1ORb4Qebic52G8ymTXyvMtfMnqDXT1Pa5x0weW7ddcCYgr4Z0Zt1o7oBuSerIKh7jJRPBZzQ/N2tfz7s6BHVvEapyNj2M0NOetnolrzfPxxOrAYwQ+BKPzoPvl7QXWuibjwQyxWdmLmuJL8pgmmQh4nvN6RaqFthQK/mgM+XzwtDJpsc2WrG2GneC8D6/hMGa1TdFnc9W01lU8YQhT2poBOxKULldhRMdGv+7SKeGPIf73eS4704/U06IUk1j7biWIGhm2JX64rxTOsnGQVRRKkxnMelOKdWxTgeXM6oGp4wOwdSxtMT6c9K+y5ZRD1tG2nEPI+LqHexeQyTooAX1932SFe2aKXicx6efNbX3wEpNjPrFI+HDWeC070dBNsSbK86732O7aO5AcEmJigf5xmedNTdamkebRviVhrKhvMwsQjHBO81wt6XqnOeIRNaQ3mFIblnYEE3WSKs+t0HO3nCO28y8KAW8i0NRwjYZbNCQHbqQ6iADp4PwLyY8cKEg5aLs02QdtSihoRi0L1XyoMYUYIgtOFk+oCeEeElSgSAhgP1Rvy5xpUe/4q1X0TOEfYKC8qw1evzI8pmhY0AcooYA5DBZ8dluGJioIfTUG6/TwPcwDWLKXB+WC1hBHqL+9tT7PheLMGMDWBHoJY2kyio0hRC7MmaMX0gHeEhhBAqNlRdkwEAlNKtrYtEeCHLh/cH4OkelDfDp9hKAMFzFVstLpMwftdWU2xnRrdEETS6GKIMFhBBdtniZJxP3Y6gHCDQqT208bm5F9KA0Yol9vjK3GXz3Pm0xybGXtefg1vX4fPXN8uP/zZHyArz2LZrtwVwfQbUhR4B70gqPSqveCdltraujGCM5hb8bBRPusg6OArHzbhe88OErLFRo8AT+UY02tHllcJWEJtK/tpr2p4P79mpodBNJaoc0DO9Eu18I+zYliuJ3ANBSbwOZ5Hm6PhvDXaiVkLYCQhtsjva4wHjRltUPLIVJpgc3MYmmrFeN463VxTf7aDGzSZNJ+54XId7aTGiVr+AcjXhvoM7oAO1BedcNo2/BMpSfePaKYylDhlMt222bcZ8xZdBrxVem9iFbe3mXHu1ZbtE1JgLPGfiHomcINg5YdN+ukF/0GobQbd7cMJYHRXcCQ7FyOqTexijPdmgMtxrDH/TOT5uwBuGDfFXDOyBzY1CxFj9pFhFd53IOjTJmQOUSiI7T9LBBgAO4aNwv1LiNEaOoDBRA2okYwfG1azutDaP7ZPjgbEuk7Gax6k2aSw5jEVkB+M1hxYE/lOckLBqSrhpQcAlj2rLjtYl1DuIRdBHowAL6bQfylHboROdOA5G3DqTk0ZMPZ+Z37zsJPrx/jTyJZcSGfIQ2tFobH0N0+cYBD7GxsBymgRbemxA+ST0eRoDogepPk1wSXEteuaYYJI07ZAxy6FoeEjA3kAVb5ClaBfmwwhcQYP1mZZgfQO4mc335Z6ZTzRV2Ak63XDdkqjAnYDQ/CC+cgSrZD8uyDnrYym9ZHjdFtqVuR4D8FlqWx6smjuCehbsC7JCM/lhM4RdhPq3IJamzLOZbjQ9f03WqhZhK3iLmNgMivk4Xxvtf1vK/v9tr9jmnlY2/ysp5QAuF571pMhU2W9hfAuIYkZMpUyZIemPj7cNUHE4RDjvQUtFDHsokH8JOnylXj2xxg1LIRdOjx/oEjymPryOl16F0wgQ/R0Xa7J+jkqa4FwMN09BX1LOFW7ZJRaywnn1ZSCqQFCDkqM8NtKKNbGp5M3YjfPA/4NKCQmg+I/OpUNEDHpPP0MogROpCrmUXKj9V5TuqMJZDwjHTczPCr97Z2KAEoya4zmNJpmvH23ZazdLuYHhITyzHSSFDZYCade1Pm9CY7cETEzpDESd+kJRcieVSh8kAInH73XOfFhk6IDdhfAQNrgDPGErkDDZh0YsRSR1kcg8zZMaKmXbZbnYX4ZJfE5PnhmtgbuScQQ2Wdou1dP8f3cfKIKL+sFtE+XGN9gINX8uFDRWWeR/YdhdiINJm+MFycD6ZGPR8Wp2CyX1wKDItfq3l7qjGRWbDncOFSPFfhwMq+socYyzqyYR6H9sqlkTL9ta5cBGgN0wiA0iGvlLkausVA+0ob3grcHGrz2SvJfItiEqOCky/Cmdva9kyrioGDMCtZkTEKVA6oUxXeWfI0xXSrtX8IZlR9Tcr1ncmKm2WlJQH2gwL7LU627ulb4Y0UbKSzF6Qteb6oPBJCxcS8tAqd3UADvcIB414V0RWB2UkVog3/KMuh+EDC0YEB1W4ueUBx7Cuf6ZMGUjcuujFZT4o6/WqB1heOYHF2O0VW6voI3eszrRoR56JTF2johKo806+LLtJ+S4+MArDVYl6sg2N2NBXHFKTU+PqitrGehEFtTpLDWVsOb4YqdWGk9OXuFofKOXJhZSm1jfyK9Cogx6aF6Qqa2m92Oo3CK1IgeG4lz0HlVU7gaxEA9unbYXGyX9WUtZIJ5afMAFG1Tuq6XtruWlZpvwXcltBuK8O1BJTw5/mJ6Vc7IGyE/meIAGAXS1YD7ywJVJGncLuDiFPvamSyhZQrp9t9fHzsPP7UScS8e/jzzz93nxZyGTGbzcIHyDLkO+biw83lhcvrdoP1MfmyjZLZVIwNrzvZU2Uy3KDlIJ4DT6lc9STPkliSi4jdEDFeiHug+GAEXtnw1nOKLIpDQ9Bw1P8/+uMi0Ct+N+IG8oZa36oEZDzpbQS6lc6V1JUmuE+hVUeXgGAaRN1rzhxtjDuiLEW5xQpVT1ITvMLriI3ii8pb2BFrU62xfUfJmS7k8Y4vYS2nmeSpvZ35QYDbdUmyvUtR/y1Vh4gN9c3BG9is9fcsocIm+YZ1WVagqsLx60BP0dItiNmYVrUksz4fLw6XOollakIQ6FG0wSsvJjYTt8wFy0nrfBWnNvxBbGc1I6lq4Db68GDYTocyAQ72wAVFzJVJTKxeRHnFioqgyPUOLeVSTLWdRWtbray64AZiqioimngLZ2qteZTy+rhZfZ2BLhaqEXVsByPJCiHOG2RUCWC7PjGiJ4QS0p5D0+2AjlsI78osWlTi2pbxhkX6jpyLfgoj4kiI+5h3wNulaU1qx1IUQL0pVdqp9lNVPlXtHYHr/qG62tL/xSrzUBAxuQstOVSa0rjXZoMmO8RBSodCJxA8zSLpvlReOG4kaNQTa3vD61C1b8MLNZc2xl+hac4IeiRYCe2VqWuSV0qlqCJZttwdnWnw2hb9PePiecQjpDOJOIEGspXgRoAbZsgGS9EolNMOm2XXk2ZFxjU5Fc2szQTPvhzzSZ5fjlP8Tuqlw9qTq2CvDMRVCWsWpv404ieZBBUShFXi1Kl8jXtmN3oE6o4wgoz/0hf32cpdNedPoyS4d0MMgWd34TwTfMNjLtyBuaBQFxBhHMoP5UKoqXv1xuB1fJH4M7eRXvuz2YAU5SJM4RQQvrD315eFhyBYPmOIGhGw2NuQEeaLWaJAIJbHlCgfiNbbCJuXT1ou1XMK6FIv0FmSH4VgOdKCqvlm+EQX4UJeaKMI25SbpO52ZYZiN4Kb8wrMPUHfB7vfq5sBOOJe4s+Ci1C6A7TPhwhVy4eeLhv7+/842f+Piec97jFMf1bzbzwfrUBvK9grAq0ehKqCsefN2qbndejX6hPQmYJqPEd1mbnftwA0PRg//T4B1ruT/V+oONfOzU0UexaV7zQyc8wHk/F+e9LXuC1CfqqQv34kq0vXB9PxweGkreCGI4LbfEbrsp18x8Wfm/+Y/+jmrbyFPxcb7tGHGm36uLmd7+f7bt7FX+7kvfzoCH9uTn85TFNOf/nx8TF94aPaOf1hOR1gjM8L1SHx+Uofwp3TRzWo/Z/qNAM6zKtnxu7L1MF5gMXzUs8bTZiNQJ3u/WR0CfjXT5Pdl+DKKYthNtbuMpur75DwxIg4nDHtNSEcvykcW4+eXyMhj83V91tIPn0hJNvPqYl0GHbTz/04lwueI4zNz3eXeZjGuzKfJfqbq96j6iGyyL9lqczTRZJFsxzWTsrnPA2Xq+g553GSzRf5PEG+im8Qlz/KuzxN8jQLFvljGEX5c5LRR9CGz3kU3vN8mQhO70kQrWckjPqx8nf8VaUupmJCkCzJEhMX4O0cQSfHqZG/vqwbWX/hgBUzyHkWfYUC1lz6+jLMvnNz/f46/+X898tBfgW256eff81///13ZBLqYinHITovzi6V3mw946dRk3W7iDzfMXKA9FhfgW4/8y9gIc6M6kB7XbXgg4Lfeg9AA/9Q4b26rNW7FopYlZnpMGQASlk8u7psavnb4Gc1/KmC336bYHvRaWMTeqXAVb9/vOZq2Gbmjzlf5vwph2AItB4e84dF/rAMY3z5GF7mS0hinK9kvgry1VM+4/N8LvxZTh+61jzNl2n+4R/5PT6zVYgPVs1WqycybQVRw0tlWaq3HDQ1cBL8aUXUdL1uF3KDn/E8XGbPk70ulIjSmVKHbKUmYw016RLiWr2Ugt3QHvXbEXoLGcqI6/OeVyz6rEDffKdia9Xnetnl4ObD9fvbXz+fDN8XBgdWN91j7Q2w167PZEGaMns7/6cTjeErvFvg2Z+0gcrBwU6dnQMyRj2YpC/UxjEVVVVWoTk2Il4wKAQfEJSujzkveo0eo5W0iXoJyjNL5CXCaRZG8jaMFT4NBPVXjDY1oy3Ff05WFGEh7KDiNddCpkfscpY0zH4lZewHeqAEzwX/NWmztZ5fcumr2R1YrERIH5YDePFXloKCc6ITEjB2vW6+672bFITUm6RFvLcfzhT9PxAr4Xyx321xkA0wFe1qznX+G1BitIas5Q0m/R17DbhKeTZLFKhjOla/cP7Aizvd98Byz2K7nZKt7F/NO0RT+3dUgFlRrM3syFEhA8hg9r3DqnmD5lmxTDmn8UtvQv6p63SrG6wecBOxj9XtpV27KQaFrjSusbxCdZ2bZyqNcHGW/Ul9KDBrr1BpIutFkbVWNJE01hckCK8qU20rwzf/wU8DEa7kWzrBiqt5dzvRklN09qiO81Ic12EhArs7I7xTldrHRRhx4y6MEd8/G8o/8cf6xZZZYhQOSD2aouzQUA8bDVVSNMIYqhMH+hVKuTB0YZBeBKR3G30kQoYUzxgOUyMFBJbQO4BhnHGjegcyQihp4Mt4Dnk0I4BUFm9UGmm24gIw02w+R8NP8fccB4b/6IeYlb4MA0NrgnEnkiVBLDNJ+YPxEPLH5A5iEoKJ9AqgFNj2zqdD0EMYo3qR07jyr4xzZAYI859xg4VuO4wjBzXC9Bea4GgQ3MpH1vwLYnapm+exBIGUMX0entetswRUxXDsBo/LyarVmEwDf8VBStHQT5aMX8obKB5U6/K3MQA9uoVduYjL3hAiwosmv+MCGxXdkUxW53R+XaZ9jqX/pGforSLdAkG6oZ/wGpc+rvK9jxPrJ7/FsyBDvbFgqKP/9KdG58//rDug6fDPVbMEQfMvuvU5rAGoXUJQuwHyl7PIX674TI+o79PsDqcimvy/4laNfxtd04XJyKje/IKg/j0Lkbsuk1kWcSVGYF3xaq9RJrxgwXKaRMYI8nbpr4wvEGZq0y/1P4nk6ZmYSCpNvWUIcUEuZ/wCTUmNXyllU6/7GVSdM5YzIwb6y0LmigU1NYKDigdupA9zQ/InkDMDc+84VIGt1VuzDaP/oHyOTi7G09NJkV9ok6FHk2tS7n+phjkFPetJ4UCLsJoKLsoQed47ZAbK1njemqykLMLLYCuM/5sC+xvTtghRgw+f4tMLK03jF9gxWsPLSU+/xACA6m2LwoJxFVtOqmcTRTrqjNk3OBF8PbFJSUnDpwnn8IBs8Vf48vEum2Tgu0n0BTL306VFY91XXrD79Ycd5Wbeddf2JpmaitK3xsq4j1/sCbBXERDGRJtRHEKx8WnD3ldBA+0iFHe1vacQm2qQSPjaLKc7IWuX66Pmyv7RW0uWCm7IK5UPPyvLWDC4SR0xVB+sekdcxfLI6Dp7SEetnLWFesUl3XOPWR3nlAMlxTBI/jItBUmUAQmgEI5shSf8tPZz+j7C6pTdIwVmet3a4SNmu3XgbfPtIa9rHXft9MJhT1SyLoKnozcAQUqXQO/DFfYt9tqG+7/srlH+bzbXby3RmQsNen0JH5s9YttLt44PeZXIcUTQtuK4ZW9cxPcZrpit3P84/7G8m3djszNRotwMmDXKMgj7WDU5SXTPnZQkUcwHmRh7Ex3yvRAsf5L0HJwRUgTv6nYJBXlZkVHYYsxh/1IuNw+oifvB7O/sQHS+F5CkxJc3wvPv+VyQIcmgFHEUoiiygZBkm9mb0beESApl0prh0mvV7DLFXNYtrdakLCCs7fp6tPY73bVVTI+YsoDKQo4L8zhhm3caN4B79SsMutIti9K6fUAP2ejSNcHViu8wTGnHG/zSZw+V2r1lgti2MNfRZNfdMGpNu16/AkH4tVmoeKYX76rebtEbw/yyXffo+G8UeSvNWG8b8uLBVPmASpA0gtZkSYPfpvSdztQ3Ta+o0AibrzOTTauPox3tvL8+u/n3TwN1EceFJwhKX1jfT5E/mcx7+inY2d8H6v19tGFSX2gNKR/h87wdLDt7f3Jz0liOvwL3aydy5PVxL1pL+8fdEkbPmKvFyurXk2TjMFTauKL2obbY67INu7Y7rapazWE2rSpm1XDTlJAXewn1fwMAnfpX/5Tw1saC3/4HC8pcpUxRjlL5HHGz78KF5Mf5O6tk/r3zEqunvwqA9MQZi0mdIjv0Xxloipips+cLSITK05V4I3t5vZVKWf5wL53UvLWZ19WTm9v5SoHKXGgjMWILP55FfIrY/LsUdfuKhG6/4TuJEp3Nf4WTOPJSckJKxaqUbG31/gsdas5hjTYAAA=="
-)};
-const _1vi6m4j = function _highlight(highlight_2_0_0)
+)}
+
+function _highlight(highlight_2_0_0)
 {
   // We push the source into a DOM element so es-module-shims picks it up
   const script = document.createElement("script");
@@ -29981,11 +29590,14 @@ const _1vi6m4j = function _highlight(highlight_2_0_0)
   script.setAttribute("data-mime", "application/javascript");
   script.textContent = highlight_2_0_0;
   document.body.appendChild(script);
-};
-const _1mc6dpp = function _lodash_min_4_17_21(){return(
+}
+
+
+function _lodash_min_4_17_21(){return(
 "H4sICHAaNWcAA2xvZGFzaEA0LjE3LjIxLm1pbi5qcwC8vXl708izMPo/nyL2y8lIYyXYYZfp+EIIOwRICAEnPx9FlmKBIhktWcC5n/1WVS8qyQrDnPM+95kh7m713tXVVdVV1bf+/vvGyt8r/08c+UGSBxh+k069fLbyaFYU89y9dSum+Lqfnt7axO9b6fwyi05mxcrOPEhe7a48S8tk6hVRmqx4yXQlLWZBtuKnSZFFx2WRZnlVVwolvuXhepqdyMo+BnHg5cF0BaqAUm9f7q2orrR2QH2jok+oHDT6CYvmfpoF69/ylcH6g/XbsjCULc23bzm1+ubl1va73e3GSF4FWXB6ufI4n30PEi93Vp6mfnkaJMVWnJZTGtbL5CzIi+gEBnoWQL/naVZA1SurK9vTCEcJNd66YYVl4uNUWPYvHVxJrMQpnMz+lZ9HhT+zsvU4SE6Kmf3LhzGs9N0sKMoM8q37XhxbhT2k9EEz3cnG/SP1caP1I/wZ6By3r88BfzaO7Cvz3ZvP40vMYF+ZThey004AA0kz68zLVkqxNnAikZRxLEQy6ruJGsiw1ysfRUP7F+ZKRTIuj4aFFTipk1mp7SSmqaCqP8P6q7ozrDtorzt7FKyuQn/GGfQcausI0RkM7aHuf1Vp0Ky0pb5sbe0Payv/VReHdhRaHVaxLWuEym+oUL+qO/rDup1S9GHOx0e6ETPHGc5xSi2trlrRuOz1jkRqpjqq2kplW6oTHWu5Fajhkta7b2+uDaqSoYZc3c8A+1m2z0HwqKQ5yACSknFwZCagP9QzUdXs//n4H2eZd2kFtp6BEoYu2DzrlSur2r3W2ouqzubSAcj2sFac1WVAiKu98Pt9gA0CrEawIAB7Y9gWR7beHBn0GboLe8MpsdcKKFayqp282c71TZSqibU1bKJcW1tuYLn+2b8H6BZ4blvOuZVoAAN8ks/jqLC6XYZOJrUMpx7iwZuFvViMj6pMZxrcCNTMACDVoNUEulLav2TPKGxr3CIyB7pkOwzJnLQhMQNakch6VjAauGsDexiMorU1t9eLFBTjwKMjJ6oGvhKpHvEdcqm7rPIUQohi9FWlutiB4xpenVZdulH1KZMQ1cCn0A3AaLighelE2dKJYz65gM8Y6J7LJb8eG6o5Hn2njLcyd4uVPmUVmyUoqraovmJ04Bbj5OiqKnfxJ+USKJeMC17um54cXGM94Pryl04En0QwsgLA27A6LkE9pcPiM2h/XBs63z8AoXB640Gb4cZBCCeEun7mxWXQggC+NzaOo/FgA/tRYxEhJ8B/wwjW4oA2agZgcTCK3KwXwc6/Wt6aO61bU6K+RKK+ZGgHEvVlZnMzWH/JsTzg18JZnvkxYubi6OiKAeRHDjwjmBoksqy+8wLSewN7PQvmsQcpbwoHdrTLZuXnP6wyhNnabv9B/1YIHljndmuFkvWZl2Ot5vvndozWoB0u6UQCNEbH27ANNb5Zohxq9MIf1LB1XQ3QoT4DNNgwq6sAL+YAYGv4qZrR7uFht/clw31lPj+pz0Z9F5lce2xZ3mXrBZCtkFJ9v8m+v2/5/hS/62HAbkTio2MVMJ4kuCgs216fpgmcDtn6vMxnViF3TduUvMWaqBZcl0yD83oe/azyJ+vQ1rYH5wHb5YAdMzg+iyMxDhyYgtrGflabBlMq45AHMQ58734LJ78lstIOrRj++MliQechhBxFcWVtFNf73w78xm9Gbsad1Mf84386ldVEJksTqY8pRt5lrXgNDiLEaAi75rhtOYdet9TXGwwDhP3fVMF3wD4DTgTk0Sv4406CGoQ+b2b6gpnmtTwvalBcjajA7bxVKLBf92de9hiPArva1EVVy6t6LW+BdfPy4iVwlRewqd+a3TO0YY5byn9pIXveZkT2wDFgsn1oyfZMZrvClg+cJBHdO+uD++sbg65TJGKj33cySPuU5OWceNHpCrK5a8ACl3mwvrKXXa5oDjqZn+brUXorD7zMn41+iHmaXIZRHK93nQAq2b6YBz7W4Jnd1HVK+ABMrxdH05X/hk5E3nEc/PdKOpcEn5cj+x0lRbry3xOYhlM4JYrgv7tOCuUmE8m0T2b4B5nwMEqC6WTSdcJE3IW++zwXHTCzNAZeHbN4iRg4MYzRyRNxx5lhdI7RCYbOMHSCHy4T8cCZQto95zgRtzec80Tcu+OcQsrGA+cC8t2953yD9gYbzmPI0He+Q6vr6zDqHSgKvXhJhT9itT+x2m3I5exC9Fbf+ZyIh/3+/cHDhxt379y/03/4cOC8gU/r9x/ev/fw9uD2nQf3Nm4P7t4PbvcfOFuJeOe9cz5BvzYe3nl47/7Gw7vOk0R8gg3i7OHv5ubmwLmZiPG462WXXejmkTPuHkfJtAsD0+HXAXw6o6hfZpjvsop8RGFFF4aMKWEczbswPAzPvayIvLgL88CiKvs5pWWw9iddmJWjI+cpTMM4Pf4Gi77yODshSUd+1HXe1tIBwUDaM56WXyb+MwUh8O0d+/YkTePAw9T3LPUpwAQk/eBJO2+3L/xgrur4yj5tZ1maQdprlsaa22fJz4MkyLwizdj35+z7W28OKS9Yyrvy9DjA2l/VEuMYkr6wpB36gcQPLPF9lp5GOQ7loJ56gXOUFFXax+AEthMkFixxN8AKM55SZFFyAokBT7w8PU6xPyVL/KR3D6RHLP1z4H2Xo0wbqbK1sGgs5pMyDGkC/KK2QN5+FJxDsseSn8WpV9ze0EAQNz/du6M/5ezTy6R4oNNn9fTBPf1hXv9QNTLhg45YVWfND1uxdzoPpvr7SeN71dZl40vV2LQQtw6PJ5P5ymFPrPz11/DWiXNMaZZKtCEVfiH9HNIhNTi01v8eHdoLLFcc2jZ8PUxk0VPIsmqNXOjXIi4WJ8XiR5kWi/9z+6GNny/g83j10Wb3ryOIfSuEhBLrtABOpMz8wHYem8SLKvE7lHv0X2vW+DA/3D3qjez/2oTyO5TaSHxJiaKR+hGHtL44HEPfxv8ZHx4d/b2wxtANGxKsUedwYI//c3h4tDg8XLdhcAP78OiW8xNK/efw/O+bt5xt7Pl/1rFkT1ZjrY0Opz0IHK7Drz2ydYWqxo1ajTbEIWKNBJWAKg6pbRVc3LRt6OYutnJ4+J+b63/3RpYNH35dLXCqPptZ2a1m5Q11L+/dcrZwePkt5xP+/sJqk8Nbh3+vHI7PM28OILJyHhWzlfXe4dHK4d+Ht+zRYTK65Tyh7O15rfWeTblvOXuQzRmtrK7ccm7SNBxe9Ptrhxcb4eHFbQ8Cd/qHF3ePIXAPAvcxcD88Qoh5itktWzi/rnCU0E4O0/oWmz20Dg/tEeR5hrGb0Gucrqujv7H3h+sqYv9tH15BpneYiRbiPQ56vNY76l+M+2sPvTVo6eatyPmB6f3jcX8g419pcjTQr/dGW2mSF1npA648PIKKXlOBFCq5L0vsYwK03l+MB2sPjw6nf9uQ7TktyYWPA57eg38PIBBCIKRAeFj2Bzgb8AODhq6+wF1y8z/2LecVFv0Lpjc7LDf6Gw/o70OACcj1BXbk4WE5fYBl4TcMQ8C0MrF/Wyb2b9+DxAOZGAYblAi/kJhklLjRn1LiRh+LF5n4UPQOil6SOZnKcF9WtXH/GDIEkOit/TyEUYSQisOQ48CBALalMheeD3+OB5jrPn65D/hWfqG6cNnlutPCy5WnpZdrD2WhrlR3ULXfx6GEkLhyeFhgVceHh1iP16cxwTzCPMFEqZnSU1UO7j3AHIMH/UBVJ38G8mdD/tyWP3fkz135c0/+3Jc/ss7+Q/njyRZC+rmLPzDnfTgSoIeP174eygWnFZdLDn8DOBoytRbUG/iBQcWZKLNelPXSrBdmTg5ZYNGh2sFDRP8YBQa26HUR58tYnFFsImOFjJ1R3dMe4HGZnsn0SxkLZGyKsf9QhVDLWYa54JMvvx5nCqpu+2MJVccauuDrOXwF+O72JpB70e0dw48NBFhVJdZxIXPxaqbBPaoG6jmyf21cAbmFZTj8HsMnSvArgIbKHsvOq+59N0ABtN6O7s2l7M1U9ualTn5cS/6ok3OIQ2C6iOPF6SILFvmiWJwFtj3qOj8bmZ4u3rxZvF183F7sLvYW+9uUaTsT5/AZQruycx52DqKfdenvsnS3Nz7NYDpgsEfr39IosaA/Nvamt5v1trFff3edN3LZEG0N8mKxkUwXt7MpIPrOeLBx+8iGb8UMML04PDxejAG2JkcwnC1WandvsfHu6eL2x6e1UnsvTCnYs1TqUyZky58z54nu7fjkmk5+ypw9k+k0o1UfIdTJ7ACajRLOzUyfMnnmdE+6tvPUpExUyluTckzTJBQcwVLtZdgm5Xpmco0fU7O0yvDfR11oPM8AOpzuzW6zFy9lzp/1nL2d1syq9h1dOyVQaZhjWBzYVjBVrJTs3zvTP4QAWHAAftiHBArw+X0GmBtm/QgX7IiW7QjgnpIWeOwcYVB+UwFKXYz/I6MQWYGT7kcmxl0itbpOV9KdENC0pgwCWukSwQ+/nNzUUUViYtTwpF1DYcqwovRkpCoPZDH9LWbwI+l5CCgaHkJyCiAAlDL+JVocA0R/Q2Dvch7ovlWkqI5w8lOlVR1hZCbEFJEOIeBruz5wSNledBqkJbYb5c+iJKKJAI4tD2AMEMyDQmc5cr6SpOp1Jn5dDW+8zsZecSTgJ5Y/ufyZyZ+5/JnInzP5cyJ/LuGn04eKxk8TSngrf0L5+Z2M+TL2Xsa+yp/X8ue5/Hkhf77In0QWKORPJn8ibGswRLnFPnV8X7a6L1vdl63uy+b2ZeP7stV9OcJ9OcJ9OcJ9OcJ9OcJ92ZV92ZV92ZV92ZV92ZV92RX4CeTPRP6cyZ8T+aOmZF8OdF8OdL/W/efQ/S4eiV23+xiWBoKDKrhRBW9XwTtV8K4JBliDJ4ODKrhRBW9XwTtV8K4M3sDa7kN4SyZj0KfgFCt+SsEQg1PZ8gMIbsvgwyroVcFjEwwwbyCDD6ugVwWPTdD3IfhSBqdVMKiCoQkGmDeSwWkVDKpgaIJTnJN3chQYTGQqTs+ODN6ugneq4N0qeK8KPjDBEGtIZfB2FbxTBe9WwXtV8IEJTnFKPsmgVwWPq6BvgiHmLWXQq4LHVdA3wSlOyReZisFLGQxN0MfuPA7k2gcY8eQaTHEG92YyP4YLGZ5i2TzHMFHmGvYwssEjd3jEACNGbvPIXR65p2EPIw94xOMRn0cMkGLkIY8c88iURwINzRAZ9FmkH2rgxi8DHtnQoIyROzxyj0ce8IjHI7c1fGPkLo/c55GHPHLMIzjs5zoSsMhGn0c2eDYc9omOhCyyMZCRGzJ2m3/C0b3QkXs8gt2e6ch9HnmgdyRGPB7xeSRgkdt9/uWh3qYYOeaRKY+ELHJ7wCPY61c6gh39piM4hNc6gr3+riMPeAR78EZHjnlkyiMhi9wZ8C847FhHfB4JWOROn0c2eOS2xk8Yucsj93nE45E7GpFh5B6PPOCRYx7xJeqSa38n0IgMInf7LHJnqhEURkIWuTvgEezCRx25xyMPeAQHlOnIfR55yCM4ul0d8XkkYJF7ff4FR6dx0t0pj4Qscm/AIzjzezpyh0fu8QiuSaEjd3nkPo880PgZIx6P+DwSsMj9Po9s8GwGxWPkmEemPBKyyP0Bj9zmERzcZx3BIZzrtb9/T58PGLmvjwWMPOBfsD9fdeSYR6Y8guP+qSM+jwQschuH+tJsVexqpPfqXTqMNcq7S6epjt3BXvylgfi+XNkr5wVST6sQWQVyeQhfH2E4LjC4icETDP7V/QuCKC3F9L8w/f/cfjiE8q+oPJWFRPhIZV2oxpFlXajG0WVdqMhRZaE3UP4LUW+HEIM/suq/sI+J3nGZgW6UveDC0K9KeKgSHkJVHzJBFDoxJs6BigG97iSB6EpZW1eIAtiGNFw5idNjL15drf+uS0ZECCEDOt0pWqrIgzhcXa3+LhfGVCcLRBIsFgX800yS1dW3kLMo79qW7QQt9QcXeGeYr66aQEeF1pN0GiD/Y745ZSACiC5VcppOyxg+6N+ODLAaZIITBaJEnbVgXVUJ4wgCJw1EBMlJsD7PUj/IcycMBFOgvVFkl3TnnejiWfCjjLJa2OqWRRR37XXsVD6sFFncFPKlwTreqgF7x8O6zJVPN62J/evqCibKh9ahTBisRzm7MXE8lo6MqxOzBODunJzFJW/pzFgScJnOnMVxbiT36EwCcWp15dU08N9ngbiwnme2c4KBFxC4xMArCEyrqVmZWxdMvfgrDiAKLd+3UBW0czyTv1ayEiV54SU+LtZWYVOuWuIXfRWfDOHTcSw1hRPgVidKKD6ZdCsNu9SqVHmT4Jxut/ldOcwjv/lGjQuEwnVWm4BUmeRRvhySxkc6zZ95UQIpnU7h3FBpEV62Q1pfZyJ1Eyx3wJRv8BL+XzY2jTKID3Q0jOIiyKhYxyQCd57Bigf1koX3PdhKy6SA1E+mjbMoOJf5mK5NYdkKhHHCoJvNPjLlDd7NvdJqdt12EtNrPgRKZr1fGg9l4COpKmepsno+tOXRUhY9zqoWlQI1sPXHkaMeZbM3LfNhD6uRrQ2cG40BdfpXQZwHUIYq8+M0CSw2G39DoRalvQ/V3DcnXaosQR1FfSYzQZsHdYUf9Z1SZCOtN+KigtBOZEGq0xx1KqJ12FJZ4YQQCpKp44twLXU8EYxCN4URxWJ5vp1cxFr/aAbQPRcvYstvATEb92YnWyw6iPiE8FdX5/BX78pzUlNvwgrJLxAWh4mL+itDH/VeZo/mQ/uX1xPFUCu1nOGMn4hk7KH209mjXGk/XYp4fHbkTMXluu60cwwRRLPOuZhaJ9SvYyF+JvaJOB/SEmFPz2nd4cPHxEYzkCgpYe2Gx1ngfYf1uZqMZ6g4daIxyaRasgPaxjeYntM1GtAKEAIvs1A5sniUqW7DgTgujob0PQ8KK0CbhwCtIpg2WAKlNLKYeoUHMBbloygnzXjb/XUl5xN1qwTT2S+ySgmLMqA2IqLaaRAHRbBSq3GcGE1yU9maKEYDgCSmIJQ169TlcXJhZyj11YJVh7qkKar9ZXoGNeIGcsQeYVaXocbg2ha03lpOZVBX1eU1MUOIjKvStlZixtjjUwPLBosIlcP8rq4WpASbJm5B88uMIbL/X5Y9XV52jdObSx1eN2nQt89k4KDxdsfKHvVtUvI1BgZrg1GxPk/nlu2+MROaOQPbWVszzTmdPpti/48bXIH2SOM6O4LxMZuHjCmRfc6sei1J3bAjvn5FAflBaW5YEUCDFsy26bnS/BxDFUe27WbjALsimsuaszH961W98cfLOjPLKlfRqS/xL9RBc/G0OSicU2+OQavIF4sIqKqcRP/qK6tzzrp+EVEPYULW5Ua3qqn53dae8AVhlZwEdX3bs2vyyS3EjBlqa1ZlhAXLqA8GQGiuMK/DtqXMA4Q3bcr6Sl3+m5UyM4uzlmd6xeibN51auGTc4IEPr1aB6maa2I3uHEt80FqmOSvnmaH8aHwtfST0YtNnZtqwjAxk3naEcPGb/Vn8Bi7go9wyzMjh+glpgsbj67M25+H7b3A0GmVxsj/SJjYAFDxTB7dFoBb8UZGsDQzpz3c8m6FeT4IVJQ0b7SoAsQLDNLRBpmA1MHsINZwbcjyaLOtkcNpSuKQwkkSnFI9MvFOuru5QWiqAagLeuITNDrRZOtqxjMr3DA56wP5AqXEAx9Y8mKqVxO4UyEsZlsizF4sU0Lxm1oTwoGJMSMMQRiUT8CIvSCgC+dEOrHssrz/l5+PLInjDKqCEHVMBlNmKLM/xbQiFcs49A1QhM/Zg4Ni05SlGsANLoFQLWL8aKfAxq2nOH0QW0PAJ3m3DAdN3jDUgA6ufHAJ1AfZ9O9M63xbZuCwWz0PCAJBEp2KHEgs5p4vFE52f2XiYKhjKv1HNfAH1QKWwh/6wws9LtqXcmINU0amTcID2uWlV1qLS/iar7LVUtsu8xSIJzV0TJyNItOtGaFv1WU9WV28C5+S8963CrpFZn9oz/ljKaMb8Cxj1eZYWKbDpZKWwF4/2pLXiLyC9w+ikzFBt2+30nSApTwMTIwbIzZzzLCpU2pVNhiSCoaq9ditdZkgZxbC9K2PImo1mBGTKWzL0hFibmeZbMw49ZAChRC8y/AKX+AiZMBeO6htFlbgJpy2QkXaN43wmawtwQZxUQlMIG7xY9WD7wk+cICO2mpOwAxCFBezaKJArCAVcROC2E2IzGiRCQoshSlYqUQlWnEuUhJ9z4ndC8TPC1e8YxmyPLNds4l2pMzPxE3E2cHozIV4niwX87FNnCIXpci+xnE9VQ4YvMt9T+JkDQopUY4A75qNfV+52o1Fv9BaLAyiFaLnoPsXYlorJruCI8E79yNg1wlz+uhqGYhetkmfQ9tVVulhYKSHw80wzk6k6n7BnE114MkwVUg9t5zuOY9RihoI2IUQcPEPSEhcJbfZS6JLtfpPyqrZSaAZ4I6T6S8cULXXRoWRg45E3mkbuZeR6ox+++94HfjYH2DtjB3JmnSwWbNtS1ScAA8DkI70zLuFc28V5amvIYaj3HUO9733WRIsh0nsipJ2aHdz7BrrT3gBwVtUu0pa2gbRWFIgGbWlGowyDkeSGXVegbagyuIfiqaAd0rFKjR07kZVWhuhXy3boz01voHzXWH90tIw3AbouS89J3DeHvV4N93POnR1oJwIHiIkdbqL3gmFQZj2N4hHAQ3FlhJUjNzYzyGV4AwE11nAG1AWsViHQcPAnWncBjh1ZkQixnoHt6mKAGhCDRGKXPjgFATEQuGjio2QhaF4bq7mc0+w5E4XBstHczaw5wfhcAO3QB3Qwh8S+462uTmCCJxU6PBOz4Zk6UYrx2RF9ZSKPXJ7gc7nxVoBid4C9gmWpPujRMTFqjZAz1tZLxw63kc1QYqrS6iZeX8z6Nk34201X0UYLIKqwIlsDZEekhCuJeUfZA9JFPsAVTFQKu962CdPCivoi0gPymbQlWDJr5yRXJr77sJ4OsLXERa9lmyXwHWUPcX4gAklVBJBYupATTpuAcgJLUxLvs4kczQ5+GSpb/gzlS8Ycix0RRcDndnz027nVE7q6qvjdpDG3gRkYZpfzB3ObNsYHmDQTbyIgWSFUQqvI5EaPUjXnoUBD82GxCYMC/GOPis3BCKoOkX5Tlbse4L8QTiisYVyq6o9EaACInapl0CQjjqVjgfc+25bpUq7zllxhPVfUbrVb+orp4wb/qmQhvpdSfFEREX1GQwwliEH7cvFgNpIUdhOuoX1UeUmA78i7JpyenQZ1VFowbEzH8yiAmQuILOMsY8DN7RSnmxB8l4X7KnGfxKurT2LEoYR5R9/xkHVfRzWG67QxgZuM9b9ofNND5EQtYwivyV2YHjCO0AzZtIty44KI4+TR87jhxuV7sLz/M5RKIwoA8rfyhWDwsCciQMtA2AHI5mQKN8Ot4pnjZy6lxYAPgeIELOlbc0DJBaLkHDszNxjddmLISZyZVQC7tCkGGwDmc4OrIQr0gkTQUN/chuWdU8eGNyTRAXsATnhMMMh78gj4rplmU7XA+kTMx5Mj5xJIw8I6sd0TxF8nyAEiCj8ZnQAK71hno13rzLlEYm/mXCKTImcGBj1cW/NUXVOB/Sbaz5pCiaksgcNWhSosf3W2unomEcSl7cxk6AROfLVAM8bUMkyot05wDTNBrES5xEy8DCxdAW6sjFhp8TyiZR9yryEwDeiWIbW+pXhcVn5N6GuJZuOAVIDM4b4A+M5Q94m0W5AAZUzh9dlCtgu2r8/2ntW2W0OjxjgaLYXR3FruTyDe5KiAptEXnT4yRiNyeAGgiGba7ueqrl2sjnOFrBmcZGniLQULIf7CTPoiHb1NXEmmeyJUEfTIJHycg9GXxPXhi6cjHs15jF+/JAD+Hv3OMO4RBa/kE0RfdU6xlcovUCopICDMZM6K2olg5JEmvx0gxkmgMZpHtTG4Exn3TYoE2Wx1hi3KvRpztFO/2AWqJ6++Fo2vRAItFurC7gyooETfm7kJkNiTUWHi5rCtd7yEvXZCnYvMhuh0Zkif1fKd1cdlc9voNy1QRAskxHMGRVtLVEZW4bYSDmWgppcp7KhGYZcGxYVAYSuaenU1HG8cjcLxAK9IknEIuOjI7Vj4S1R2RV4b4hJ9YakqsDZfYGYAm2TsH8GCY12sboINT9Pu/kqjVsM/5mq+iH21JUcZWJ4TAwDg2HO1/DM6ymBbxY7nzJLFHOmY3HZnrNIWVuATm+iOYnoXi6d46qHgBQ95OApj92thS7P3Iq2fq0+u3+8JQwt71y9oUfCVv9mSMfWNCA9RQOd1NqYm2EXIU1as4miM1gqqhuhD/43nLmm1JCNJOnxFfA+rluB1g/sDK3WfebXD+G2gVC86byPGwO8TMEkOEQ5OQ/eY49yuNiQe212/MtEDzgsOy0KeIlmbS4JnptGaWOJrVDVKvZGOO8ypL6HKarQFBCXKOav+BHZF77b69HjXIFYesa69r5HXJCp6EeJcAjFhVs29nuwmvHwjGPd60sNXy/lH66C4728Ro/cG1fUbzB8sHG7ad3AuYhDFfPiLK9nCpqPkEk4YQCFL3PrX+nCfRASFzyI8eaD2BLcAfK/VKqmst379Ek3u74D8Q72T39xdPM0DuUd5q69rR2IiPZAAFc+obxJxARRIpkIjUgAJQJ/7sjg6h3sdUB1Dg0RCIKID6xUi3NRGuVev2yXsAVzGwTCUvUTJmO2QbBc5vKsr5wfnCvZrR6mRtQmqNcNj9JUkSADlSaGRFGd5Glip5szxbOdAnZ/RKAKOBw4y3R1gLw9QRQI7RKIAdRc+w6PaRyFaR56tPh5jGO7MSe4PTcFx7MwWCzy8cDMDTwU4130VytBeCb/ufGTlKB+IxcvS8vEyFo5Tk/bZpMWwi9wTH6pdLKZY+8iCypypqvajj5WF+BdvHvAXFiQW2xFkheJY3xUcspaUkvlOjKciYuyAZs5J9eURZHfUvMTc10ltTyVMWJTp2Sx6qK4yyoDA3ZLzjjcANcn/C8MGFGabjGo+mCpMK9FfC5s3QWgd4F7RNSCCdAFy3eQK9vUbTx53AdPH0QKb08hC/uCx9b5B8GaVGOOXn6GqSeS5Te9Q5ipQ8uCkEub2eoESYydXKKKr6qy6vFXq2wGuqFbf01/k3FTtMe7qnU8QzUt/aeGoSKJSVPTGr6uaWCUVBYpVQkFMcQo4AWA9BYAJS9jHQManeI0btnkS+sDPwOvWpIY7DpYIoWA0dS8dJZswvQxFoogfwi5WQQpdsEYZ7X8cuJSzaWmFuR8TSLQW6B0vB14ys2LYJUMgYGBfOTmQHHCGkJOsUFLmWgUihE8D23lTXalBtEVIkyz53UxGutcuig4yBC8i1W7IAZLbRtwRAg+0EpqNtDymHMKWKO1R1WoJrbqX2EZZMWlcRlTWD7jeu9j6EFv231axlvQGnODJymqqG05SgRF/FltYxL6FIiAo5/RJVSwm0Rp2Px0Ho8hFJ5EicZKe0PdPKymTMZV8+3e7ROHBWVU8GsCfzc9JdXk1TVeK/9pAGVpP4KEkoOPFrQ0I4aUJpg3PZ1EckN+7pXO9rA/7TW7tS6L8DWDppFdz5hiVDChfZlbm1QnBtNZp+qpbPIjg5FP3jVnLfWPIprTl6qWSJt1oTLiBa5hiSEDoloKUEL2tVe5pfUHiJRT3e4JI6dodmvAXixqNpJIoB1KIlFBTmwV4UycgUvb+0dCjIxZxfIiHmKLsYYPAYGI4NFzE0uOyB9TICA6XX4Bd6ObBxwMxpDpa4NLnk47T2Jh0T6O6X21S3oJkpoVYK5R0tUACMSOpaqZlryRRhe20mUGWDLJubvYd/Cv6hpCMEIJL23gGQ59eyTjoFYaqY9gr5oDwZ4JsLXV1Ohkg9U6Hu0c1I1TKQX3mijZw+dnYTcjbT0XVF1L9DH7KR2JPOfUacsl30CvJRVMq5bESeCphN87PKH0kCjd9BLRfIKLewC0rgXdp5D2l2jY1OdysbGLlfrsLWeh8XyACU9X1Aebx8sIsAKBwpAcRwqk0BH1xTHfEniAVu2EF7TEiAavsRTYiAkDXwNPEAPozkeM1J1BRqpIcZQH0e4aVSVYytaVgDZDqROp3nghvNEHh+2IBlHyI4ZmMdua266s4UmKUdma7GO6cYXyU4+zlMHvDk1EpYpi/SMR62l4AXnSecO5qfo3/5Wud9t2ovPbB7KAYEIjI1GjPPg9xj9kaDYRD5cEPpzuFJUivWs7fCdt1S0CFrOQxscVbidtje/WsVDxaVyqYsSJ1jXt+74sn7llp9ySSP+aI7ywfneXqALNdyKA0PzCv6ltfKgAMbsF5vrabjLpr/a7LeLOTNvSQcrmvj9IoDy/hYim7ymwfqeESpkor90Z4vWYraUQxQuBxv+fmIlxfeyL8qLK7eMVHAl55CQaUAyI9rxLnBgZaZ/L6aU5rB/A1k3fgSoQ7G+HxL7WfxbyCi4nRox5O1GVcPJ4cUSZ2GXcDZifW926OJ0MzdTWHJPncyYh2h6a81qyGPvOY5lz92DTnk5OgUJY0nYwEU6kJJ0ooC7QWk1pMGYIw5J5MstRdil2T1R63Eh/MuXEAqB0oJYt5Nral53Pl15i5MR3R6YEXaRH8JdRmuyoNY0B2QW0Rv0SpnfGJqalucyKd32oxoe3ENZaDT9w6JmtP9OuoDPY4O3E8a5wA777uZSc5zH8NpZ42IJqj0ODRhlFdGyHoo+d8lDw0yQbSXyGZXVBRuPJGHXAITF+vF9Knjiilm/Uj8SKj38UCyPZxeER9MFMJjQUBoDKgdOs3MRemu9fcxNaJGMZC4DUrbQzYKSPkJNwDA4qMVPzGCYRXJHdJXG6M8pjjsnbB2BsG2t/roC3ZwsR9IsF6hGrmW7m17dfJkJ3rVsWc8NIXMiofoegp26RbPUO9sKsO1T5erhusqdwTS0lXzcfuz3j0MwacRcq8yTqj4VCOVvlc9dP5Jd0is2uPkmnTLZVO1iutvYpfgWwf8a0GqfwiY6g+xFDuzwYnsVRzMcKW16WGIHRchRzZolQLdGrNs8uVf+izdJbmvCvWg4uA1siw5MyHaVKFec93OShN8hGcOxNz/qCBBLtW+b80yLg5wDfV8pMAzKAaIly023rgnGAH0W8k6Mx0JIF0UCeQiPiD040IJalaAoxBx0OVqtXVZLMgbU2g9uB8kV8Wi0AmAOmQyZ9Sg+GAiIpAFsZKkkdQAfxm5JlfflksQpkAJVP5oxmHNa2Ks8Lk71vXIwgtGCEUYSKpKCtm3qgRIdZIDbMDs1iSrpB0SB5aPs1osClCQ3dowPD/trrTIPcBJaB+0Wht4A4Yi7xOYpe1Qv6ye4PrueCkwmdZ1VX45FeozkNeOVpLkT2ma2e/5yGp2gkI9/pDOwYkCzx+KKXZhKxhgFYOrP6jCAnzeIxXLUdSi0tmottqKIgEXkJ0nh5lzK8YnvxR34mfzCo6CeJeNYBYDiDEAeQ4gBgHMJMDIEWjHE8NUtLSbcxFCR/9Rx5+nPd8HJ9vxpc+CmF8MzM+zJKN0yM9FLOVmdrQXu08rrtBJ9V9IG0KedyZlzQK7fi+5Zrh5hLD0gEOjnRZgGFl7GBNqtTQbCEhkU/scIYnJR2XIb0m4R4AhSgZYx9v1YApKUdPUF8OiXR3V4dafOU/raMc6unLXAri2eVMS66PKhcHgWclifiWZGxMqecY70JGhfsmQ0AeZRaiQMPukubvaWSVDrBYac3rOEejZVnpyzXpcH5VuTkYATSvDeCUxx2+uTHC13pQNg9TXoHl5u3V1ZZDPBpZ5doa3g1D6dXVT5FVvfpDTCy08Oj26ADovFIgjSLki0NcXBnS9h8C9sKehvL21kAIm+L39SlmypVSeqNU6ioRFWLNF8hYmPOc8g6rrcdmoiD6FeYgxmN9CAcJp2MDK5V0bNp8wSdjK/CjbBWfLr2/QTueZgLaQwkZmguY7WOuhX2RjpNRSDI74pCAEPQBwmGCBHbCJiPHaq7YPVKF3I1oz9I9I5sVIM3hL4wF7dsxyClpFBQmtiKPy1Hmku2Pp30321dKELo6wXPweckkbozOed0+G3gpsE3nokQee3i59Rz+uHjOAryjlL/QrtL7NhnG7qDyycBWDua6qIApSbNKphsAiWjZvZJNw/51PdDI2froWb6HdJV+d+Jmhu9OABuFP6yq561VaZLITM1QPbqlMRQse+PVLaRYmi9uYRpdHS49t2W+OEXbW1v1z/BnQ+e587s88Oe2znj3HzPCnzs6970/yw1/7uoi9/9FEfhz70iCVyZOAH2uG0moTUeMBEnUQzJ60KiKifQ9W6wXpd50lcDZqo7ctFqvikyAsyollRw4bM9RiI82zMCJwY6rsuOpKQVd6aPbqE7RP5L8ezhO10hjw0Nxwzu8fai4gHStsr1OHwWjlK7NnA+lU64zZ/QOEJFODH9hH6ylQLv+80YtYaNKO0i8z5HHx/OSidyZouar3yEnuaElclZos7D1gXSKUvTb9pA00EmS23KPB1OGzLO851BsrardXDRsrg1G5Ri5yvTITfHKkF108e6dRBbfrsrKrOK+MkAKXyrYAAY+K+X1EmozZMFZkOXItlVK7BFdig3b1c6jZbVzlLQDWQ2HWlcqKaEg7jjC+241OPJIMT6ShrX4TJZIEQzpbCOTUtWkPOOoKIAXqy0c7eQWHp3DFK3sb0aWjygAiH80bxXWabK4TBbHyeJC6p/BJjEqBwMh/PHDo1E6PlbFjtTeSB0fN7cLOSKT/Sa2DplDwJBuStNlVadsA50lFbzjnkNlSKk9NKjuYldXiUrRB2uKcJwUkKKFL+yQRblpNsJLEC1wkZakrqRYYa6kaYHSC8OPkYGZ6IqTAB8MmShVARx5jVFt85ht88vlbT7FbX5po2uB4THCxnR8zLf38ZG0NsHi54gGYts5FVvW1Dm3tRnPVAALMqUeTOCgiCjpCSZhhzDpxuWaOHUmq6uXjzwD0qm834JNH9c2feZMnXfUgBzM2qXcyBdipg/eb2I+ukABiJF7XYqpwVyjqXgRQQWh7Z5Bk5uD1dVptQUcQCD+o0vspCohfGkO+VvEEkOBb+JksQBs8g2G9E0t3YUzld3L4fQ/RdVDIgLm8HOWOBP4sQBmp0D2nkH4GyruzYH8q5EIMbs9/h1JpxJ3lJ4MSlHw8opd3Ua/KU2wp65ptSqMMbQq6IOy8AL6Ag4XssMiFReeMRguydSBK1lKC0bQzFlpSSMCCMDWcCFpQkkB/kIKMtfUueoWh10ER4ww4fiPKw6hIo/RbuAkvkHh0jJW6y9kra9eAVousRfyv+p+OdI69NJ1Qnel656VFaFWMIlnVkk8s1EghdBuofQxKP4stpJb+6SnrftDlB5Qcs9xKftodG7IucA8BMbvZAJ5UBJvVF0HW41LGn95n3uC3KAYgYVilH1klP8R9iMguQtATZ5kpr0jUaJ6tvZrQmnI6FdoAzXIKpmfBac8nAS0dRWtDHwcbpOwfjizi58y+s3hrGERziJ1J2ROroCYLpmPpN8BwC6wWY/VQY3rCKlAI4i+7WaYTgBJu2FUPMroPUL3MVm6ZIpsqmt4RNd1zQh3m7uhgI627BqrEC9Vt15iN4DIluYD7Co/asfvkuYqVi9R6TkepcAqzOD3wE0B9cRABB0A7sF4NCwWEDhO3HOoaFX8v1Y8Ok/cY+TDV0/wQS1KnCSLM5RRSlXjMSmkOXMndybOTLZ5BJgrM1ZmZ2bNbkqVvN3cOoFU54TjchE4N75E8KFucBFGlezUi5lrFa6XJDlYnBjSpdTmYX33RWxJi6WNhxukLfOVpKKKn5cC8V436Nr6HUwIVlqA+F06ssA8PauH7ix6qGfTLOP0mtnWsuoOilShmHZAO0xoSk0qsRusJZ4no7fI4KHTkmL0A4MvEWUgdmC1ekurr/lgPF2ILvW5GOJ3ZoNSdSgYaf8Cbp9UAjUAAFV1Tib+Je6XVKTS3sx9TrOdkvZMKKQVWoiGYKENR7MoR6WpDwDqPNGgGQBclsMbVN+VvFz0ARx3lAXuuBpXDFBGYztSCvs/ImvuzPAKb06sEfzgm8nwA+xRAD/AIJXwcweviOZA9Mk/2DOfXeVj1/HDmod9R6GyOYtRFQMHLWOkoVN0xCSxJ4jpL1G/R4hpMnohqSsgJODzsbRywK1yjJrZeuCjD6XZFnNA3GbNpNbnirwjNQIIDQWwL6zZ6DR3d3PbmkDJxiaJq3q4ebay8HdOYjTqZi4S0D5/VPD3IfO6Vr+BTqnJHSLmQYEU3aDQnalSez1w8gjyO5FWjWwYes84rJ/Q/fsBb7dhJaH1AtAqAi8FKjkuPz/DDpL8HaSq/c2QGWlIuI2U7TOKqCko2TK8KDam13QBT1bwkh6DE2+Od+oTaHqeKDMnLcirPGFUEwBHXI6iX2VwkYxzRHoF/FQq/5fI1CCqA6iFMijpC8jKIie1WWkCcmlop0tzBT6co5RMCqiIpCb9qtnShSym7gJA0OKcSc1otONIlB2HYTEm6v1HIFnsX6zyK60scIZ2V6gVy6xA6jn1sVs5UOGL7syZHkYDE1WPqatX1P3CRXzNLssAGbHYYsEvnPQ3GWMvdSfCXFChpqwMSrFJWCi5See3zXSi6jrQMdeEtpK9vEtc+n2vfl8kWhgDu6qXOD39+vvXpHq/PfFOA1Rvx180lD8N8tw7oSQVlGWSQlaaFW61YwtUEqHk54krWd+3Ml4UrkTmAewM2gOAjEPxHl3roUuWjnJeg6xucz9wXwAe3wHDYCHmiZMa+FbiGdiUIZla4cLqRTRyCAYAsexcQOs5MTol1f2jEDpc6NOQP0XdsCX6Vdv8l2QZwZy+4I1YB5ML2zDSnZQBRKX16jMTSNT00waC6YhMRQvmPC22mamNRAYGgcxqCAQI35kxcScEMtMIBHHHsB1PVKovKZHFPnRLdUmjjliijrgVdcR11BEz1NGxLukkw51/Ine+3rvuZX37TgBcJqKhLRnbiF1Q6WuibSlr98HA6Rc8PpzCydawgYnIHrmZhP54rJYrjymw15xbmLZejEAbxzzXsU22q52B3YaFblyDhk740aN1ZIHUTZd0ZC95TjJUfu87L3PuGGspxw/f+chzHFMO/ogpYgC0kMhEmKOTnUBooAtzVMrIKuKqxV1ESUo2lRlctFhElTHcSknVV7cXla4P66nxEvvV6TJKu2uPvuINBUtimjqREWR9Nd4kF4stz2hT0BX+ljd6GriJ02QeR4lVcXZoR2ciaM/DDv6LqG4r0XRSuEdmO9l4mT8a6SS3i+7iukdutn7qzfk94bfGYrxXjIEhIjIz4QFppJOFdXA0pFvWMWKjZyjFPmqZ4Me1jstnnnWnPwVwxo0ybs3xnfEvlenWk5j4lPET2PPoOZlC4kCJADp95u1YQsWFLlqxJ0iYjmTBzDX6ak9QZZQJrneiazQVakoIlWptJp1KRNJLnTq4I3IlKk/v7jRL51036QE+I9wyNKnyEVO3WKt/Qv+okCpt35MeHCWNj6pcgpfz0Nm11Ggy/CJfrQBnQTJ1+R3dSzat+hXeJ0V1a1CM8JZEcWh7hV1Trvpo5mTZ48GygUhn0DAQIaV0paLRsaRmsPSKQBYjtrxZHKJ7hNRAEOxfqKUj8NLBKlu0iZ0OOkNLfQtvTLciKyV3FlLtlMyZgPngzr5qE6CqyFrUiyrobJMsoIC6ZnRMCiNdEodI5RGhlEkcjM/LguLwW3Ovsc2wThuLyXu0WJDNI3pEOsmt7biuk7Zr1kbrpPEDSF8QKkLSkHlSLWx4o0m3scuzAEg2Ra/5pthPqVAgkz1FksXqN1e/M/U7V78T9Xumfk/U76Wp9jOv9nm9G0NNSzbJP+qj7mJi0kl5zBCByzUFJpE0wbi6Vw1TcQaqk1WqzXKaM2YGhmYCVrY5GHVXVwDJdu0emUQhjU0ix2xzY9R18NNKF+lPffv7qXC6vw6TW3+v1J/p7Pbw1b6Vv28dJvzUfcPPVA7mQJd3rK0YqGf4f7wVcw+VW/UxKfCqtr1xqPAZXdd2UGuRGRiQ9Fk+HEa2u/v6bXG0pE021wbw978GQvRJS4ypTRmgVHYuWYPpDMzppGYRRlA1G4xIkYK2dVGZ0rjVbgyUB5FM+s/LkF6oeZGLDMPH9dBV62wiNNdTyToz3PVszN1j+fqzjBnc1ZFK7EAm/jSTAgvxkUVkXpjRRFlHF3zj7jGE1OgOwzqwAJVmfrUaMqJ7huvHLH3QNM3VKoRM64kaVJ6Ij5UZ9Vd0SNh+T4l2BRbN8lbBbsarqSQZYqUDAxS9XNqdvLLu7qC+IOZCcR9Tc2Kw3OmcAuyeEqPBuvuWI2zkDDleY0KbNrK5IDNz3eXF4oRbnT7j+0h55ZO2WEy76brLnoYnG7QnJB/Qys5QOnDU642ST+4djY1oK6wZClW3LsqTrQjxfNSeg53kSpJjvufPjC9ctuF+1KlDlOkhoTZAQi1bBEgfP5Jy6MUpqZFCE6cJ+R1CiVwVuyAccl/f/T6CSh4cUQa8Iaa74aL5WVUjNU8jxmMCQAerE3RZlow3UA1wA/qzoNsJOMhPlOAUVeluExAaCWyCCfhH+KNPaK4cSrUQN3QS+IXUdxZ+dny8CIIUc7ksSLEjVJp3d1Et7y7mf6JruadquadruatrgS9oWgOjo/I4CyIEfn71VI7gwZGmQiA4woGjuBwjDkZsYw0xfnhEBR7ikB9CrUg0iEI7XBAlF/h9ZUAxPqr8kiVGY5/5Vvid74TXHKwr8pfpJ0WNK54M6Ud5a1N593YzkkZXl/TV1Xp1Ua80I6G4FtSuyWJSscVY1Y4jvM7KetERAAdaHOjKfMyY9QYyaza0fZk1MtcVPnIWAUrC8d6Grrf8mopUfYfqATzaGCUu2ZR4JRlirtWsWl9ES/a3lZ4H0tuGMsT7U3IIu6zWgZyPgKMpQqkw9hn4Fw3wTAOmOoKanikIebdQfehnDA4cjskr6wD4yPRXGlRfUVlLIeueOJ9RdTNLLaD78a6tRgp/YCDXB7Ri3PA1VDMC8Sq2cB5eJmtWsJbZ8oIbuL3NPo2r1ys2xY7hsTkjKwWlUD+zTtCCfKbaxy7naxisaQ0XKNjRt8UB3Zlmj4pqZUrye2lMHBGeyFoO/4i00vRWegkF34Tk6qLdpm2xOK6b6f5787RC16539i9kYbVwpNqpFQ/LvmND/C0f1WaX3aSntZ2QWTe5L1C9lN3JereH2o7DYhU1ZhFNowkUeSdVLlGuSDqaZoXFr8VN7xtP7pgZVY+W6JmRj+fwJ0noORP1/g1jOZuPwtReibGdgj2Qk1RhSjfv5CQswq08yrRiWa1sZAhSl+DHHg3U5VuBl2+Kbmm3WO0EZJGuhsvczkhdo760e38WW8EtdMNJxlbpOKI7e7LEd8qeqJhKZtQUpXWpyzXe6R1pDEzGoNWrEJH0JY0KQeU4wNaiNoeJabqsZ8UHlyyPizTp0T869KYmm4IZksgQsODagKskBAZte0hvA1rcQ10UF/dfQJ416n6vwrTBtC7PvJbajGDPZ3RnCNt+4MolkxZVj/pQAJ281aUV/v+y8gKwTSGb6OtGGk149S1H5KmS55Hp4iketbdtp9NHhb1a0fiPi9bL5WnTZuH6cZUjK2tR38hIfUPODalvoMOJEi9yTNX1Nmf/PJO0QYzlT81JH+oTkDKB2fElmeKXSDcEvRI2nu2csCGX3ED6f9h0UPHllcaVVGkAShgW07SNxFvpBEgf1HtRf7xkkjL58HIv7BF5Sh3UJ+7sjwrtJvVSJzXQaC1nDkANrIEyn61VdPnHiIUsMSukUkqkEoxLdAQH9NjAUNZM1f445QwUA2BymcNkuedmEW/87wDoevi5tKR/JyaQ/6e5Vzt7rbFmF42NqUp2u+7rds+mKeNPr92K9GABGbwwifj/FLavh+zyOsgm28DRazVLLgL6cRPEv1+PkshDE0GazUewc20J8ptqvDBJfz22m3Dk/9IM/8+KO6QRvmHXrkM+/ttK0Hk3r+BnyulNyXmh85mOARQ92cbvEx3CzHpOUaQKcdSs/VN1PWKlpOBG0mEislIb1fAluVW9Nyg99tQExLU9pv34ugctfN3uvznv/ulcQAyDPEFgu1YlHOwrbFMZOH+XOnXGtLm+lz6rydWIX3o34bLM5vIpHyJ6qZkAs7ZO7VvFDF21I63kMxINknF59Q6GvgLk72B8qkOzcsVS2yJPft/feua9tLLuXcY/aiRVK2skSVOvdvAnO1q6evM61IsORepr8PT6XT03hMZGY+He/iFSo3UfOI17omcVvm9p9VpC7joq693/PULuOlrx/Z9SY4MlguzHnxWtF/p63fqdLK3f6+vrP7l2/fbrhQrRJhwdFe6Bs1TfQXM1n2vGrw0tjo8Uu2eEB4mIGiJNlAeSrwajCE8Xlpr6KHDbAMu50+54HV3GnJLInMtvUstcK6C75KK1V4F4nrJ7PE1NBK5vBe066hkNv+ZIrz6T6OFiscAn9ejvLnfm8OW3WUNOnHxg++sru5wu+AOxtZfWDhorSppXTHIRLn1mgofQmGFiy/QcKZMbsK+Saad3q8zzobVna7lAIKxeFzN8uCRImqnf/FqdyARKXrT+/u2maBSsb+9f0zRB3QnlEBEfCKxnH9erA2aYCZZKNsz6O1xpWCOTnUzZM3A5xyuj9hCgq/FhUHu1N6g92esUo7L2RG/gAgqqiDd6kcx8Ncx681VfxiaH177yOmwRyGi8PWSj5SIVQx5ZRe2FWnoqlhnx1AQzklghgwg3CVF2l7vj7VS+Lfk4OwGyUKoCflFiWg4zvCNkBrad1uQAPlub83Lp/eDlp18ZCx7WDwfpwqV0X5nLoQa7W6DudcAQM+PJa5tI3hiirWNgt2bP63sOWLBLmQJsIGOer821W/MEZsZhpPJZdYplxOHpghzpTNr6nLmXeXufz9qyB+70muwnYSVtSJSj48Qlt3xIBKIbkBF1z+1rlq3pC0c9eYJ3BL2MeLUbU9Jnzh6huyGlJbETEkLfXBu4pM9xqWaj9qLnZVvnfff9NeszZZ1vUNDjI9cid/hkIKLJW0hF0TuSvfj0rEMiLHIHoY8OzJFBDuNrlmuytUJi7H5zyiWZ26PbhmTRXb9jo59Y55Kj5vPWKvN/WeWUV3n6Oxj/FFp6GrlXp5CrxlGBl5kblXbtkPnWBODrBK6SKLuhavqYuSnWVGMLHi+3+DNz/UaL30MmT2c6fmR08YITHBLg9pG0MvApkSQ5ZTeIEo1GiHosgF+nG1iX/J+rMozxbV2YmRuX/x7rvAwNm9ByGVRc+zhVglx/UrujgyrW1hIjpAZygtm+tl63fFxetQwPVkdetquNYcw9gIzGQZ0mZDB+IKmlipcOGY92jTZBy3huXD8gxfmsJZsSi1wzIDh5HomBnmZulL9txqcGpghDGsZlNYwDpo0Y1MyrtsOa5SyTf+3+ru7pn9S9e23dn03dFb1VmTqhyG6uq5yJOdAcU1E4Z8ZXQVA7I7iR+1SgeSw+bIYnyfGIfP6fscsITZgC0lu7RFn/2hT1+tbMeXo+IrnSZC2wXX7D0FJQF7mURjXZJt54womwWJyvrgabYlK7DDBETjizqnsSwvHYSUt1m54hcA74w9LcVgbm4nR1dSYHZsnJOeMEAzRzIgVnj3PrxIaZw9d/LiEjlGXEgMXqJG1xYBuwZ5wCqHUZzo1UmQvM2CX5nIg251Jog7sTbutbWpdU4lwnyE5VSwTHviGgThR9bb7azpk0/HLmzsRBNfZLGs8xOqY8xz+npGH/L9+9UzaTi0XfIaUt1KcUnQ5qYHnTKDmBqrun3sVnLypQaz1zJuIc5Y5oYbmuPlBpYCUn0IVukXlRjBeqmHuENekU9xTOArR1API1Fp6Tr4cxUJoidhiF/oadB9Jg7xs/CLZ+i0ETpoH1ZwhJQvHSLXi1pCV67+SoCLYCvdsdAW0vdXPQkSg9YFyaU0jaRJSy/tTsVVWBOThkBSJST0Km+Miuk141v+MT31vh+hZGFos8q4kNP+mj8V8te2PEv/UwU3Mw00kqNwp23c8M/+TUvM3cuCZDm9OZ9kzS9cyVycLms/bAxRMOPnBIbdR0BPd+Dz2/2SRSzFQoiqZsCjdvhkZI8a8Odm6I+1wb4vavMb0PUFgYiZ0ScH6fmT4CDe1ZEUqTjd5MVBNsPG2QMB28XP4f4AqNIALRVdih2uQqwQ2g6t/hAOjlDXXi/arKKESCxIjJyEfwli8rETKc73pW57vmM+tx2Xxk+F0oiaZOk5iuy5GS2v23Hrh2FjpOuCCR94le6815gz8aYprr5XKqbA2gvi5V7iWLWv2v/139VLzWxH69AvMgmXrRlVzx8Jc7Gtnlg2b8uTIms+O9N/qzjceO6AUmThW84qXUA0lUE5O71SpGJ2VAYNDvYLGov9H0jonMPrTULF/+SNJpsAeTBf05qeuDHrSzHJ2K5ahMD9p0iNpc0pKxhQ84/FSW26lZLhjk1sK2oNdYxrJUeckGBb7yJ5s6nJOpP9iUoD9p/l5Tpdurx8ckjX5tyeXLdlzY6BuOog36MjTz0crzI/kOLCRo8lg/62Wu6jqdgIND5mthtM/UsZQ+dyFomRk791XOzY+kbTm0YWmbeYeyQ22uf8BIzWVX6cpNAiO8TW/DP+nta9nbffnzTP4cMJCN/qF5APrv9Q6n/1SiobwvPrPmqNPtqunVBrbY62INAOckOqfRTdnlh8kYne7X7w4VblFv4H2L6ogorqBOH6LXAZ/Dq6jxSTnv5JnECIDLuNf7mV7R7ZwUcc2hGMZWlnCDtppwrzn6ukb+ZPkzd7T/2yVsYrgXrORJfbMA14V5OuJL0oREsiaqjCaNuqnS5c8Ee0CR67CiGniLQn7b1K+u1gTqENcqjxl0+xvzz3RJ3dbrHql12BRrn5MlEJ3yyWlBuJ1j+fJ6fZIydiwd12owZhXXTG/ATUZry4aYi4nZ+Lf6A4ARf0S3JZtqKWXZvpmFZHp67UKu58j2SoVlyPAJrYHGn+IjnempRVHLtlsEYPI0Gb11pQTsvZt5dYnb46V+rODLEqiR0B8yVzI4GbuJPITXdpkazqO+9Lj895vkik0cVcAEexIAZAcfaxvU/2IPbqFQKhsVa5lb8II7tRUZvc0sKVHqO59gVljGl3ogyxuq/ngF1/ndkg4EKElhxdbznG6CdsKRCeFjosNEkDeQEapou8UVUzLuLLWtJ7WHxT5ahiX9YayKDK+wWLw2iaMD8opOPq3Qbc9ow31gu++r740nPD7y6SLnwT8anu5/XjOhsBWdzzily4u33YLMUHuK3gthwjOf63OccDGsljpm7lYmvW4yAuBznfw4Y5fzJX864s31+VKeb8tvIXjp0ZOcFak9DfjpuiLn1xZ50iiyulq2C4P3ljKm7Rlvtk3z+MgNpRl+fRmf/i5zc83fmqO0rm5x4Ko3OurEWuYyseWz5amhg15ZDl/wmX/3+7zfgtq6v+dDkBdRO/h+tBTQMw6rPR+pbTyrZ/1aA8HK27VR5XKaL1eTTzhy4G2ecKLH+pjk5fX/otLAVNuodL8+Vc/96q6mdlPz3G9qHCmMAv2QHfItcsnQYnKGbKxd763t0EOAWe0tQ65j4KAhQV0xwwBPZSLeYh5O/Id81nMAp8WB3bCmr2COXpIhs3GyHZLyz0CUKGrDg6bE10BHkXk4KGozwWkSh9WW1e/PcHbSX7o2DNoQfTAKUH9mqaraCzYfZGVGXCPf4o5EWWf3JCunL+1knYFRIWxaPQYiGpXkayl1cRdLuqFEF2IjYxruGiMRK4JNWtIFH19I9iRZQf7dMaX+Eu1BK6ZbLC6boq7Eu3aG1aM/j9EQgLOJ3r+Z5Rvt9dWmmm6lW5DcdgtCDH6Tt4kPy+bYlG9P5eEQL5w6OoFcDCr1SGQ2+rZTqI/aD6EUG6IQBj7CgSoppjoIRs0m/8m3oia8HgdL4JyaulBDsmbH3G4PUEDvD1RTyN4x62ItQDJDd5e/JjQRCe1qSQkeyHfpoN+J6EOxge1CSNJ16kNBBfp4S0wDhYKbRaUuDlQQthcg1QQUD7CrwBr/10BvKny6UmMuNMXslfIhyw+Z1R0Ea90ePg/X7WrhBypE0zsKenKb0Bxy6Pgwk+4O14v0TXoeZFseKsdw1rYGS2JbUsC4Z7WB//PCOQsqb+9Pyds743TNCunShahcoPLnhYzarSTEUCyMNwfKAY6hCdcqNxzZJvH1iijEHV6TycXX9P1xRTNWw7gonJOgpjydX1P8c1vxXeAdDw9vrnZrVcxaBv9dPmCjTBrlvT3xF6jrF2wyY0g1dFjtwL61YSYgst7hA45Qay/pQeyZijGO/NpmG61qGFldDR4VI6oNGmsokU/+Z7WZunoJr+1sCeHIGyzCGqLvypds8XXLL7GCTT3HbwoELdQ45IrIJ8vo5HeqGUFpqUFwX09ei6NuelOB3h0ztLvRRgEEV5h+kSV6Qrc1Feu+NMx/tlVSuOmGpbfCp8TN8AlPG5GLgb9l+82CXQJ2HqPmj6yO9hk90rWHWF86CiaOkd5xkn5wlhXbj5fOO9U4v7thm9SIuPXWdqotmfXMrVptb56bNiQQfYU9dQrTWQS7QVHA6PJhm5JJBYG7M+vXFRIfThwpJIEe6XT6enQ6TzN0t25CkM8J0esTPUqwbaEzVEe9hbweJUWQzVPswGLxonBygRbKKz2x8lcXH9vEp4DXg9z35vTdVs9z9bqLbi/mEQslTC+L0bPCbWTDCpBnVk2wbze7Tveki15Nu7du/Z8Vmf7p4xsBhZhsyqR30YJh3UQJ+2tgvHWY3zpx0AmL243TqZfPqpmlAvm421vp9b5mve5R1+51D5Pu8EaFyGa1d7RhesljcEXGAFkbCJjBvCf0Knvw3ZR/VTif5BPUeOGG2bp/rfQOkwnwV90eNGpj7C8YbUiP2eg8Q+hHL+x1h5hVTTz6JVi1TBWWNZkUK2IF6oFZs+0VIYi8WRmt/PXXirsCX03lnvAN5DnFlV01QrAy4TI/SIi84ziQAj8dGxofm08Vwp80RKJloh6fBGAhnzZWevzNXvmFI8lxYq+wuVwAiZqb+ZkSEnPzasaOIeXmgC3hOSUMu/galSEaYdDWZLFAoTKummrGmqD0ARNXFgtqH+YHn3dCrzq9Lg11UjgrOKUwo39BiRLd9MBqQHyiIFr684Fu0hes4nGWeZfsNQh08QN1VicMIKDCgk6sqMWCYnI+K/wJzdkrOAVuV3YH5kRBERSC2enKU/BMHMyqu99KYIgPjs9NEZhS2xjX+0DK4/qcqU0gcifzrTO9PmcaYTPVn1N+mrfQPExs2ZbzE74w0cz5jVOfHENrKw0jXfuo2CCyMtCYuWFvHwhCzqV4ztT66er7M71l5byhnx57s4cJL/+4K4nxC/8C8qB3ij/qV61DfeoL9vOa7nz/F92pH+/Swcq/685n3Zm2rux4XGbxOHEC8V3LOvWDLKXo5sHcyzztqXIE6FUnuCXQpl2JSuRHpCSMvybAkaKbnkZ5jqwdfcdur+sk2w2u1AwMFf/PrLr2jLw1leOKzLNVxA9sVg9JJ8qRTLa2j0+e4ggqZUipge+LFA/5FBYoZE8BVEseymdYuI6W3wvUYyRW2BO+ZiPgbARKorTlCqoKQnwt08t8+QFb9OD09KXAY/0kTo+9mOQeOTpNUS9YwtD1I5YlOkk/wcegSvaGZX/oiVJmiO0heTrNhSdVp4c3fOiT7n6uvIejlqd2UlzpWMO0wy4J7Y4I9XPEftUMZCjt4YyuBC1eKXsXGOaCidGvof+/tdH/p4VzWWcfPl5HRVVKqDiYm1jPBySgJxZp8Eq3hahhxmmyn16lIFkZLLL3e9BFZyXgykZ+zS/0tQpAqI10jfLLOJDUL/nzObpCGrGppcPfX9MvzxgnMvKFtcSKSKNJ6oFVz8ZFpOIkU2sP0mx7/ILsXWYpZY6aP0C+NMtHR8L93XntUh5S46i7O39TW3AmRefpT4M2X1wou2np5yde8kfQNpQn9f59RRkHZCsa2fa8uqhNPhsViRAdTwBcS/ofqLPKK3us/Vlr90U20W6k/exIYxtdgdR80bp7HYteAEMHvmjjgjgNtQWCdYoiES0VWTRnY0UtrljQaeqQ3NIE0tNURU1gIls0dQVfs6qhUyCFs8LA/JLdjLnXy5ouVpYMamxu3xNI8x7G5ykbH3I/xkzUYO8avwCK8kjwPWtu7HXE9bSvyLcMu8XwKpDMgnW0H5MvpVgUexxL+zN2k4EF2F1FHQHJy6naK5SV0DwgaTTfR8946SfkXPPUIh9AtvuhflfwrnU7LV8CmUsS7u+tGmTNcLRK5r69v1bJ/A3i11Vyt8svRvZZNewa7rlXXQWoeUkeDWBTb35O6tptmfiUSK9XCV6TDrXsP1mDD8zLzQ6QEIV8VzUZ2gX3x8Dk/3yelIEO1Juktkt3qfSkNgCgeVWbm1pSWQnrvd55rKuXr40wzvhLbdWZAesXRB5vPOc0qLkp+NBAcM0SyoS2WeyAN3NONXORd1yr9Lyqh0u543/o6bt6k1n8Zz2lYhwKgusa+i77zW9oy+sb+c5GAUUu1EF6McoC9zhYnwahV8ZFjrtzh1R3LNu5cODLPPK/Q6rzI1M4MorFxTrxSE6KwafAXTshhrazLM0cH4PPVJccD2NvPXxpGEOybifH8MfgZPti7swwvEtSHWeOYVTQk1VN8EnlCnc6Z0Bv8fhJLGIev4Ti4y5gsTQL1r7lk3zmZYguu0fONBZnMfAyqqHjWJzEqMW9c568z1Lgb4pL5zwWfec0buLnRNwa/2f9qHfzlqTTLuPV1ct4/XtwmZvA+svtyfuPO3s7wKVWD+Yko+4u6Z1Yeebbk8F6t5cAu3mFc0sdMP35FgutNBMDanwcC0STzvcYqcnuf7o9/fU4tlvkrpUEpD6khcGX9vrfI2skDg8PLXuxAnt/Zb2nEo5sFJrcHEAO5JtvAu+9AxMfjC7Wn9ALEu6B85IWicbifMTwJ+CBH0go+BmLnXi0E69D/1L/U5J7Id7sbMfiGQwGVePf6xXaCR0c3i6tm58FCDqfaSbmqscv8+0EzpQMpRDOm1hMYqVF6WzF4mU8ehmvR/lWmvhesTuHCqaYEVr7ZL6Sh/YUO/1Ep+lp3vNOIHmvtsI30BWbXObHEfTX6cJeiJJATyFbTRSudbv4ahycdMxjGyznTZwT8uW5F50GaVnQY2C1lNXVeg7naSxSAKU0Xk/Sc5kf9xLGdKrzFuvNg6JWaxXHOquY8ywWHsxrEMXOOwqGcQrb6D1NN6wDgwy5lrnzQy9elJvF/oqNRvmzKIHJdF7TIiA/5eyrJUWIp4V8Tq2cehfOCxmCTK9wWNT5L1gPMJJ58DIpnA+UI/OSaXrqHFClyiLZSXKc+wunC+P39qPgHCXdOu2tN4dopqMwAGAu8YWpQCftBgVESx39HHjfZaEo12sqYQ2S0lyUsG2R4C9zJ8wFrKmfC/Tgl9uORyGgZ5yYQhmEcgoFEJpRqITQPFeQZXAPPhmWi3k+mudaOQiSznSShkBIO8lr4FcdO0j/tNAhSsnUuA35dYWsxa55uWeXXlllJKYo1OkvHwc2soYqwwFa0gHLtCx4Fr+kVMz9DvS2Eti6O4XDRMTuy8LRckJAZo4SMbu/Ju7XqyvnK2vnFcPNLJ1feYuvDnt5FdWFXvFHer9cU+qLw10WLxXjH2vltgrnoPYNN6RIsnqqfDtAFI1k2EEia6QBvhVBIw12pCgzJ8qWGkobqaqhMHNu1NKxJb+RF1vyGmnYUpw5+XJLs0aqamneSMaGJo00bOiskYYNnWTOJU/zplNRS0BGQ0wbubC248w5X+7iaSNVdfGikYxd/NZIw0ofN9Kwi9+lL6fLXLwvrRIAYUqhNEAtIec4Fz9KQNbn9Ispp7lI8xHTnaiIpzSvHq9Jrlyg6C5ysRe3Z96jlwL0JocjAmAujE5KOsbcTt8JzKHmdgbKz8WuR+bS51lUqGzAwmBD3wBHlc7jXNyMgadd0udZaRwsyM443wEMc3RR+p4ecApya+ys9Y9smx7/3U1GLfWojFDcfeo5O4254DMhX/+hbC9hRuPW2pgFfiJIZ8eJrPdxTSmpmrLP3OcaUNbue8/5uFR35eIOeBpgTmDKoAfIXuB1GH/9o6AafubiPBgCLpdKuYgA5Q+RKvKEs1BLoCP8AljsKh8g/Q5ZXGQyLcNrizyNz1AnoCM+oBPtKneAuQuooazSSkyLSADxk+F4w/mQ+i/quwrxJRnVFH/UW/V44tgucoH07JEyzQv0I2G5ftfAL9T7DCbluXoEPjYpH1RKblIKVWpmUqKies5FEvfbubiMR6Xv/vCc3Vx8iKxTOO4+5+JtDRS5N1pOj8jVdN5QyQsouQUryh6f5Y6wVfk798gyxwdSfSudBo8Lq09XUSS16NaeU9gu6mpOpF+ncgaj0uR7qy6VXLxeR7kE3oF9wk1ltQ6BLJFGL5ANk75MnVchIgy6GbadJy0l5QH7jTsheiVfNLDoHvu6KitXd1T1XkvVN/7HdZNZDdV7s1Gvnnbk2L+VzCmR8aeHDswFvc49+o726LKep9fUQ64RnWypPqjiG8LwqBAHLiDndI7G06aVrN5KVnNxZTtv/21r19rAFeha/x9b1w6xbOcZtbyTAv+dC/5aMlvsVveae1lNcZb8/DWlz+obPdQBU0MqIbb0wvymtFEtz3beLw1dC4FPSks6INVACbl//G6iGMwURnegWUsl0bCdr39S228me6lu6WnLef1HO04vwf5SL1Te09LCmXsVUmef/+uhV+X5oF/8LwfNalXDfUU1PgcY+nJN3exVomJzYPyGGllyu2ETSo8Jkm/A7j5wXqQERtDghwaotjUjPbaiG+Al10ulaDmV9zIpS1V96ljQUTgm2/1MwRQHdQ9V9KAL+pgMRGDUYHpZzypGAxc9BAX/6HmqbHM8FTQdT0lnUy3QglpAlZtQ5fj8gN7XsN3KTRXpwx7k4lkdQPHGiptLjno9FOO7TzI6cAYk5J6JV6U1S1GAjaE5hLLZP9aE9eg3R3V96JMI9XJnNXip+YBeGzhRK1w4KXptKuxRFLML2XH1cPhl3nC7l457vfJIRCP0hofXKe7LQDUGnUjhX9k6DNVZAvKoNQeMDdDiwIzvatnTy3h85IzxJs1JZ8toYUmt3Uiwqwfq1CbZHGjVKONRYIT0hJttbsjXy+tOBAgNjDFRe3dS/sqhOziicCaectqGEzZaHGPBiPylblcKXBO6UzfPGKmlewfTfB5Z/sy28V3RY2MYRX4uAtKRJjj0flv14ux3tXum9uENVj/qhhm977hlxjXdmFnSzSdqCbV2g2c0vkMQ/wy1jwqRS65rNhPf8hoYo6XwQIjqCEa/W3itOvLp1/mJlg5AjaPfRkQVsCo6SVsSNz2fsx6WFX+g3it5Ub1Xguqz6pUSfMFDZPCHuZrANCbZU44USnmPNb9+wmjtjsmZpvMOisESzGc2HSmTfyh1Xis1UaXOZssEBy91kVT+mOAcn4kIaHLgbC8p1CAd9Xg2BZK805n4GLRoF5lruyuY6NHHwG3Bo8pkkb2Dh78B6Yl1Pi+nXjnHMxTWI+ZGofD5TPjB6KflA5r5GTinM/EDdhlwFRcz4eEHDz5sB863mYgxGkP0TeA8nokcozlEnwTO95mYYXQG0b3A2ZmJOUbnEL0ZOC9pCt7BZHxsmQw9F49oLn7OxLsWrPM2IogmTKoFajdLfSuMz3of1C3qC7tSnkOSfFchR3QeB81stzRD9f1Q9UGe3aU8EuHzfBInf/5dzvcmJ+x823lDcLSXAc/VAoeKIVdIlR5fMfoTpQg2N0aILNXz3mUDj5bSC8hAXhEGQ7vadfRUaCp+oK2OE2LFvtHhgdwhPe5LujIiHYdHTgzkt3c0JEVR+Rh7jI+xe7XH2BPHIyVezCoi/FiZ/gAj1zgtq6NfHfZOHqFvlLczvWmezMRBy6H1O9dBRmBLx4d+bInMF+DQFtmVs+tZb6Cbzt7/zcqPmVAE6cMj/RyUS83CZF8BEQv8Hc3BS4D8py0gAojgtTEXAbbqGijSeSSsPWvBQ8bUbdkVn3aa3hkMka1sdfBrDMUcqTmrIW5zIFlyMkyVVmuZVHfNxDM0l/OSRUwOTGaRbbOLakMMlPhIySU+CISqNpU2BlT67np8qjm4X1fuK3WXD5wXIKrIeu8DV0WhHxD6OhP7156E6Eq1pj3pJD0rG4UozXMl4/O74pS5u6aekWzoYQIb9M9lV64r+3wmXpdWlyV3geRprfBGrcbJdTW++uPefCC6D3iff9V/rlkKDI3uv0mG/h8sEce115UwBeUe1X2chgVSSgBeW+or4zugsFLza4Eja8BwQa/aAvKQ/nGwbvkGpVR0AQieiy8oTc7oF/neYH4tAcB1hFTSSyR4pEIJUN7/tqiiyJEkn4sCqEwgrCmAWoAUmNmOD7UCMeV49ItdjOciuZZq6BVX6I0qn4swsrp4jQjzP2spoQvcggKwl+eyAF02QonJb0r8LUucyRJZWiZTKHHymxJr1Cm9w7+ue2ERZOJl6EAwuxQfKZDn0Ukifs5M+GUitnnscwTM2m6VQvHPFC/EG/w9DgDPBOIn1nccJVPhz1ToMWCNZK4ir4NL4eEX38sLInXEOyxCjKn4kFKwTL6LkoLp6RzYXRHJCN5ai1SFp+KnJ0PQ8GkutlUM2elC7MpYmRRPLsVBjhG6whS7PobLDMa+HeogvRctdjE+DY6hlB+IzzIm9TrE1ozFngYAqp9mzg1KgumM5dcYRpNTMEJBeYDVfMprcejNk3oKTeUepWUAgmGqQrJPfi36eRbFgfB0mozGGA0jmOVchXCFY+x+GHvFW4DenEWo87Nawhx6MNcpRZCISVpFKP9ZLQHzn8gU2D1vZMn0XBRzFZJ9zyiapafvvSjLxSWVUECai5s+jwLAPcWEE4DpOUxShtOIF+iRF4vTlCIFXnZTdnEzb6RAkafNNJrZtzL1LMgK8WRmwpB/T8XS7wHOUUBR9T692EL4+R5cQr5yJoO5eO+rEPT2h4/LfwoFL3H8EHiNWb76MrJPTs/FaxkF1AqRT14V0XoE4gklBqcpvmq6RVUF2Ukgns50UA5DRotZOhXB3IR3QlFSLLqA7bOHdSXBCcL5J6wqKWaPsxPxFtPT06gQz2YqBOPax76lCKNPMG+aTYMMkqcUgTkS0VyFoI5czGYqtg3/LkWqP+6mp4EIMTb3Mlqu+ayKSEiYmBRavYiikf9dvNMhaPi5Ly+55bw881gMhvmO4kiBPMtVCBHLTlpFoI6XLErz9tEkFOIdFsy8BGbXn+ug7KBH8QA4O3E2oyDqWYnTkMKnME7xM6VwXoi9EJdeKV+IbUzPvdN5HOziGn7DMniZ+sqXAerHF4rMyjCEHfuYsqB4T+xS6ZQAMp2pcDD9lEQ/xM20FkcQpxQ0vRNTj4KowiNuYn2FF8XibUqh74F4pkNygO9qUYk43us0Gf0ho3NxQIFZlhYFJD8NZawUCYVSibW/+RSRW/v9rIrg3tBRGPgLT4ZjwO9Se018pKIw+zlibvEBo2WCp9HbkIIII+9zHYRx/zARmsyvKvpDfE1VCDK91mHKsy9juBAHsoGfgKuepzpImV5QdD7FDZN4JkzfCozLtwtEVoVheIGH649WW2lZiNfYmXPYPbn4iNlQQiye4UAu0kzs5zKA8K2CsmWMYI9eqYCam1cpjxLu/aKSJBxh9iAB9idQ064ietqDC0DRU3l6y7A+u/c866vzFahz0jyIEeIRn5/OYYbkiXwaxEg1iq8yOo8KL0aQDukwBXpG5FjKjwHaRUmJ+LKleB/qIHX4ay1Kzb82SRT9QVF1cu+lYl+dvHAWC99zzEkLnz5TNDqLpoGYzWm805wq8fBL8EM8x8JS7UbEnglL9UiRUwqhLI8OKqRNkpkKSSOSWaqiSJ189lXkDVAoopixmMw9T3H5dRoWeUNFkHwTczrz0mzb82diElYRuQ3PVAqs1pavg/LTJxXfOU/EkyosP+7R2Qiw/JYCxf/X2NU2p43E4O/9F2EyDJ64bTL3jVTH5HppmzaTNEnTa2Aow4sNNMZQsIHcOf/99Ei72Gtg2k9eaV+8lrWSVqvdpeFIngE9IYF4jnd9TXDTV5KEZOiJ5hwwj4xZpl6CFuO4H6UD5p5hKJBsb6GVqthbkY5jLQfNSIeiFrGeoD4vGlgEpECvAGh0AK0KqMsxt/AhdBGW0xX9lx6TQA8G1EYm2ggcyLTW9HkUoAN0owXPmW/ZsjPAz5T1TtzPAR3CBoFgWJoroFF5FBjI2B+UKnzB5sMQqk/BS70Kd6oQrIQfYvUhzWqcujaDAXljpIir7hUtbDIZs/YYGYjHUMckoctmNo3N3bRUyBAoLEJCyb5iirJ0qCjD7GdKqrtuGNgvedICd4juMbniO6GByZBARuophNjhgf7aay19H2s854BWWsSEB9IkB9H4GiCiHGkNVnoMet2eCJNPaAc7qejH1KTMnio6E4SdMdPXkQXfsR5J6L3ACV3oM6BbMYK6a3pQS2rNUvVG7SfmoG82xdg4Qpo7k5gETEokF0na0+/73DXgu27EL/9pQUPYpoUNuT6J0AfiyzzlvsrLWESNZ9ETdTDq2diiR3xRPH3Loo3Ve0KHYpFN2a7/W1MrCtUWGtCoq4lzFkgzk75L2EiijkIa+ElLQBr3SVNJB4OUTYdeuEmrkFgpYsbzHBpqQQnooCcFFtxd+oD/JBNHWorRk/L0jvubsLIgINSUobXYKJD+j5KK2U6Qv/RBrRQ2+q4lQ+wTlYz/TF0EE/2yhOK//jZH5UL1fgcSc6UdaG7ii6BBK+nSx5EFVTP05N+lPbYxMETkq9IJBZEmYNMjaYM3aSU2ynjCQvG9mitGSpypkWPH0qPY/MnUiIVrzRWXD020ohnJF5pVHIj/GpSy07lC4qmhtdSdjyf0w6bAFGcWUK54VDDFLJiJL+ZKbPTehULjn2lwMaCPasoYJxA9jCyo4+pGbIONggpK2knKsOIQe2Erlj8/uCsNivnOim0hWNWXi2JkM1eirp+a5/8n0/36wQnCJ159Pb+9u7i+ojj257VWBW6Cil8x3gJOyRTdPqWnDJj5RZ7SjLYTOtJsxW3nXokm9mnxOzB75qowfp0q8JwUg1+5PhUdSC/yy4cKB5Dbw0x0jV0n4IgRqFYPkkbxIildQbfXgW82iBXrNACiX2/hvOh0sCY390tIry4Xa42DVR4GIJeySOF7bBRFTHV8VEO5wXje6bw5blSURPAeymlWvvulRya/vSuwQTq+uQGLycJ5OfxsyKqfwYTlGbAhr8wttmhsFqePsJDCBL1F3CDReXy6l/ixs9mvREK5Cd1M3XOKWEx9goXAPwxR4OROHJKTC2ZZ4Cf2i2BF8ZdAa219hIk0Uy5CjEaBwPs/xCEpD4vaiWd3BLaO2/a9xvUhRBxHe+inbCxv5pfqy3/3zS7TbTGpdgy9KcWCq0NuT5vaIhZ2XOZSq3tXuEmhVuyJzVrbVVds8X31N2woRSWc12kg9/Hs8RHv3pS7NW6ZqWuuMCh7or0yvYwf4RdfricWyp4/t7r6CMpLkY/9fClSL+QzLviS8KnFfx5nWfLm2LMfM8cBYywJcNPexhlQe4m947J6NBe3ooQH56ez2ZttcUXoPPdF1l4mXl2bwZlinhwj5Xa/5G/49f/bCAw9uslKl1KrxgOxhwelQ/dgAh5SxYo7h9Dr77VGXYmWgXsy/smZ/jUvk64cvtYt+zj/SYuDSzNIBK+Ql1KzFTSsLFCBgY32BZlQT3AhRZBlr7/jVZu6py9SJnRBZ2KtsqR4k+0AtCkFjdZJu7AbOaTEjSfDajKWoSMKs0yudfN3RVanZotyE1uU47Y/9XLlhBuDsJRdT55Po2p1XlyS3YyWfrV6crA5/wGnQVBEByfKpKPS/mx/RgcHe0Li/A6NWWuO/CWF/JzJ+SKMibCgtMSW+8KolNaH+XUx3G/b7eEv4+QWu+Lkhv5os1bOA2jZcK5OmcpVS3kQ3MLzWV03hgXxXd8A9aGKAwjzmRgb6AU/FqNxCAMGVi0esjuPE2msOa4FY8567kT4L4Zd0VCG6pmps+HD2AMHzpjb0MGKZVh+f1YueNrcqyVKh5nJZdEwZdwQQhNHVdzRnqtjpVoPZ300Uhz+EDt3XUK77FiXK9Sb465GracLfL8xlps8bpzbrudyWcFRpXJqDdMQR0awPRouWkGbWm3Pl5ThEJSu6zImzAS8l7Nv0to3f8kCCdlcSYtVdCCysSPFvz23S5pSPGOHSVkfqNP4oYQXAtJN4he3efE07maBGUehVVkmS0Lf3Q42gW9/7mJjTOgCF8emME8opy7S9il00cn04x0b5c1yL3n6tYWjvltX5xBFDGSmj0PXHTl3H7UpDXkO8Oz3AhqAhXZIF3VA7LgUQTNedSeDajVPN/SIhF7gK25HBFcvQDhrGjRqtTR4FaxlBx7X8LReoPVZvWni2Sve4vQ/2i8SQzcdAQA="
-)};
-const _a2navy = function _lodash(lodash_min_4_17_21)
+)}
+
+function _lodash(lodash_min_4_17_21)
 {
   // We push the source into a DOM element so es-module-shims picks it up
   const script = document.createElement("script");
@@ -29995,11 +29607,14 @@ const _a2navy = function _lodash(lodash_min_4_17_21)
   script.setAttribute("data-mime", "application/javascript");
   script.textContent = lodash_min_4_17_21;
   document.body.appendChild(script);
-};
-const _10o0pg6 = function _htl_0_3_1(){return(
+}
+
+
+function _htl_0_3_1(){return(
 "H4sICEHOK2cCA2h0bC5taW4uanMApRlpU+M49vv8iuCl0lYhnDjQQBzUKZphaqYKaArSOzPLpLeVWEncOLJblnMsyX/fJ1k+cjC9VfuBivX07qd3SDQatYmUceI1GuNATtKBM4ymjWiQMDGjg5BNvjcmMqzNms6J49auo3gpgvFE1lpNt33carbc2qcCF9d+40Pnp4NRyocyiLjNsESvVjT4xobSIkQuYxaNamwRR0Im9bqVcp+NAs586yDfnEZ+GrKutA0W8qycXckho6rXs1+HTv1u9mk/W4bO6oNsT9o2I/vEjMNoQMPeJEi65afHVquEhSPkgMnkdY3WtgQwtkuDwJw0YbVEigBM6uQbNam2hhFPZE0SPxqmU8alMxSMSnYTMrWyLcmmcQgAC3UEk6kAMifgnIlfe3e3hOGCLpgqG+4jn9nAJOISgPigidaFPP5jefdPtqVCC5Gdz+fO/MSJxLjRajabjWQ2trA1fksPuc44C/JJh86hSRKMud2zJQZ/fngNRjZPw5AQwpxRIBJ5PQlCHxlmaqsDKNU9jRrSLUzmCDaNZkwDN/BR50fOTGLKqwbQOGbcN5wQ2IAQfh0JOlboXq46Q2iNMN0xjOvdPUZ1Fcx725Tu39jgsS0dMilvxe1ns/zFENioM4qE3any7KAtSzd8ljtjra1MyFkTB+SshSNyeo6H5PQ9DsnJCR6RMxenxG1in7gujonbwgPinuAJcU/xC3HP8Zi0WnhKWid4TlpneEH+9ihd79t22+12YxEG/MXCy30If9zdKqSLBqdTBuEcMgvP3hS0mIY8aVj4inA2r93RGHKdSsjDQSrZPXCAE12se5DlsB7QhP0i2PeU8eHSrB9ENApCtTuk4fAOckx9hkH8QOXkMw+gdGDLD0YjyPNrFSjKJUCYP2YGGcglEznqOFzGk0c2Up+C+gEEricoTyB00wosR39hgrPwjoKii2KpNm8ZH8uJBi0fooAb7OVTDC5kZtELpvoz1MhX/rc0UcqFwTSQAR+DvuyKj7V1UyqA+a9MVetimWuRrX4PfC1xSpOX66zKlAjJS/7N0+mnoaQzLTkGLxWqwgI8wbdoDbTqBQMqMLR9V/KPyvefle9/qW/BVF9hV2E8odV1EkPmPlIogxqqTZ+xnLVgoz+ynz/1TwyZdR2lOobZ6udU6O/vaSCYf7MA1RMoqUkF+AugpULbq6SlIRWVo5CDbqDTcGZAkMH+HZOTyFdLSYX8NBolTG9K/2c2C6juYWoZyOGkB2dQ80/FCE7+ExxGFbVkmUCXuKV8nNKxAkjVWP9Jw1RjA98x027LvpSNki3KwzML2PxjtDBfPY0Ei8X1hEKBD59YCM6LlAOWu6D/RNH0ivsPUFj7zhQyTFWrZ+bI6DaaM3EN2WMjzPoIytp9mYbPls5yjw5lqrobvu7jAiaGIgo3YROhsqUC2MFIJtF8AwAu20KROsMzwDT0QvAYlJl8aapJvlbBnRXfnilKs34flR28l00rpoQWHf9V0LnH1+g1ZNAQMcULfA3lzFWVShWjpq7RapORJpYEPK6LeOJkOdphl7JzdFTp1vyZ9XV7/NDMgaIkU5vJXJ0Qewnb4PLa3DP99oCInIKRr4evYv1VMbqxKUKzI6I6EcwXQ2Y3ni/7jTG+RR0WJky3awjWIxvDkbW/XjYOX+n6+a+/kg+N/ldsBRZyJEukPXOSMADyY2qUP24h0BzJiYjmNcXiRgiwFgaqhI5YDVxTU6cP2rASv14PIAteOlpp18uaqVitbFELdPIM1eSlpprVylITFISsGMhEvS6en5bTQRQ6AdQKCkeyv1o17K73ZfUBHTYyFcF5x24f1euNL7BzuTpEZkOirg1KWH8tToYHx8eeZx2xI+v4GNZwEK5W0OMukAcYmd+qrqpnvkKdivptTwecKv8uSYwbX57BXf1CGCpnILDwwIWhAGIzI7kLm3hxnOlqXGm4r4HsoEk0lQUDrU2NQsBRqf/unVUigpOWcOwB27DKeMMJBAfc2QIBj93hWGSctAe04Yah4jiLAr+mxNN6vRSNlSaEvhnnlH9PI8n8GsyvclkzodNBp6Ujvzy/s/or5SbjUCNX+zPe6/pt3Mz3/l7cd3sw072Y1h7MM5VDymUV5xxZBNxdddGOAwI+oyG4bBBwP7NZc3vxMtZwraBpKL0f063X1TLBiSzLA6+WB7UznKh247MrdanYLgaQVxAruDzBsWxtmNjSO2EX4O/1ZwSfJ96TzSE1BIz1lGThh/J1io+PGfLOTtTZ6gKr9xnAVpVNfVUZ5zwKMsU8AOauV1BW8U+9zwb/DGR+g8lbYKgihU6TjIE+gfku6HQIZaw799ytuCleUEM08WqViQbW56UqI7W+gBmVHbkwimZGalsuFNL2xgb/C8N/L3ugyUVof7c1oEp+vqFeYdsIvtqFm3LD/jeN2jnLk1MdnCVJvZO2+fT3Mo21L7YyIyPXeg+20itjt2crziIHgStC9EZcBpuYlbBu6Xa2czwmm+dnF+F9RfimVDfbGiras002LztsDIZCnv4I9yXLKoVwkVFp6eNNhhdFhrkQ3YM8DfeIbheiW839EgFeoGilprsormfAVei4YtVezlVji4pwqvUdvqGv2jZMxz9ylSkuwGqzUh25SLNQQXuPVUnbXx3m1QJ2vsn6vDhMrQtFPd+VflEpaIDWLurWHtwslep1CkzzQlMe2R14UZe24K4WCRm5JSSv/kuTx+s1tJb87eSeMHuGcG/7kt8TjP1OQ7h92ff4CqsRAh+4CD+S53523e85HGYq/fiDOuW813OGqRDqXQd28q7AHA4rddst2kMxZzKnuA4nxZDKofuIsvvwSwHdhxspr+oi7lE8U9cNL1kT+cz1qNr44nlm9IFRs5BQDq1H1MwmLdTvPMAkTRF4isOf0KJNc4M5sCbLoVez3xqiwM37ZpouA1wivMpIlI1A3Y+22sICeZ9ALsfZdNW1LA+a/XqtBuDapgnJfhOSN03AezSSoBHtE+kp+VQ9Nprxd236yqZM5vhUVn3HnJjm0YR5oKJHhlpRRk2a2xM0Ui92cB+WHxn4l9kcjmont3VnuAZf8Z3hGu3jexskEtpgFaweBa+jUN0SwQMoP0mC8PyW4EKbZx3xAS5D4C1EybZyz6IP7sz0K4+DqCnVkLnZqHqyQbVza+gKbzuZ8kQRqLB/i8tbFFxTPDpxmkAaQfDWpWJMKfaIqiHafOQrX9rsezXa5XfIW/Uqm219rf/j8JVVK2QTblnRk46MjdadryXZU0lWO3t/SVi9zi5Ju7latc/zldtqlQSfKwSql8OFym2a31b2e2J+XTXisZL0rkKqOBc6AZp5FI1FJCN1coq9kvywJLeSoQhi9a5PsgudSUxY3CiPFjQ3FRp1XQSn0pwqu9hvqvhN3cQxL9U0uaBgm28RJc2nnAYqYv6a+PnxN2C8gE4j4URuPmJIcuWMmbrJrVYS3zsTmqhbXRdkMXlVPCs+2fcGTXP3Nre1RqUOD9kLwv+tQXbU9iuhVNjaB3ipw8dMhx/VXEe/UCW/B3JiwyXZMoY/iCiG1FlCOYF6mpVcKKHORE5DAt3QSWZjQuF3xoR6MyOW/reQhc3Jyf7NUnBh2Pr3v1lyp/+lY+HXrK8cNNdoDdPqT/8FYW6I33saAAA="
-)};
-const _1i4ixrk = function _htl(htl_0_3_1)
+)}
+
+function _htl(htl_0_3_1)
 {
   // We push the source into a DOM element so es-module-shims picks it up
   const script = document.createElement("script");
@@ -30009,11 +29624,14 @@ const _1i4ixrk = function _htl(htl_0_3_1)
   script.setAttribute("data-mime", "application/javascript");
   script.textContent = htl_0_3_1;
   document.body.appendChild(script);
-};
-const _nkuke7 = function _inputs_0_12_0(){return(
+}
+
+
+function _inputs_0_12_0(){return(
 "H4sIADqR92kAA9U9a1fcRrLf+RXyXJ9dyQzDw0k2GcBcYuPE52KcNXizu5jYYkaA7EGajDQYlsx/v/XoR7XUmgfGSTbnxIz6WV1dXV1VXV29uhpkeT95d5n3x4OkWL0oB6vFqLeaZv3kuvOhWDobZ70yzbNglEDS6MfychAW5SjNzqPgdikIenlWlEGZXA4HcZkE20E/740vk6zs9EYJpOwNEvwKW7pIK9qEavqrk2YZtHr0ch+qcruYPUrK8SizbaWXw3xUHgCkoakJPZeQ1w7K0TiBRidVWA+vzj2gnjfCeHAYti7KcthdXf306VPn0+NOPjpf3VhbW1strs5b7aB1zsCfT4f6HGG5ikfBBSALCrw6/ZD0yk5cFOl5Fl7cDJNRmVyXocVoOwjPRvE5AhEF208I2vTMJnbO0lFRPr1IB/1ge3s7yMaDQaS7w4/NGRVM+iBWyaa6yRoll/lVQpm+dmjkjMJiGGdTZhqzGVH4qxMPhzBQt91IoAsLAcaidnBrgOkG86DJfkygQcQ4zNNMhANZQEPnDqLP58ZwreS5B6fnDjLPq1gUdDJj1FVYGf+6fH0OnqnP56pESP19gp4TF/TIzrucnyZQdWGE2CD76atne++Odr8HML4TKfvPIWF9TaQ8p5QNkfL0NaY8FimHP+0+3YPEx7LYm59+2nv9bheSv/m6lvxv7Fd2s//qZ1X6u7/Vkv9NIMjG94+wXdnAD5Qiyxzu7x7+CIlfyQafqTQJ0ve7Bz8g9HJIe3/H5tZlzb+/eXVEo/xKdmJSJRr//mbv8OjFqwNsQ7V6eLR7hN0f4RjXZdrR7g/vXv20h4U3ZPrewTOZ97ha52D3JXb8lUz//tUPbw7fPX318uXeASLkaydz7/mr13vvdo+OXr/4/g0kqBa+kYV2nx/hRFTL/M0pU839dmo3/9jdf7NnCa3aBmW/e/bqzff7iDlA5zNBhP7Shy8OfnBKr08r/ebAFtyYNlgubgs7OD/c23/+7un+K+z7HSS9PsJpwGLOFCjkcwnM/boxV1Pj+jeeIpj+N1/V/b3Dw3dHP+4eABZ+QMpY/3Z2MU3k69/NWVbDtrG2SAVTa91XCylaF9hoKIB5j5sqq0FsOAh/ufv6/9789O7Z3tP93de7uOzMcnJQ/3r356O9fyJeN77xpNfxuvE3X7HKstz4dlohtT42NNZ/fPWznF9TGdP39vd0Oqce/esnSQ3fitRa2YPDd4f/QNxMk4JM0X/uvzj4P3/h9e+++271epBmH0VxkpU8hSEDK3y7msWXCcgCvcSpdHA4BaDry0FWrLbM3r/b/zAuyt0SJLLTcZkUUDVLPgUv42F4DJtZK9Y5B9BXq+0kHcHWy0mncZE8HyW/jpOsd2OTfhrlZ7CPckIvHvRegjiqvgbp8Ke4vHiTpWXBSf307GxcJE9xw46zkhOT/nlia0FrZTISdc4HN8OL18mZ+hrF/RT23KNRnBVn+ejSTRb1PiajLBm8jGEk1zIFi+wn2Xl5oVNvfsrTzFa7ORzCLCX2+yi91F8DqsgYVSnpZVqCqAtjSnazc42Ky3gE3f2YpOcXpUwRAHLCz2lfQ3IZFx+fsvzuFCs+is9sfPmqV8ZXGqIhYFgOB74Bf1m9HZVRQZxKleUIGbvlP93Pf7mf/1afo6RIRlfJ7mB4EVeSiiHIm69j0D10BqHqKhGdjZKzf5pf/9K/hiC1Pc3HmkA44dl4pD9/HaejpL93DSMsQLMp3PTnUHg80vhBKMaDeOTSnE7dux7CvNlUkBf7L5PyIu+rlDIela/OzopEFyn7z5KrFEeV6ZS07F0cwSLQPY5HZ7BgD2E1KGIobgpQ0Pbj7Hwcn6u0Mj4dJP+IB2NdDXo6TzTW+UMhBEVfOcVXafLp+/zafhxRaf6+fnoRgx42OEwGgP5c4ezGm/qfPL/czfo/gWaydNK5BIYQIr8hwfoYf3XKfD//lIyewkoPQSrHtJPIqhXP8xFQeObwltVHwf++e/fTG5BU3gWPVh1ec9wiBtiNe+UYtd624ZknbZk96o3yQWP2xQi5gT9vWr3iIv/UlAeT2FyxJC5Yy7scdAcwpyrn5b5IZ5Zdz0BaNTxcJnd5ZxCZSyeAZ6O8V3WgdjDMi3I4yntJUbAmr7USVSW8DUbxp67SxAtQUKhUEAwSUFZLtktY4XlT5GEF3GBaNrGMz3F7OMT1UEu1Cc5eUins5O1lfZuDxpbnxPeh1zVOBxYVhJj5AdPawSX8ATInRa7oMB/ehMyt4HIzWF7+oEen1cE0G47LDWOJKI4/nGyqAqixfgieBGu2jq51hQtS9iSqgeb+CZd6EBL2ZGWoDivEFVW6Tj73ys0/0Jq0W8Caja4J8PcPb6n85P1mpRw2lRZ7RS8eIhd5HX86QspQsxHVGw70pC5vc/Ogig8HQKLh6vHWySqo0zDWtLyJqj1NgmQAA8MOcR2/Ts6BY4bvt1Yf3qreJsdv3xZPVk/et4NW2oo6wARKZWDqFIMUulhRJdWkBSvBRhQsMxxeWMuLUf6J+MbeaJSPwtY4K+KzBMmZarWawJw57Fq9peavU9gLPsoKE/904+Jpnutt/1wLvHK5lHanXpKfBWjQC377LUCuA5+aZrZxq8HRtIK//IVTjw9vLk/zQSeFlRMDVz/BaqvhTveX355ED1flXAAhA+LXTyKsvPoLlNn67WGkivBa8cyFRV9r68HKSrfbgon7AP+3VlaetKrYFMv4t21HJN/0Db65M0v5kk7/0kyod5s5vz5dnUuXVTZpwC48xBvrBIfTvfrLMayXk1mYr1EQTq1O2A7OYsDglHWu2Z5agsA/65wZ6MGlDbVAa6vLg9E60l2Qt8n+jDCHdXYWUYFWazqfav31rzUKmxMS5qMorEj+z2NkhNSx0a7tTzU8EBekRnkx3oDEgMspLdi2uk/rcMBIiGpLmGrp3XnW4NVSqyPAs8iUznonZE1qBKrmC4C9ytM+bpKzNiS3Fs5rEwcfZ7+O8zLpB8nlsLxR462y88at6pfjv7ZOfsPlM4UVzLv4mxZyfflP5UpfBhjHCrcgRH/9AvA4NsQF4WndAzxeA6tv0/Uvxakbm9jUtj0sZ/715llt7uqqrYo0A/hgjZ2mWb+2EBpQoXbU7nQ89pOzeDwou3fuX/eu/xpxPGVxHI+6ePMysngKsniGsnhal6t7KNOYGr0L1Mf7yS5sgKLP+cTrJnmLuwAGpM4xfJMud3JtarwPSUK3NRsuNLTOgqzB7uoVouo90OnMrC6krbWx3bTYLXppSrYdnC7qyLOYpG6Ik9zWKYHeQ6pLpT4TuKDbwcpKOuco9UHQrIE65zbNHUxvBEnOV/dOtCJR72dh82H983H4w8w1Yg0DC+FrJtLvvMia+f4hWlzmx5d3R6mSqSXjAVrBlLTedgi+HaRVZeSzVqb/MOwzZvRug7BgpUXVvhDsVA5+us3k8qW3+xnTPn0uUERfdEn4jnEXWXR7f5/Zw1Sa9OhxMEcgvazXNZgG/jvXGp45wvsB5TPF07kJoz7VX5oCAh8O7o9K/MaLO4Bwtxnw4OALLNAvyizvB8d32l0/j6f+ty/f+exun0c+7FQ0P6v16Lnz7up36snR8P/LKMo1mNybfLeQ0eHOMz7FMelLDGKqJefOxPQ7D6LJNvalJO8/YAXcyy4o5+EPx9Ufo238fvzIi5t7Y0Z+xMxewF9Op/6iw3U09i80yjsB5rh1zrEJzEHzdU/RP9pect+WkvoI7xdzewf3IbL8GVF2H4ZlvyvvnAhbcBp85PtZJOMCfT/27Cm+zdOx8mBhpN/7EvLAfL9rqcnh+8+zJhpB/H0Q8ZnYwFXyu2HEi5ZFwFoUEM0Cfh/+/seQH0DzReWuz2Nq+vbEnJxsgWn4Eoj8AgysYRf6r5cIGk5h50MeuQXVD7vRuBZ9hrTaxtP1uygPX+RAboqj66Iyk/+q0D0CubBgM5f67Lu6dIfpUc3c98Tc21Fz9YB/cyGkTD8h+2MxM//5ESxoc5K6Pess9Yvbde4XnM+0At0vMFP36Qd38464FzLSPlUN4p3vfGRKe1UHK+uRxojjWpzLPlSjPMfVx/c/dAyHTVHgUzz4SFcoKvffj0ZJ8jPlhdhGW/i0tcm3uK38iWVjfFcffdHxUs+xugWhLs1zT50suebwE2IClO8t+3upcr3xaIShJCBRI0P7emHBDv6DNw0dvzFctPJKpot37iZ2LjViUzZFot3nvWZLzvBgs93dkk9xm/15u4EaFl3iAiKVTR6nJ5s1prL6S7er/L4z/z2Npksoy3QZi12XN6KTKv/luTK3sAipfFkrIpLHf7JqJcIJd/gxuQGqC5TfchUoE+BifKoh49sHUK0GCo/UFrXO6yJtiv+6WOvKedqpN91/mr01CS50/FYV6yCKTnDoM9y5dTveuypAyUl5iHWL0HTeNn17fOkb76pQU9VJhObaLgrIsX4naLWC7tRulqZ9CwwIqpQEvQh1ynr3TKWCEOalApoGuqmoKbXaaPN1IXcuqRG13Ot3jhr3Efm7sgNMPPzNa3qs8gvkbf24jGvTwpMyjEcc+oQK8pdkt7Ksj73o5ptmr/GiUn0CuPMOlEtG5fcJsJmEq/K+0+wsd4f7TtPuzVQA3U9h6OYOjcjEgEVP8wHeiwWK8hGUs3tQfXuVbb0djBTacf94gvcXkZj9vAKLNuIH9gxobJ6l3ES+gqUblqEx6gfIx6wjpJMyzXyc0z+9poXqLbYdC0e3JpVo4cEwMS+BeBEwjyLhA7QJhCn9u30JqagzHBcXYa3GHIt/IkQ7MWUkMwHmRB920irr2gmlJGDgRtVNYHFDmAQ/KjNxYoLxrYwQbRRxD1aVc5P4/V/+5+GtyZKGjLWoU+aHtDrDaLL53mnTL6LLhp0wRlvb7IEHi5z+bm278YxgzTqBjJrKq4hGFVCqapyAwlVjMGRTzRlw/3k97bknjeM01ZKfvq5A470nJkDipaLZncExtajid8GEljmySpNb6aN27i7al1paq+iN0mHZontqTjpLQpA85Y5xpdPGco29490uIOe43j9fxXc6cDXKglVJ0IOc5pW9jXcwUcYNYuC06xG4hITPrdOtP9JSdCiWN69fEKQcGkavUXXdsB42YVNme+KxdM4TpRAgKjJzn554syfGQuciLqoKBAEoR3Nw6K9r+nJHqpkUo9LyEvy/1nbo1nRCDDaKeP9luKyMZE50zsZjDUO1xWRlUFqICs9qK5DbBSJBa21mp3BFPM5jOdYigpVJXCDFz2l5EbZWVlowfuoOJ/qnUY7BJm7COoXQTksF6xL2BEaxtFoJnfm/+SlGg0HWcPHrKi3RgmJp9orCiaTJElV47Szpa6NA7vCfrr5Se828IhtfniajFmS/f3h7PRlev4ci9NPdky7jm9OEQu2En/Bfp5dbvM5OoK1QZquroVFlac+cf2jJFYoYMDiMknI6PoUCaJ+41b+7rMNNRHiP4YgqPWMTU0gfDCM3Vsl3KaafwlIqexcvEITwVtslOCqMjvsROqkdjABEG5ZMjTq6qT3sjUI+8K8WDa/V1kOIXAh6F0nv4z/wLiFKE+pSu4c3u+WixdCa9llacchGJ1YJZ9Gm9XShSetFn8OQmE4ADy/6oSsbvXuXFe/erTy8XV7mOkxx8/c5iE+TgTMWItJ9TA4psx1ITJL5k9IjwV4oAcDFqKrvt+jrycNb+svXtMmazbFQHog73dw71gKmZm9mpjh0NdxNO1oqvdjwgLuVeeaMj5NCFaIWA8y8HW9sfLMOZHUrhtKi4ESsMhII/XGPfgFxYj99TuVgT4GyJWEardYlNMTdTmRw2yIfpMDtbiBDcQ8DgtQySXzj9Ioeo/GoG9LMlqbEQKLFNufuvObEa5b98oCcUjpJ6a542X6NojCpz2WMRof1NQp4loJD2H5M0k5wrOA/ASZ4fGLNuQrdxzq/rTo8oU3B0Z8WGJIOADsdKmGy2h2N4pvO2Si/DA0goYZp44QGrL8iVBh1G6i2c+ebai9VIV+BiW0Y4ieW1hvERbHNi/MJLQAq1In7feJkaAZIMhAmW6B2XqbI0lzeKiP64j5HjJsoy7Mr6JJM2cjkp49RIx6B1pzrxMSxdaxduuCDir3LXuJGi7m6yK3oJy1gcZZBHNjym1IhZDwxsAa72w9v9U+ShswMTBgBkE9/J0Ge9UC2/ggJeoMygGs0a9pQ0Ici1chG7nbFLSlJaQK8S/fP7GsS6cWn2UOdS5r1vaMn4ngNl4CimUiTAIX05UqRoAxO7nQ6qrLIc+QowQ8pdzF+GBNhSHZIKenZTUg/nN2FqQgUafyr83e4BgxMEBnnudoYapfQv6ddbmBHs0H6rAcRck2s0B9x2Lo89TQfjC+zIiS7pNmjTPdkT+xxmchEgZapemrZ8gjCwWVMBninBU7vnKXJoC/aETioF8OY2BwMu2PEcrG2BAyodhY1o3IdVirXILGkRY4EEZc00fzTmWlOQjiTDTprG5zGvY9iW+csue08wxAIUcDp/qB6WCRcphJmgGlxEB9waxZVatS63+r87pgcVZFnnFIsi7vIxyNkcFQE9Z43R09/xLRQcMzLNFOHcbLYS06VBYsE/varBQ851W1xMEj9pV+KLEdaAfmfMf6vJB6Fsspz2LIoEfS1r6IJSG/DuO+UeAnc5yKM+BbchrcI4T2i3Ie3jBbYoPTQ8aRLgUupAnxQUo64OapFLXQ5QdVWjU5pQJVXKap8tVBHN2qT28HjaELK0Xv959/601nZAnM38I/DPjAh2ArWsA+FmBVMawffcONU4EnwHfyHZZa5jFPEJnzlsi3MUOcEdRVNRJaBcuRLwNtwO2itteZZlsN4VCRayh8hU6coaMcryydv+7cbk2gH/nw1gaQV+jY/op1oBz6O6KOr88yPtx349ViX+vdvpsHujqn+cFWqegiIOr73MoNRIgO3UYya1l0Ws37lwV3NOnq/ZiDGj2CRzczD47gd3M6aVXg6s7TaOc4Et7SfY7DU3XGZU5gC+Ej/k4Qh/Uqqcf6pxgEp/sgaZQucquuJ4Wpbqxapq0DVjxitZcHpUDfUrR8kITpNccKtKSsjZ+mHAupwTxt78zi2aT3CKtAwkcUMKysDvcGG27PCdnUCQqeQAcyDZRmelLOPRumltGorXm9OzeyZgWXw6IphPDCWOHReugaJK8CAU1J78nHZdQ/h1n2+GiZ80HEqDgbpnLXVadlQSNR6uu46sjlHNVxnTdbBvXWNsR2pFmzlqY3VQjHRIl9mKKkkDnCz2tUT09Gat2FtVdQGFqqBB2425F+6hvuYTgAgyfu0GxQehk/0qrZ/QW+u5NJ6oQJGPVNP1jgmekW5Z9wAThU5V5icdk2MVqSJOn+CYhdQtU4BRGPtnUCfHmpR/CwUrSYL8q0iH7lcKy56CcW+CuN2cOoMHeYtzZJ+CKkr5iMmu3IYA/GdAnAr6wBZDJjHD/V7mz7W4ANEsYqhLjHdnbaD2NtdLLs7/czuuBX3mKSv48+iqP2A13JHyY0LorN3keeQo3dVeiUFjRjH16zUXqtA0SSCUEY7sFnWekiHsU+5sfA2uITlkg4HCSz69Drpv1Sf7UCHPi4oinXSf4HvMaHUxAld9XdD2zwrEZEDBS8pDG3FIZiO2vQbKAv4OEmZseTsL+MhMnYaXtco7lyH6HJKLTX4ajVeWF311yfih0qFCfttDKmFrW+wThMSnE56FIU1Rq5WSMQdaqSakQrw21UrjjGpAVeFJcO/xln6qy4L2nI+RJwWZECyFjdHz2J8zmXB4KKNBoyqf8i8zerC8zSsp2Kuhrnw9HYd6nWsr3oyENWy0KZBuTZ0HMLvEBNUuxSgG5gp5C9fOrXc8KtVYx0yTQsBLv0GcsW2eScRGjZ5oYUfifxIKcZzr48RGenMZ3ITGaPLpqAY6P3BA/6pzIXY87a1f5D9wA4PGlKqXswx6ZHQOSZ9lfBBC0tPBMYJcxLR2FYHU8PwOD5pB8enzH4oiVi+qM0wRhqAYyByHbye2iFgcoYkzfDZhDA/XjsBIPKTKGJjEWiiJ8buSmHIgUUx/rkB5geiV0sLylIa6Ql+GZcXUOc6BEmIf6dZuI4bO71Dp6L1ypM5woGaQYfKsF1RTtIfLXXdpZw9HsAx2br0UcSJdUDW4g3yUvWb4NIfTL6J8qtSPJdLKK5jeZJe1JFT+ZliSG5dcwpQq2Q9gCx7apu0Cse1GS5npAUIyFAf7FCjcNxkStaHY3lGv2aU7l3EGb4C4RpCZ1SaZq0O7A6nIJAHiJrOKAkXPp8opsXRaAyt97V5lE+mF4HVpV/pYKa5TmWj1ieDvJJSq8bgooY5Jg84vbRNJzX/LrWyqu3r1jdrYKTKaKGOkBu73HQmnf/VGHUt6coZhyUsc16ulgrvOq22ARnZo0SP9PYxfWryK6DwlSzdhGRrS1NrTBy/XDk+acJrgDzM5LFitTVE63LS8fjNKuEqTNq2SzoxaJ7CBs84j8eeOn80M0YcDpDbN3TC29pMapH9VObOTKzHEe5O3Eooucz85QxUtmI8nsNDCcN6d+wGaOwEx/TrxJhzH3CzHWRIxgIUshTINnkfEfiMxQiSPtjQtJAyLcAYpeymupwxsWbyLCkA0zLhfCvaqZpDl2zSqD4DfpavJsBBu98x/DTPB0ksTPiGjhumqTIHwjAhxOHfFaHmMG42Pp1zOx86rfRocMbCpSVLtFfrJHUrw3oXOBV0RH+T0DLas8W3SapVb1ntV5ywJNXy+taHqVY/lsE8LO4VzKmiVyx3fKw8+4bHX4UpaydYdr67oIi7J24sDDb5cz7Ytgp3nWRz2kpa2tTBfbw6C42NcVGdPOl9PM3dZ4q1hs1ZoeVkCI478ooy7tEdlfznrFCNUCme3dZELuXiMRHWuenn+C0+yA+Us40eW+uJqv7wtnoaHE22+umVzscSvJUIiUO6ymwR5ggN2w9vCRsTeTKuDwylN4Njbdc52Lb1WJiQd942N06TCG2lE/aTooY1wqAeHnorDNUZw+R9pPezrVUzsi2ywD8x7zCouXNkdWAzLNgl/ARx0aFku49pRUVJHg2ympmq+rmrlub4yT6N3rSjRumIecup4wXg9GkdexUIQnAVfmPEinURwRYjfZaAbwCiSbtC7UrDaVF2S5m3NSnViyObg9KG1qSZu8zPzwdJeBsozwO5MRWW9oO6D5J5joqpjylDOqusCEo0wAkq8rhrTJgAFltDPITWk/rSMe5mE1w0+ItdMBaRdV1JV3LBwpWFKhPb1a6qlXS2bK5XKdWRkGs04uvvwYMr7MQKkegj4hKR+0SXtSHM6QoidgNefZqqXdnd2WBcGHEne0Vq67+TUR4KSZEkR76bY86qnNcXmDGNM2XybanWZBvaxsQ9vMpwHzO/I7Pcu+b+MS8qCxAuFaQoS9WjMb4lKPc93JTTovOuhi1EMnqjUoIhEX2maevosoUpq2YaEx/VfFVCnTnZFNDi4JqAddka98wrTN689oOrbwGrCrjKsQFHM+Q8QcAqQYsO/Kied4gzOkDqdFuXolpQ7XlbHMlecdARCcrmLJwGwQ360kgUbUpU1+np81BeJZ0aJ9C8gXUkcnG8F8r63dFeHWmNZI5lDXekd5qu+aVHlDkGaVHW/ZKfqZxQF7EqhU6puLSySMLxBfDfE7tZYekXFVdjm2N2MdNwitseV0JpqeL7hRlteTTOtdkCaMQvMS1UEHbPiDc4DSq3w92cLCZ1420mj8RNV6EcA6qRGRB5dJjK0SMcz3jc5tjgp7yZuThQeRf/wW2eF9VjlrjoZ8cc5RQJHYXJcqrbjVp5l165DLXBV2xmV9f7KRlU4zN+wzNkV0pRfqNDeSbDcdPmsfKVffohrrkfsuGTL7tjJt7rUZ7H0vl2w1bfcR1dSaRSWVp0AiLiFPJJ0u2p27CQHAUuuJuM1o3QmUVKFlsdTaZhdzs0V2Jjtcb1mVZeGBjDQWAxApU1C7pSv6glTXDjIXVeMTw4EFmRScMsAazoEvbEQNsehJGZgXOtzN4rLOJoRuFVmqQ1zNISqTDeEeYXCwr+1+w+7DEsKtSNkmE+KuXFE1W+aYAeK7pvEB5gceF4qAT/Y8N7UeZDlKLjc3pEWgMjg9zU8TK9qmscuh95fZrE7a4EMz4NdlU3s+oTskNshPUNsXj4zgeuVJZvcTXTFVFKp6fkLvIBHv7jJ79ZTmxqmAwGxDuJ/YDc3csvQSgpE/MdD9OS/U8g5TKlapfxtfpi8Vml2Q9xvcQUwkM1uoaitxwqF/fzbHBTvZ7CvolLzkF5XSl0dxx95FvfaS2v86mRLFFICwalkO6IKKQvbMfuoUpEYtghWf/kDJ+qqWowVqgG/+QMwNE2uqFm6jO+xs/42uQyBrkM/zYlbZb+zVlqlrfRh5R+cbKdcRwucAZS70ObrOwlkhagZJ7lZ2ehTJTlDI24JU2yKivoEMGyX5g9lzKudHF9saJ2LXHC9p1pyjnatzyWA2sSU7o7fbPNiOcdU6ThyDH4TZFUFP26Szm5jNNBqLOcW960yOURrFrXLarTqjOFRduBGrVWxqNFW4EatVaGgNVP+ai/YFO6Wn1shj6bbMO1+62Oq+iS2JKQKhduxZr1UZaCJlrWlU4IWXzNQ/S7gL05H+QjV/TFFA+bl3z1D+ejXuVjOnelcXlYq1YwGH0sKyCLTBVz/JKsVzKdfFyyeKjUH/qkyrCuDTxcgzPFcavVrIXE2ezpwGeQU1qJ/hTMsCnbMElg9zSGiWNcvzeeqcUsUia6XrVIxHSpaEhafFpIezdXHPB3PqR750ayamEiSVSkShrVxEJD4O8W6N9rNMmKNFstbZzDsZL2j9cqpLf2cr0z4kbLhk24B0fUsDY74RDK9NI/NsxYIb/H2aNUJtJnVkHqmHN4MlrcZfwIwFwoaOh6Fhqw/aVJzXeWWnI4rivoSrY7k9Wa7ms8ty3wTZJmHcgNUxEqzTwAcc/diK2SPcTHH7280csXlTiqz9TgK5oomdSkxdfRfMcnf4zEtijb6eXJqGfjWBn2A9NQ8QlHSvFJN4KQTG3FQ+otEJkv0opasZWoERLoulBTvVqD7ursp65q2MsB9VN1fal/R923UnxZn6G4YhOFOjINB3oJRlaear5/qXc7742KDc/gTCfO8M1oOmX+4vCVvidjL3OsrzkOAZ7OBO+Zr7/KIIIVBQGwzSNo6z95lrw6OyvIRPAoWE8ew7/fUOgvP4Tf3NFlAYdQuy/LjLGw6oczJveCNBc1N6Sf4+rtBuxYgR9RrTEHhVTpKAG10DBktztljSapgLMr0rnp1nR0C+oCN6g9nXUHzuEwF1fOxvxBZvJBYoP4cDIfpt/q2LNsc0VXChMlQt5389uAysoYZ5iDGt98nxUxV/lameLH6UnVoZDsXArKtAiv1OaIl6Jcv0SNBUQQn4dsVnOhEtpfbXo1tvJ0uxY2fnIPo66MFUESYYCFqdGlPibTeclPoYyPsHXhqq5oCN9Pjm6PfnokPVd9TaoUqYDAA5i9DPgAQKKSEvWpAGOiPeY4UjXaZVf8YxFlauMk+jJUrOIce6Mc16j149zU+rGJWgl9/DGp0+vHz6XX24l3fDokmKQhhzYpZpcgTxEYrE6hCzDwdJC4DDwdVORRKYHGvV4yJLW/Fw9hpGyZFT5m08VSACuBTScrV1S5FfhIANSVcTYukv4KqAl4LYmN9YvUKEdxVpDst423dwbqwIt+zTRCTDceYBvWdmC+Fje1MvIgmX+oAPGMR0hVv5R1VeEU5Vb1809uqVxY3aYjtZq+LRQ/PiIVfjBVB7bH6L+WUMgQM+OGEFSacYtRhbXXzY4oKfPxVpBQI7UiKQLmqAUNlJmeZznMLhdjfdE6eNcLLbo2R3iBQxsFkmGRDshHfD1Z+UZGOOMr3YBhiljkyFzI/EysaD3yrQAwpYpBc7oi/3UuEtHdk2sTbkv7B5iS7NvgzPRrhBlkHVVm0iC30dBC2xDKoCd+gdHXbpsb0NH4GjpxakKDXLcbHKOGjVrlCbE3bon+bCwpRbl+x9Nek29LdtOmnfcq4ZuWnjhoSH1pmcaDf5gz/jIZVlll5ZhsmndBPVSa2d/1nN3/rUi6yALbU03tosRgGRX1KOCPlRfZGY75xlSMrz0VMREqgjYfBfxRqwfNPcG8SEwZUguaRrAzoBjB950rkqHcELLkHGPyGD8BmADHTZASABj8a/lrZuJU1OwenKWMFWnxHMFOyFoBfAXBZgaiTRe2BI5lh4arS2Cf5OKCIAiPwlac3ZDrBGQo+4rq1RxwNp9p6WNwOhPjan4jDPNqEplpAWgU8Wpw7gV7EB05266+JW0dBxQd2kJzUaItPvWKLq86BxqdZHvs1ErhRdl8AIl2ROSZWalRG4RqaK4RqLKN4CO+S7Vy7C6E5AMErRaGSAeiEeDwqih5WZS0Lkq9MEpaGZioREOeRx8JU06VgktFwuUUGi4VEZfNVCxvqLiTr2mE7lM4ObxG/YTPsEqappRpJB0ogpbEQJAZCHY0crrTkYNH4+JYvGmoUwBvhtJxejFzZaMzOstLE7dcZ3MHVLyTNKg44BzioCo5AZGXRjFFMLzLNdmK3XHDerTwy1LUqXFcXFb6Gapb5iI2LRRzFZvWyZW8Qf7AEPiVjdh0JUlJH3qYwDoqV7uFewrpKRJnwUryke5JVovVw+O5VlzYbVLC7ICsNUY1FTVo58JExftME4DvgrC3H6sYO9lGftJWVVtO+uO613fNzedomg9VBb1aGp6OXy/ssxAr90XfzEhWI27xzo3Qq/tFypf3JZMYdcfrxV8zaYqR3xHJc6DZi+j56bT+Aoi9eCIl/IocqlmTW6SRWdRaa77NIosJNax+qYV31kpst5Vr91blr+N4VC1zHTwKKsVYchL3eM/cTRU2fE5RIreBatMpT9yn+BUvt+qLoQSAp9QgPzeFKCG5HnqKQapbDOoJrODIKHYIwB+etQPgeddRfWiYdYNZRq/CzRy15PU1UFH7yQAvTp7BzzMKb4aS2rUrBeClp+VrzMRQV8u0S/dzRYdnGBTsLNTy3Nk6fwbLWr2XIWg4ZtnZeqTKrdliXOo6WNlmmFDrWofZ0kaCR1R9JbiJglX1E9phiUO9A0gDW1mhgDFAp4Sz+LQIqb0IkiVEepIIGRyQAXQ4GOmCwdqLJB71Ltzgg5Qk4jrZqE5NSvjrpADBoNBRkpSZUFk3uMiSsF/+Ok4ogDgr5WiR4ZWjuuZ8VwfH0oeUq+vITHQfCso8KC5A9P90kaBL3bC8IVGMguNqNyYnyu5dfF75eiaxWdWwo8cQhPwaJMwFl+HPUAfvVeDzBBagriS6UTMD5ylsJAYL0rWrIWo7XbNUqDzjL2pYnf0WuDONbsoLDIEJBUAH4p+FuQI63YxhLEuN0YYEMA9MyHOrud+jc669xskCOV1IILyzJld3EGu0C/9p3V+tHxwRgRM8hZqlX3P5rDG++PefzVZtHMaEbuJ3FfssFcVELlE83+dih/ukoeEdjpelrmKrP45vUWTukennrpkbSOGAz/8tAxJxums+g46Mo4NRabnRibwy5TQPzwqVNCkGap9CnCtyjpQuifhm1qdSpn5j5B3N9CvuXvKCn5XtmoLNLNVOfCXLDakPeY7Ec4fYf6/X0vtOMRykZbj6tlhePbcX7jkCf8nHrJByyW06gW/7lecF+vaZPy1W6Ugybox0JzqFxYoNxirBxcAnCnCJQFGOkaeddAoMglKRrDlkHrbB8Y812coygXmb0A2a6ntZOfAM0MyKe1Fo3vGQji9hrI7B16P/4b/KNatJxTPKsws7DjCKbMzU3ivt+Knn7nPPIwjo4RUxlqaJ7x9zserh+n1Nvu+OW20OHklC1cc5lQeTTaAKvnrbNy8iT9wLDhq5hGdnHtHm+zo537sehu/Dne4vvx3/8vbt8HZ/snISPbxN8FW9ROVT3cl7ULvTcSWcTaXcdSWYDaXgHTjcscPV47dvf3nYebS8E0bHb09uJ7+drJ5Dq2/fPvxLy8TScITk4AsF5eZNg49cTdB+HWhbZ6KPJ0IBuyynEGNa15G7W0VLR9VeRIVAEVKfivJXsO2JffMZsW5skJ2Cgh8rgYMkEhsCR0bvsrKNgsgTH8QjGJqbHBPvgT91j7Zm+CPj0kjRxhshp3J/Ov2cwDi0CicGdfUAOHZPbQyFY2PhbKkJ1Fb6zxYPfZKhmhN+j4F+Tt47zFFH21G5vPDZa3xaJJ2mODodXe2V9mXwhc4RHTSGzam0F7hRcyYLrpUSk8zDCfmnH5P0/AJXy8aGjIxjHmxpC7cA10NGjT//RLaQ9c7XxgfiMr5OL8eXyo5Gj+BiKaUeU6kL6lbFMo6vDRQX6ofUaUOqTdHOHwmQVyhmtnIZoYZ4MZJruwaFBR67V7FTFUCinpuATSC/wudbBzxmpYMqsH5WH6iSKjQI/dB76Qhf5vVRbTVuD3bWMjeLDDXfKgyY16n4M2pbLJkskxK19ZNWah0rRFSeQ6tn2lcR3LewDFoNEmSnP6sHs9SBlY4ZIeKhkfJSohXE/7673w6NqPOE2wS8nqXnY3pDqGsMDWp+YeLyT4HbUBCfxykqXdqqk/6H7OBCL5CSiD2uVUe1vTjDM1oTWUSZxzjCchGMM9jB0DLYb1WVA/UNgFymBb4OyhZE4neEjzC0gb8NcOjDwmMHnE9UDHDrv6JsdPJVt2k1peOLc5EcC1YiG9lmsBg2hPPZXzJN8WqfbsDCWaCHqNxFhh540snPWthU1Mil+zcg6ejmyA1xnVuIkPdgKMHTmzZWj7Mb6h7aLGzYZNM9FqX3XMiXCCVFG9kQ6vbVHUzMMBESl7x3Z6axIOVeo+djSdo5YVrOs1kNDJIzdHsiToqcDCABsXIJuWusvIamVVcv0kDFH49e7gcqsNxSjafPw9Fd1vs5jLcS5tpukPo9ACrtEgwbMTnHFtpBjMY3OdnpoFiLgrO3sOsWWsRaFbfPipnE3YRUoor2iSzSmCC1FqSZIffpeKHoJN2M9rt7AljeID8BhAflX4Zx01CTFb9VBECSRnl1qsbagRDGiXDQQIp/oQoTkluBCqJpldetNq2Sy48KcC5SVGSigGO4ewIWyZK6/ppOPEBtgwarUadzEEoTPwAyiaIeBRuu6QzGC60yl5IH/LazJ/SIi+bnEggBuoyEHphRvkmz8vFG9f29mnkZZLd3Omh9anj+QaADG9vnbjzRR+QQjYbE0BoNiI9azgY5bD+6jDXhHDhGPXmghYf1B+2gXkW3vLVtEWKqqkwurY5+dIUnsrzYgSmgVj/PtGu/dfsXeO7g07nWYkaCAVQxHR8EAhxnLjrDcXFh53R52TTCDy1StrgXUzG7OI1OFH2pt5AxaO6PxA+VG01b57x22b+mSyFoT40UTAso613ktmHku8JZh/FWnub9GyMS0pc0g5cjmzd6slVSMCPL6HZ8NyyF/7ONbIncg4NiKr3QKaduvukST3SgpMnWKnWpGRPpjUJthEwdWEvBi4OswHwxE2YTA9O+OgrSEVXZRWcxoYs+MLquA+RFFUj+kKBeBGVakhjNeQ1vnKJYNlLhgDRPBK1xqxjG2RNQRvHPw1veQ1GoVRsYiJQqbUf90IYtc9DGcAK+4O9I+byDVKUeJX0KS60fIqzAbOJz3GwBaN60jPhP3/u0XXT1tjGhE48twvwTEXQFOMp6xA8dO7vKjp4kgT2suoTmASLAydIWa4JPlraobz9yNdOTxo3RmN8/l4cPtMkYbDwwFmksymv3PVqtVqhc9+GtU37yXjAukgKmt8SqjrYfuTUipzGupc4yNK94/z+sccEEdbPyYqVHswJpoGFuTKJbIEyq9iEH5trabEUT/XStNrZqz4ZIlXkLig3gmPH43t2+eOZfw9YWpu3gg38HI3eJyhUgvpb2oXYtzTQYVriuChgnNihtHpVb4gfFPT0Gc3qspanbj3qzE3fgJDD89uzHk3bwcVY4LluJX4KRxJWW7M3T6Q1g48AwChTAN5KGIXMuSz/ysw3AhOOoxfmGdoxkoOOuEUsI8OUTZkCbboF6dGITkN0pZw7x5IbEZzKmb4PYDyQTwZ+tymJFTH+wQNLGxfzGCIvHHwzKzXk4jt8Y1uWG+0A/E6Z2y8hY2XUpU19Jk7oVVaP+fga/aauqVd5SjyIBT96jWyUde8GHZtDZt5EcYXpx0WEmDA4tOycOi/Rs9MS19OPOer4dshpn2o6msemIjptLGn8fjNxG/746M1OLA8UZ4s4sjIaFuAJRSbbxamExW4ZAoWQk6EocYig3AE1o/QQP8xVAzvD0cx1//tG5oQbF4OwLCHJkj5RPn8MfPYNLPQNre4b7QbIC5GWRlnFTFIfhk493FDdbXlYDIoaoSn4gwdkt+UGVdGaFHpHbCDGCXsUgjEkeXclh1rXmhEjkuqv68IGHuxgd1oSx1fMnBFgtsLJAr2dOHH3hLON1jMo01y6bTp3nacewfPUan4AwZm2xUo2Ur+XoigStB8p+rf2kjNOB9nJVUvxRPDpPys7pYDwKK7qBOMH3onkmjvW98WVCtHBTIJZYf8XHjnijaciWD9oV7ezJdrjFRXpW/l9y47oba1SZc3+DO7PQ6PWvHUucGoquIuU1s4YTbcYSUKvlyM2yThP5R6AmK930D9/fkBn2hjvu2wZSSCUdVHZkSaYeqppOV3ehLE9M0uo0Vv0CphBhXQtpJkWtfMEgPEBackWHMOU1qxyD6mowHjBe2LfDLmHwDpnlIygGykWtatRBMf4pCBR8R5OjnxN4Dcp2Jd+jcvPgCGg0vMgHZGrYnjYeJwZAtbcHbkrjZHo7cN0W7oAc6cfgQ5S2HXlB5zmKB8gJqpK98robcTOVqjvSaN2tYlYiXb2WiyHgsCklzMcnWjJssxXm+NSkGFrX2AD8V4Zfg6b1drzx9fd7ZKegn1+1HMmZdnFaEwoy1YlnOxMWO8Pd3Kra8QW176I3ygeDozwUX/tkOl+LHCMY74LENkkQjYJqinpWTy9Kod2p0CJeg6Yu3ciMpnEJ13NQeeDgJiw1INb3hWSgSri+YYqTYJaMcWw2MorJ5OwisgZOEHqtpBnfQpa13K2nloD2ywPZlkfHst2ZOxnGZkunWGRIqftf0nSaGIZWvRaTbQ6MHXIYgnCopsgeKj8K1jtf4wAyyJWTmdEBtGUFYuqz+tRjaWw7EhKJvRtSfbQLulNHUdPkPVofqpylFP8jJ1OlxrrcMu3Ru4q8UhcrKw8GcSu0QTPXwBhA/q3ePlHIVl4twjf2q19+bLTLNsT2wrxj87Rsw86srpcL05pGUGWZ1w9kHe3U2EWtSc3Y5axN1djmyj5RyjDOtqsVtFtAawh0D5x7BQ/80PI+CldWuMjjaBPErqxcoZIg4KGLd2+z9eQgV45WRYcsvGyRdAZbe1731hF6NSx6VsSzxaxbVQ5ecM1pKvbvcsijpC6Zkuqv51kJRLeBI9l0G+vhgbe2kDhzOzN4utfRwPUt9j+/bOUAz9JqXl6SqYmty5x+1/gl9snPKqHVrmtyjRORWVmb1S6a3L3F8nMEaX6LUkKq7ktQFC73fS53JBqGWvu+YbuC92IRkix4Xqw34byJqQmcNb+4uihnw/+EWl3ReEldrD6X6VWEm1qBak4zQgXyKCDNT+xWGK3o997ZrJ3e+obudaQXhgbX4XUkJTD7042SZgVRp+5FUwVzqH4ak5x9O2k6Vq85xm54jgYVp2HTZ0hSFw50Hrdpe30Dz5gQHMeiIG200DHmVw2/rolXmd0+pWXvgi8AhHJgQojp4dC1F1hXkmCl0+kOwPzfKQz946bTMgUont0uRq1saKfP12nmhW0XCGgqZJX9QbXmRn9UnhNNdCHpQXtb/E7U4J6z+WhBsPj6xDtOf82ttsijqOVFGJV1g+LXu7ld0le+YbfLPx0ZZ1IbRQF2W86r1a7gqR8of0KJH3HrxSV9eTmldkAi93Rvbf8jxAZfCnSdUG20EuDWlqdVoBU9rYc5dwocRNVjvkqYMJwrMbOqj3blNdpOme+yM0utGOcXoINdktOmG31V5gLvTAb9SggtZ+rUoaOceX2ZBE3n24GnOfUQOF9G6XfIMQyhFASgmRdV2OngwOifF8bMTQzmW+YLq6uEcZu+vqYZhl7n2A43M87Uk1R054DmBi0SzqSix1s6GKRFAoPp23Y3TH8vstImPzbJzwd5LDL+ZuFLeullPLBZ31UglAA4tOE6T5m1JT1t5aORVWoVBTY9VY246a+olfJqNSj8mpwE/U86yzJh5LkLVTjjkRyxmOV2I3gD+u1WuIMnfCaUkpouKzV4FoUF/GqDENKty9yiD8jFwPyda+06kbxtNY/iG+jmYnol6Nuil8OV5+bjuz+H1BRP/jLPclBSe463LKhsRD/c71awvjH/Kx+V69UaOTQd7osc9/iyEcKJifDncx4z+hNf286zj8lNP/+UUSvqt4JaOxnRl5mlgAwIz2PgeDddMc87qCGjpcEktW1u1HICYjIhdDVBWHezLM+SFi6uuSOVVi9KKLpoffZ98AUClYqL2wqD9cfjFGV31FOE5jQFLxMSW9xDZ2zacEPnnAUdttQRTjka4MFLLcwOXzbXT+ORxTOkCwr0y945Px2fAtG7VkbLxRZ6Cmp+3kY/HcbGhjQht6jDKjLgKKWaQGeTDvNxzm18iLlU51oLPZgCCMuLeOAApxND5d9eu7CpbmuEobquIezIyDySotzNYO/Gxp6P8DnA0LlFWxmr6gUdmAq8/drqSGhbjtXiAdcy26a+L2IKqfMdaoCP1ADel+OSgHmlkivwqM2asYvybQyCqRm8exRADEM1g+QGxTO0R0TtOiwT88vUUD9UZ3htkox0aJzXYVg1ZbLhcUFKOwU50ZlLTDC9Ffl4hDwpzVSMJ7bgmPlWyJUUyVWIFPXJWo6GTUwVd7jgH0rCozGOEQRE63brlDaTz6XRHSTU0CkodL3GRS1AE+uautHgOOumdhKiR2M61HCxQM2912o53eqO+KBCoFXdXVLxkqglPgibp7HIu6qlOuFcqdSiv/KyQ6nTkflb5FagrApeA4bzJrsvFp3HOOGtY+0SXMO4WvtrqUMtWQPDRzeUFr7ZKoViTZsX203oaW6vYgjxwFvTHDxUK9aCZrznhlgdzUuR2R3QLxm7DOgmg3wIi4xnMtwW+EGpGfVrU6MZoDlonF7fmShVV8yQSuEZ2rYP1bjJx1fOixaik8rsNe19Ti1nLvXqXmil8Ntjzlwp0aGqfJJLbGsW5QKWafKnUaR6U04PILnGp3oJKmTeKC0yVPRegJo0+o3P8al3BBP9F9/AUYoI8XT8Tc9OqkBYJiSYDQ2GFkD7pV8+q9oIq2lMpTa1+q1jfNPg8EdmCujXIjlueD/NTQBxvrqGwWHsL44cYS+1UeBw3PnoB+uAKPLqvyj60u/8/JwLjUcDfDLs/wEQzBH71QABAA=="
-)};
-const _yk2xgb = async function _inputs(inputs_0_12_0)
+)}
+
+async function _inputs(inputs_0_12_0)
 {
     const url = 'https://cdn.jsdelivr.net/npm/@observablehq/inputs@0.12.0/dist/inputs.min.js';
     const script = document.createElement('script');
@@ -30030,14 +29648,18 @@ const _yk2xgb = async function _inputs(inputs_0_12_0)
         document.head.appendChild(style);
     }
     return await window.importShim(url);
-};
-const _1afrmer = function _plot_part_1(){return(
+}
+
+
+function _plot_part_1(){return(
 "H4sIAKlN/mgAA+y96XbbRhMg+v8+BcVxdACrSZFybOeDDHO8x4m3WE6chNHnQGSTRAQCNABKpEWeM08zDzZPcmvpDSBkO99y7vy4OY4IdBd6qe6urqquqj48bP3P7KyQ+UV0lsjZx8NFkpWti173Trd/t/UoW6zzeDorW0e9o14H/txuvTbQovU8HXX/n73JMh2VcZZ6pZD+VTs7+0uOynYYluuFzCYtuVpkeVns77eX6VhO4lSO23s6c56Nl4kcSE9BiVx+XMa59NrjW//zbvcf3d7hOC7Kw/Gt7jxOu38Vbd8P2rpGWwkXvL/Pv91oPh7wozdsq6Lb4toyT6HhgfS8Mmxq4zTJzqLk3SwuBvYxKDebQiYTv/sGMBaW9LPZXG1F2R3f8rdeCUDCq+FmWchWUeYx4OdYZ7Ug07/KZbnM4XmZJFDx/v7eq+X8TObduHgVvQKArQHPoaxcf3CQernfOcAiNhvodzGS6ThOpwRjv8k+881YXvNR3NSuNuDlzxtX5fZPCxg5gHHxNE7jUkLSoAyg7RYsccDK+739/c/AFi7svc/Djhi58cQrW3FalFE6wmF7HJVys4ExTeUlvXgHpe8LjVBflS6PRxl81EphDKey/Pndo++zZV54vshNyss4XZYS0zKTdiLhuzGmxQ5cksSFzjjmGgBbkYF4Cnj8TUY5fBbd6w3+7Ny4WnqdSNzxt38G0f1/wH+DPw8wUaXhw7f+luBMNVlazjz/oC+OajnUTR+Tb1ylm02+2WSbTTz48x0CpZge4FPOEJxHKRmnwGsXX2NxCytvt/nP7/x4fBHlrcgifsmIN92ESdFdROOTMspLT4p2r+1vGbmT8PCf3iAYdg5O/xhfHW39Afx8u4WkDr2bB3/gD+DlHb0EOs88/NGFp1sa6veNKTAYmM9vHNqlNXNb2Jp0YRBLrzwI221/YKZFCWvfdmqMMw/mEs54IC9qmthJMuyd4swYlt1EptNy1umfHuup5K6lFNcSf7UI+/KWmId35LdiHd66I2+LafjdnW/h9yK80/v2O3hYhUe3/3Ek74jL8Fb/NsDcEWfhcNie2ynVFv1TMWwftZw0oGpHmHi7lngbE/u9Wmq/RwXUk48o+XY9+XaPC9ktRRWzW44qaLckytDdWHCLbba8RTU5SX2Vdqtn027JbzFpTouxLea637Q2Mfu2KsUk/YOTbvVsUv87TpvBIm+LNWW38IU6pjLv6JSj/h1V6pFO+vbWESeNo3VbTHlE4Bm/v3ukCriU8rwtLjgTXzD3qPcPVdocF3BbrLh2egOAu3fvwrBz/Tqtf/v27SNOXAPZaItLLhNfIPvOrd5dlX1bp/Vv373znbyrJoBK5Dl1Vw1/5eu7avArn3+nh77y/Xenp+Kc6OnLaOENayNaGRgHvxZR0Ct6IcSUS1nYt0s5Tt33cgbYtq+TPLYvRQTLzXldpm45BvMuljXyTn1xo6kDslvGc8k03e0LpzP9t93iVNwnTP846XG0dvupvqa3Spc54x2/1rrPee91QhUZ6kP17mKGc57SWxVJqm/q3cWYylmmphWIPN0Aee5g0XSlnFl8ciLuZ4jYl82IXZajJrxC8i5aIbGG1WUar3awit82IRXSr8MpZF2LUvysEaOQ0YxQ7FMjPjFjB51Udw2b3IUqMiFN4/JBeLKen2WJ147TEvnt5PEyj4jn9cWLncx3wKm2/eNJlnu05Qxh2zsFHuiGL4cPTsNzZA9gXxNy+OI0bOOgtXeBXzYCQ6Paavc7wQ2p1lhBAI1ds1nVseR0l7TVhl8B0IZ4+5pZo2E0gW6Yb7oepMmn4pPbeD1tBeOieZ47mdUlrjKaeqDpggZp6oOlKAZqtxeWHJnauB+vw+EJ8iCf8M/JsI9PfXw6wif40+12T7pFEo+kd8s/tbzQE2RsElm2pGLgu2X2IruU+aOoAKbxWHaBcynex8BatkHM2t/3ZChVQT3R6fv+MX6dhn01HXJm6rw/xgf+H8WBf9iVKznypH9cXMblaObllTJyaLDimXyRhgc5NNtH7mwE9bc/LoFplHk7kKEeivRmeOv4LJfR+TGBzKJkUsu/s8UmZeFLmrNQMzBue5lfzvLssoXU6EmewzT/c5mep9klSCdqvQQtwgDBp/f7IG5lXXkh8/Xup2mWdhYyj7NxPKp8L/F75vyGUqSnloV86wgvrzzEuxpDR7h61ACD09UBeeXRyhQpD1seelxKGIbp4Ebw0lcL1bCf2BEvD3PuCqBD5O6CvinhHZZ0Cum2lnfAIqfE8e4hKvwqw4uc7oNTQutZt8jmICR7Q1Ge+uH9EtqR+wYeQPJvpmEIstr0Hox8fm9VKWqYnYZnQ9k9Q7awBMyagl5G5aybZFMUyvwu8M+AY+9MmOT8Zur7msm2OCihL4O3wSPfyxykPcTuoKzL7c9CB2dqi8zyeVQGTN3p+diw+7mWCjOPaQXWM2h/81s7ULNOJ3S+mUMa0gUnpfPNGBKJFmDqZqNXfRXm3TffB9+8BEi13Jtyg29OAGAnrfvNC6Dz3Lc4tNoFPZfaiZyUunJS3XDpJAeF9//8I8WJj38linZltqjmYzrD/BnYNPPF1svN6i7VynUllECh740HCKS2CnhQ3QFJ2eeV3ATNEPDwTec5YsdCKxxWoA0QPi8cYEJ+HbRFIPh81vqmM3bAcQBr0GMN6jaBxr4KeKbgfnPgaM4Edg5h5rZOUtrLFNVnrTJrTWj+tXBawp8RiAnOVH5en8qyO49WngQZO84LEDA9NUK0UqKzwpMdXEJE1bJ7IHPq2fzQq8qRvDHmLsMgRSwikSAf0DCrzJobfAroY3o+CV5vcdEi8cjuJz7TangxS0AiZbXpqaJMXhnej7uTJIPqS/9+WBoyAk2V0A4QnS0e3mA3kUYpCpCLDBAe3ld4icISk3yRhJIfijDrjL3YEMZsLwyL/f2LLB63evAcD4vT/f0E2+fhsyj8QRSkHvQf6uVS34evSY+JtPNNnpUZKgNfT7yfYQv47kGeR2tf/KVhFhoAttSTMgfx3267T11NlqufokI2m0rae9vrj9d99x5wujtEVZiH8fR5Wt75tqkOyMNOqMxtRbf42C1wYPv1NfUDOuvVclK9Nkbwb4aJzWWcjuUK+Vfdjg96yM0upHTJakjbBWEZp1g+GJNS8HtWgj2axckYt77UD55BKb+rZ1dnDN88UxUE7ZT0rJS62chdBWL7LMsSGanvLmEjFUnZUKhu4aBb5lFa4Moe/AqL1bzhFg/fVDXCdfWqHLwrKScotx58Dl8IGIjhb6fOKD2rLogWNeqxl/oD2svD+0toID36AcLZL3+t1MoLApfB4AIZhGChMUkNcHEhB7hjTvJsTlVJYA/3cIYOlmXAxTi1fL/TN6QWGnCPyIKEHzVNGmcTcDLfIZHpIl6fjzebfs95her79AoiBSCKk33A988kuACWS3p0GvWzW3oXG/UoW6bQLFizP5y8fuVBj+GR2uTpSfpLOETIU/F7CCRLGpqThnJYGr2fwWO6v99+KlEwJGopqVnAdsA6AhayjGUBQ1meBulW/BBemZkRvCq34ic3ASqDpB9DDwazL8qSHvZ6QpbYDotRZuRFWks+KEVOSfACXLdCvMhMWt+kRSbtyKQllIZVlnZJouLUN90/UCIEs/Z9/7Df62kODU8RAFldYOnTMk6k2sYchX3pjMVH1ujTHF6W4mmSRZpaOJ8s3U90R19FrwI+JqkQsYkLS+XO3OxZeR3VxAUP81qfEECrLJ1Ry7scIOMTqBZsNgo2NM3wB4zEwFEvO8rlsnkB4nQvQyQqVDD0bajGog3yB8igQUxLU6fCHALZgF8cwWPxtcUDWTN0z/TsC4XPS012FLu8Z7TjrbXOs+AmydDwRqkTJYu0G6ejZDmWBbCXuxJYnILEBY1BDtQIbqpiR5CZuuM6VgdFRNcsDL062v3N5qlzFESCANFAnfI9ileQuMLvfM34MrVh7lct90dZkkjeCgJDZCacVzBv+EyC+FTm60bQKWcChTgey0m0TEqVB+Riq6BoTSga7PSJ2nal2zb4QuOubYr7gXp7EaeS2RmV8BLaFTenvslgl68mJOupKdjNruacLGYyN9z9Xq/W/72+wwleqjnFO0fDDlNZzinQ9nm0gM0qSPXWJR3EnVFptbLqu56icL7Z/ZwCzkvvahWUYtWHbXZ1BGS9tvT2aIrZbc95Tm0xN6CYNRSzxmLW/3IxL935f17S6e4N/rHFdLUGw373oEIPB4aFBTrxl4V64ULRJ0BTnHJx1lUqGmfzKHYJwklDCZaBMqftpeWY7Lef3G9P+FtL3brQn6WspIxmUZpKp5ev1dQRefhTAwPkfJwOPBn2YJLZ4gZ5AETfYZekm9kLysBlAby0luuLmoLoyfV02qlkmJewZRMxlq52CabLJ5guE5DoYMLADpWdS5g04VV93ijKDyQkHCPL6oumdOASRekoplxUPyUqqrR2AUwO2DXeZpeFo6Ry2AIZ0seAOqTeyPbfOmJ+SrKoiWqsMuwdl/fk8cFB6SN1C0tNy525/K6KIGrGJZ4pw9DcB2H1FJrcpUrzJSqT/MDmdiPqq6sTcrvEfCP3aEAMNnzjQYUpVIhst5W/yxqfDcRgeRZhhwb2kYoINJ2o7oFv6lzLHmF+x0QGuVCawyBgVprwvjS2DXb5A9KM8QJyoTV9zKqvKOvqqA2MZHvVdpWoa5275tx1e+uUZWv+qzTqYq3kdPhT5A2lSKIzmQQfaYsVxB+7JTxtYtmQ+/2ruid/rIx1A8cFZN0R3mHssNqB+nWP7h9XSrLN9VxBsusmC1SquAl6Lv5YAiuy2cBPRjMvN8oWw9d5BzlMxIPWQYbz8fAIplxQgdwBqDG3Cn+qI84295vqh2a2P8CEHhjKLaTa4826Yak0rcycD5Uy8vAZvxu+iTjC+yhyDXKjiQnccXlm557m9vB5l3HUk/HXUnFLu2Po15W3kjW3Cr5pF6A27TCDbc0Mamwct+ZxUUBtLfqgBXzNLBu3ry83m0wKWf6dgvkLW7KmBs6IUdevevcApwe4N5X3+vv7xoLrORQ5Bemgf0i7Zhl28MmYlBj1nVXll/d6gyvqEIqCBKDG6GbqH6aCm0Qa2rCPUw3SDxwwoGQABfN6KgMjj9GrR1AjGSdUlkDlOnFJOB3KQ9gMtkFzzZB3c7fm8iC9Wan4i7UeYq2Hbq2o33eQ+b2deJCtpuF1zAIV/+XRDMxo0gcNg2kVBQ7dalDwwCZIRdgPfnEJnd1hNxtiVIB8XRFtD9wJ83uF6XL7ZisasoKsG0MXItjkHNr6A31utLct2aJVZpaqVAtO7zQGYbJBx2WL/am5WCswSR8yyjhdaqu58jOaubKqPHO7/+NXtr/1mcaSaP01OKhTI4nWhCi2oxZr5rkigfximVcOfbNY9bWwgmQHd5R47mkhck9X5vQ//dq214mt0/9c8jKhQ1mryW/ltbJyPtyTKFubZqbhXm9r+C51wCCJbzuRpUdaBzFa5rlMy1GWZLmgXXIRYYKIkNc5gzktUMPzcSkvZzBJRfRxGdGfeQT4gfdPIEuKMxlP4W9cAJw4S6LROf5NRzM5jhK06RBUEv65iGG2lOIMFnMqzpZ5sr7MsrEYRWNZEhCw9XmZy2WBjxk0DGaEGGU57IrwNwUadClzhoTXIk7OxQjGoshSMVpHqRhH+Tll44NJmWbJWKY51ERvsDmrBylT/cRJ57PoPKaneTQFTET0nCXxhbTQGdEH9TiaxVxsLvm3oE7zo4zsVwX2xbSN3kxL1JtqBAzax2UWFwypcDaWcrGI03N6KM7XXFI85zLwF7/OxlOFn0mcy7M8hsEApAH+eARhFsmi5EZNlqNZEUdiCmJccZblmZjOsqJkQESZsHijWvgz+ruWCQyFoEpnMJXWY3kJDyW1ME7HcZQiPvBpmon4IsvXgnGbRBcyHcvcPEBrixm8XaZcfiIBfYDVyQSwmOAJJ/WHnngm8CMOLj2ZVqpGcSI2WD1RqepRJVI76UkNFz/r8eI3hWR+MePlvuriilLKxAKbhswl/dGFpvBXzytYQhnUO5fjeDl31hQnUFn8qKYYvyyW+SLROaa56tVMMPW+QCLmQtiJxe88tXCg5vE4Naiew6Y6AoliDk9Fuc4z/CAbgVQRpyKNLqK/Mp4k8LwWgH1Y81LQIuG/4zw6E2qV8A/WoTqyiBJpJxa9URPxyTYQ32zzFtEiWkdQ6UIsZDSaLZaTCTzlS0EDuUiWc7HILsdq7isswQKQ0GrzNhbQlTUTnzxbRzxiRTQeJ5JT1WQoonSs4AyO4aGYwbiKIpZpGsFPcgGzWE8Si3w7U+wkKVKYDu542AkDe58oJcxq9CcooZ1lNgdmQFhUKAJwOZMR/kXE099inp1LwXOt3S0WSQx0XbR955iNlMrXCl7EqpZVfa3a2sThP//HsNf5R9SZnF7dEt9tbxwq22oQmsgqCIj35iLKN/n0DP+PNrMiwf/h4fJsAxLPJhnNNtk5PsFfeKZthv925vHK/8Pr3vzDdwvOZHcWFdVjncjtwo5oAl3o3UORu7wX9o223v0+kbtSKnp2VETUwgE6/OcfxU3cHuHnxmGsW+ecbsiK7kKpzdEADCcSjECZLTpkpkGPKoFtNURb/55lJYx0p/pq09X39OMeDS4lOrGoqkwbqEntSR7N5QOgnVnumhlMXAwQXzpwD+SQN4AJ1r2MUH5LoQjgqpEjPUtk0QJ+oDWWi1yOYC6Pj1uwkmCetNDPJUpbzH0SCyejsTFcMXyG5r7VMToqWJ+kpAX3XGW3QCmBJdkrbAAquxyjnXSX/dfMPkKbaukEIt3+SaLhhw90uP3hA53rNhw6JEB4ooRKwEOHXFmL8RRsOqYYL2GJIRqq3xjfAKAj8J0Ywno+3aJ+igRu51zKGYc91h3CUNKgtYO9vkrALgcrXg9murYLVqIDDKCKTl7aoySGuTVUBQgNcuqzCHqFSyTQ2vdtRQU4ll8WTsxZ+zXZ6iQVVl63AFZvHu3v85DGBasEdXp3EstkXDgTcvE11TvlY5piYefSWBUssiJW9rJrm0rkBZKmNimPYK8rIO3CprF6ENJWNi1bRKO4XEPipU0s6BfSzpya8+wvdarii3PpWkWv2rC1ksmvfpiYpIlJy9vQPnzg1kL78UXXD20iU1GuGRqDb6rB0Ad8c1oADTs91SvghmRlQ/ExL71bvngpw6PDG1I8kOEVbMqXVbWTBZWH9PzmOTpFgbwP23aYHx4dl915diHfZV4PhH1RdpGFgbcUjXCct4772hMdF7ZTy+6oj0cJsBVvIvRz2m7FiwoWIyAneVyQbTWj4YFKIaTF+SiRNu8RvVMO7O+Fk4GvZN0bR3Nldss5jznByTvaySS3m5lcRXiUBRgkvAOvagHfwBuNFNq2Og06oXebc1TPoqJB6s2dDHgjs3VgF50q3uErpefAUk/dbr9TKW7u0W421XW5dj58v6YZY89tvmY54uxxjmtcUrZHBSCR2mUwXqgdvcpkOLTgtawf2J6457Ol2VGgJLRybTpjZrpt/f2uPWDm/usjZue4RnpXkziBKRaUosjyMkB2Edi7ArYiYbXiuUAXxRjK+gSgGVpix3gsIyJHg4/bDZ4RaYsfLw8fUpfU4bzcbD7hAcZmAzmP0KLtvaTzDJESMCU95wQqAygrP+zaPbdN24rWKErTrGydwca8gI0KdvFoAj1qOU0ujD7sCpuO7Vd4N62CzeOKMbB1Ok5tilwFx9vPosxFU47VZISmeFeL9vWoerWLqlcWVdih7EsdcptF38Zulx5V+Tp9oqHL03YfUhmHyIGx5VA5pbX9AgEDyJw2aLwaR2UEaJmAnFQWQb7FA8woSdiHmGF9WJ82bYrHdpTuNPDVf7qBNIFZwRQJkGzESCzF5LjS6iQ07S7CXKhz1yKIGjrB5flCfboME/3pJCzsp6Nt6PYVKzbDF211IaoMU4L9HoEjBBtttw563lXQo2dV1xn0wVsZPJF+zUzgoUPM1HmhOVX5AAlGa88tkrpFqVVwd3kp0EuOx3fI/jlNe15pGpdT6nKkU44yRuiqpeT5FcX5GyxGzWbsf+VMGLHiVY7O95yDcuz6O+h6iksIVxiVQitkwBPGqee9i5Gm7WB/v7/nnLL+JYOniFYHqX99BqlPsVLyn8WTWTlMT4Uc5qd+YNOI1qe4JvABuPEvD4FGHXYMv6gMwFNpTjtFeuxdKaxASUp1L7J8DFQBMQp4JI3/1trhy0EXt+tSec90+Pgprri/9N3jd7YSiAdZALxQw7lGqm2NWGKp7Wd8zmt8/dtBGubuGa/1QsasTGVpu5prtz/uYotq9Ld1Y2uiAsfuNib9CBZAjgsAlp2sbHHx7l6kcNrCAWipMA8FSonOCmTERWE8BL5lL1J79tX2OAojPiFXjH4S6uNYL4IFJSI8Yq1MglxPguy6SZDUJsHHKv18JolG0F4jqiThMUrZV+sAGPRlWra3QtJCYwl1BTj/CUjYVwmoeqK1VvYsCituqvU3qnXVXOv6X6p1Xa2Vulur9QPVSsYmtYphRmBnxRp3LKoYZNv8NHxS0kIVf6/zjg/O3243bC7VRj+joVR7RBqOUqGYkZwJW2aYkZh3FWQ/EupVFP4oyRMAzVhwI/wJrQS4aZnZKYHuYUFtWB0JCUXcdLPHIl2kGtvQtkRRiiFscqch2UWIIexc9CxhK/sUzNicZ6zNeRZoVDZHo7I12oVN0S7sApu62sKuObwUZ/TxDAo6JyueMTzdoKcFPL0UDyj/HJ5fiBN6vuEyd+1P7ThtJcD8fAouN5sZbavY5ESnU3tebjZjzuJ26UzVyhebzYKygUNeCc/DrXppSfk4/K30PkAq9Hc56K58sdApklLWvpiH+Ar9WNMDNHhKDzeAWoYZ+mRAC+eMnbXGznQLknk4PBWX+OdlON7fH3nDU/SMXezvT+jxUzjf3z+jx9fhen//AT0+Caf7+yf4SM6Mb8Oec3JW4slZ5Ls8ARCJ42x/P6smCfRvq0HViimsUdTw9Lh20hf5sCuMsoWEWYJEqo00lKqpp3JNO7DWbycWBfrs/I4T/sL3XafekcooxMLNgCFSGSMx9nUzR6Hi57a4EgGh3qi7CgsYMnpch9CWC3r8BMRd7OWbTQ5syHgJ9HQpRlCO7C6Wxcx7e3Dgi0t+ThXEc/TvALAEAQUU/pLzufgX/AIVwIh94pcL2EPmgziYD5fDHjpEwwi+tllryFrrLBjRJzZrCllTldU0tk6bGeVOwna74oKk3v9gf4KZjVugIiaXeltZbbfQF5j7e78ivWivyGW2GABJLLbBlVm+WxdoTUDLAZDrJQCZlc1ADWrQiDcvj/WewIYsy8UShRVYZWQXWOUAf8VpACVJ53BZq0z1qbC01tapORHWxvt7fccOQypr258dOyLVRqnaZ01W1MF1t4zLpGqLqVJyRi3qMEpUVEzSUy3Cyu4sl5PKR5xgvsHXtljiJ7nhprUDqWVnfWVVgp6zOWYpESevqLQVGVQodZaxD7sArzV8UhMDHrekqyXPBlE1LfxZGrPSX9RZfHb8oCTTgjYXgDQTuu+hqVkBYo0UyBRynmUhc2VrKIbohRf+VXox24UxoSqOq41W88AgLBtE2swkElRLkLkCLWlRupV3UYQJEkLdZba56doXgwHKKXgo4q6TWGGffrGo+EFap8X3bJsmsIsSBNZjJU7qDhkjwhi6MU5JKIX9Wfe+1ocodLpcBugnlgEHjUsTtd+q+YDtJIwrxIfsVEXkN3ZXGcTWv5EMz0naHZZnlPpwUP2gFBE6H+0m4obnWv+wd5aR1Acgx+TZcqGOOlISEYMhTm/X6Ed50oQ/yYYIRRgXrGb15ujnnAZVvB0+AwxbZumo2hqctKpHQ/YYqMUFsPEVksvjVjxfJHIOVKPltEQfDHXbrKAphZMZ6HZ0z+IUgzLRIryuzcZvOwQJ2C1FLavwfoY2viito4UuRbLKsLDDfy4ocpRzlKfLSlKP34+tMLarXGRhbBLnRWn8OZYpC2JJ5CTOVGI8BjSgIl9njFQGc9c6daxSMVQdEGybsVAZxXJu0hSrPRinwVxlo88ZcKium8ka2VleK34dqMPMRRWU07SrtLyIo0p5gCAMeaWSrbd2FQASbFaHXT3rADwxFVRUz4+crMYColWlADQ40wAFAUCKyUTjk3o2pikAmBkx2ptVq9Cpxh98XAPAFMM0VP3RfiLKda3YrcjLjtb5x6o4qnbj0rUvL9OahbrZjqQLJutghlSnLlha9Un9gYFyFyRPHV+jzywHO0BTNR3tdL9QKZ9Myird8ZE32CG6eC2OtBut5fNQndBy+BVUH1mtxR5plPdKFcqCdAK4o6JKxvqg5w6pjgzu6BDB+n92eQt2rMdRTlSbRO4hDRcpaSWAo8vyJxFgTCkhUPmQIRuR4vFlNdPV7FkjBZdtqVA37b8gnY3DaX1xzYde1bm68rljAp86UfJyH8R87R0/SsMdKgvtUBR2C4xaY74cojvq6RZ4v0o+74ZmyBhDwCNlSWI2xdLEjrFNFVmJSM+VXqdz29GMUhAE9c29XH98pc1WcxvZ5lsQBIbfnobDP//P//rfOMUUMM1sZKXYH8pry7Tz80nb37bmWS7/xAOzJVonQCOMj15m+U95qoNntLwbV/La0vw/gWv9K4thC/0jbeNp5+x67DlRBwGNYwBk/qn9FDVqMh2t29VN1CJuKxYW/LHeVcS1w4AjL7tou56naKuxY62ak0lD6mjeWoBVYNSgC/M0JLIIGHKOEtdple9RJxRXxEsFqfh8X5Q0Qlbnqk+HKUhR+usaLHJKfTJB52Gy0+Yw1/N42oBpgUotlK/SrbhozF+b/FVj/iedb3t+mZJqnhhzWCJrajDz67nWTWViBhxTECs0ROFHVFRvRbJ7LBY3HsPmTuwBYGeB4+5iib64kXrJNbV/IEN9XWW9KVvXXbK6PTQIqzuyoV0M6SkLrJek7QcacVohcOdp1fTg7xWuemYQuj21OiitulOCBW0Hyp+pFFqrl7PjTuaTYY6RaPXhSAFMpeuv6TZ2p27WhJIBT7rZtKNlmVH0Ib/mpkW6NnbFUrq1QHGBaPMRKFkx3CMvT5CE6TxS+twNbRmC7Bdp9U8IWCW7ZwFYzWtlOeLWVk3TtiXN1UamWmODUq9YZ7hVKwuVoFLWJzzb0bWQwlmyYj+kIXiNPng629i41GtT6bWDDf3ZuTYTBAGRTq7wdKKFg9KngXBrP9Z5rIiAVu6pz9MGEy8dRozHXJ2UGAsvxxW3mS0pnS1XsSW5aktoXR5c7uNBbV2U3SyPp3EaJaQvDx3xTx7b/ZMQSr5tjFqlgeTgb71jeS9V9PP44MCUDuRiiMQcd+hjt+XkiwJEPoM2h/F2t7svDI+km3CSVrzNYGhPmPTvxiwqO+gl59ed46z5iSmcg6BhUwhz2tuYF5rHOPWFCeGVc+d3zT12ThM4lptjvpLWjU4+J3KWXyEeOmd1mnymu2d1KuvJZ9hhc0ZX5YNfpypW3DAV2amh0axx2Wxywr1j0OKAxxY8A/C4Afxt6niamAFIeX4fp8CuLXMQ8v00NM+VHd4kMxVJ9e77KK1YdY0w9BvZIaFhoHxA72S3hXbSWb7u92zuI5PG8Rnz8yOb+RhfyWbOBKt3v33tpJLZVhTDJm7z39A75xSlTPpuFiXYvKN6HhtvydL5CLinvko9qqRq2FuVVAp8XGLzoqXb7Hc6yRr0vXIw2O12H6Xw5Vl+Nm2Lh8R90XcP84fPhGT/0QW5zGCKz4aC07QC++bts7QKiykMG6+r5b6Jf6uViykMu8TdyYVdvs5rsJBCsPn4bFmBfTt+uKzCYoqCna5rsM/WddhnawW7TnZK/i3ZLRvTzBc1fGBuHSOcRl8UC+BJ8iipfHOiEqtf6VT67myZw3x7/lV9Pluukx3oz/YDHQeKtnjnTAFMqc0BTCJwcjmowj+jpOoHnKa/WO98sN6FXzM4+3hUP3jNadVPVKKaQuiWUf3oDafVJxIl8gjKcfWLt5BQwxOk+Bw3OD/L2uJN6lXy32EyAVzEeTyOi12QXziDgObRdB7tgrzEZAKI0wkIUA0VPecM7mwSFU3FvKF0n81aL5pb84gzGGh5JmcyiVcNYDrrMbNLBH8Z5fNd0PeQysVlyH3tlASpambianGn2bK+VjBFwS6WNdg3yzrsG56/0/SsCvssrc92TFFzC9dGZWK9Hddn1duxmlK1ct8s6+ViioGt9Q7zdqjj0vRwsay15M2y3hJMUZSmho234zo2MIVgmSY5sLsUydAjhK31EfPqveQ09UWWn+W1L17nD/P6F5hmvqj1FHPrfeU07m0Up2fZZVu8r82kt5zBpDROZSPQCWf4FaPkdxVNgnelIpTkKHf36cBvWA5vnQ77p6fBUeVd0O8RpAPLSFwoBtW8JRwndrQOu/+PgY5g9oksTPygHLou2A8/0wK3xt5X19jvf6HK519Z5ZGqsvc3q+SIEH0MIqor37U4dMwNHeWiaQxpPpwyS2GqP3KrTyvy//u/UZT+/qDvu9GpHdtC47d0baxrFAZfpSTnyc/IecBto6zV4lleC/oMzJeKOu3YEdbkNWqKyMMG+SEd2J7KrR+kVofGqRjqZWDVlBL1r1zuxwrfzPzeDn9n2bsdds5yczvcm2Xedpg1y6vt8CmWNdthxVxOrIFfcdmuBiarymM18lOWncIINPWW0Wx2uahdIGyGBWPWaZdTchmlBrbI4Yp2maAKO9PEu1jWZYdVqfBPTcySw8rs8jEVNqaJh3FYmF3+pcK+NPEuLuvSwLdU2JYmnqXGsnyWX7Hsyg6vYlmVHT7Fsik7bInlSna4EMuE7DAdlufY4TFctqGBSbAcyE6mZR922AXLLexwB+6G37C9W95hJ9Pd+Bu2eXeXb9jTK1t6035e2c6b9vLKVv7468j1xy+Ta94pyqiML+Q1NPujodkqCnFqYl5oSqqopqKQihoqyqeonKFohnY5VEpRI01xjKz+IVUxZEugNtIXz9Jw2MMrnX6tkHPlw1zFG4cSIsRPz+pIn56RK1pRn//fFzT9Z6OdjBFlJFG9qBfRWWVovv+6ofn1y0NjK8ny+pj8uruP/pzyAY5gN9VMpLAJBrEYJdF8EUTik8yzIBEcYzAowh856qxQ1QUjkWfLdBwshZoGE2EiAc1UhKJF6J1LdTUC2g3KgQSuSBR+4CZfyEHakLySg2epjnwsHBQG82qxa+1mM3HcLhaD+ggGsApM9mQwCdqj9QjdiZM2mTqZBRcoYu8Hy1oh1OGGWeMbW+f1lrSaRfhLiqaXs/D70puR/ZSpDGrP9vfbBR3Aod0VpWw2Xha20UMzQufZBocFPG+ahzBf5j6a8u7trYXtLddq2RpvgS1Y+L45lYV85NrnOuHaeE6LWI7kZVzIyoxq+8fzUHZNpjcXCzQ25iZst7XiB96amvsBm4ut7TuuGYv9feSloY2uQpo90QujvpaHpkN4M4rpCpS7CEEYE6k7EB4khpA8SMogzn1EEsYkdSGgIYlaanRcBt2RqxLGAEYKF1l5v7fZpPd6/pU3hhE8w3R/s+njHGNH3XhK0dwKYPvDXlAMbfvgfavV9tjzguwPmZ8v0FtOBeuEl65aQd4IZjU6qXRx5dWusaz4qCuL94Z4wmUt1jnH8/r+8/G8MEbY3wnnhfAN0bzYgNGLyXOuCE0PjRPOHo10qsKTwWxBN8ou0Rcv8g3d0RRG0wyhj/sqS94hLq5BpCvUlCHFHtbz5H54BPghcwjBNhHWOJBp3xVeW5rCBAjysM8+ktbMhzDKR0dvsksQzzQwRhhIlbsce/gvgGi4x7g/qOJVz/IQm6DpZqbpZRyaPc7taaTwkISWWkWuCAkAqocgngU1QgjSUVzJ1/RTE6hia83RxyC5XrBvF+4xHLpj5FcuHxDqDIJPhvp0OyeXjpdyQseO83vZ8cFB5Q4N547GmMDyU6qix7QPL4tITaCsrZ7rW9gDRg0bXDmTdBrDZ4It2AdbUQvvDJpnaVZmsHpajGm73xVkamqXYOLr+daG4mUxyxLgH9RpPQ/yO53uje71BvZTNMqxpCsZDE+DxK5hoOx6lPW4OdPzJ0JgGDnhTRV5HJJNHppMeCZ0nTGz5jgUgQZBOV7wxSRfgo9WCv40IMbHMXWric1m3mhf05Q2aCCAtPXyL+zMZR78lPoVzqHM7aKDWkyf/kYTI6TObvNkXrWMQX/OdIxW+Rw7wi2LrdCrFme+aU7e5S9Oj+18dMLkd29f3z4Mdl8FProt0IUN5rD1c7x100ZtKA/RyExE4a3eIffNXokS3esPYicCI/Q5iB1TwFqPtY3k5xDIDTRw+oAXm5A5Lewf3SwPc2r2Hd2uzLQrhnY5Dns3Y2hX5tgf5pW4eaol0vg22CC5vqYLdH6tDKbv9/ShLU3+hL3O7lVTC23GOezjhamOsWHucsOuV49qR7rbjtSvuaCg+YFyd2kwHIid2ats+3Iy7zvIb3ppBy3uyXw+F0mOrkvGzo++K5Eao8d8BHNUVKyzS18cHCSVSxhyxWJnivjEzGRHisl2uOufiJRY3noRX2RlsAx7lrtm8jITxXpOcexHwTjc61X2jsVXMMazr2CMSRLzP8/pzmEjWYYHwP7jHlKQ08FwLaanYXHs8KL3j/b3AXV/vgcUwX4QtJCaj0F6zKfIWzh0nXGBFu8lhsNrAW+WRy3JNu1F909fVDYWqMrHW6s9rnQ4xZtQ5+EesZusEAXquRZLdHczCtIpvjdwRQviKr8nltmyL8xrIl+70EQOps/C92DznyF+LDu8EDOfvKvggw9czNg1hcSIEGsPKpdh2dGva/SA1C9Tv1Oi3chgHaLjG2AIhrGTQjX30Zd56qQe4Cw1JlSK7wI8LAETLn/ZdTl45MASy4Elih8j5tOwY7GekoRVPQ2rk0wzaM5Gt8y/yFDRYlB77WM9/nXOKgQ+Quy6QXRvE/lb5MEV4SqQyrqFOHLpM0UGNsyz93T56IfACPs6cAwYvN3ucndmsnbqfN5E9ZpGOfr6Xp+s53jpnt/VH17b8c91F4roL5weHNLV65/pMKB53ne77N8sdYczra2Z5aGqFDcHXR5fljM2eboBOl+XvxUL93tXanJ2TScas+/UUIH2ypswHJb8znPt+lRj0YVzC/g6t6Gk+FzBvfFqqsmxljyMSGFmvWG+Lb/MZpojO6Qxylco9ViuMMINIbxEJUYssFPansYR+JHpXecs5pvGiYK+tNxmRNyEWdORb6QqS5VgETc56CTE8yZUhBa6LN+b7XZRy1ncQQcbzsK+UFOcysgtjCkuVsVFeqNKzC5WcIAQNmpakrE4oi5DLZJrZuvFiDqYg4Q6dwO7lP4ybFgV5Kp8llPEPbTx9LXXMqcpY09czSmi045Tg48ihSdEf8fEH+j4TMUJF2fen0L2Fqg3GrFGaEFpjBqr+617YUe02ZiBZqeIXE+BKHTF9lAda1jmXOlLxRBYh9PwKfIpR/6udbgTy1jbw0o/JZPxzAaM2OvvWdPH41QFydMMGMYwOUUpPnFmWERTSYmOzmAljv8ow5ge0tmoUpwFVaMwd+r6FdYtsjsk8CAUDyBCWTmHn/5pB5+Po9Cc4WW100q6i8JLgXHDizeAhNGgRHgkyHxnQTeE0Tx/PsfQgfFuVPo/Y5XTMkeSqcuWxEULgzoVywW6ccmxFTKnDm1/zWjw7O5b6H1kJNTi2VkxtPCW7o6ycqgcxn5gFWu2Dc3RpcFdho4tlA/Lam8vI6eNKZIgtuX0OTPM3LCDl7ycM2uQeq0Lgmb8dbMV531VZb01E+JV5TFZ58lhhtLEA5peLcDo43JHHxez5XnKB9EidezFma5BJ9QtA6i9wCJjcou435ff7u+rNZnhmpzvRq63I64PnxXribd5X2WungG9UIBjjdJWvyd6vV6LkFK4MSfJkSauXL5GVGg3bPgVjXeu8GhYw0FXWXs60q0b5yX107C0RtR71iDZRhe3Vv5YtfJAkUCu8SKBNOzx07tsASxKyi9vMexpkOnXhxT0NIj1+ws5KQPYiZSWP2HJpVCSy4iPB5YYpnyagnCygMFF9n4mbGDEYMyO/IFqzyKUFAQE1sR8a+OqtNbw7IRbSIHxrKJojvGJLsJXuElMhVoU5zpCEQ3yINE36/1L7UTP2C1PYV543OIk9DB6pPIzmKz5juNFANziQuZoOws12RhtI4XwpUX3xNHiLQfLoK3KyAM60zDjMKvDca2DzMCpARpfU2BsAGnk5teUFwHYFs2tr7Y2HMzIHylib6ZZg4g0ul5nzAvGIOKYKGZk/JmBCbvoKoQBqSrEBXue2405GbzMQTa78GGiXVgPm3Ak2hb9qgveRdf0MzyYC/VKeAwPQCwDlLA3BI7YHpuuKyAYkvBgoj9hlIYHYxAZ0fD+wqrwHVeUikoCpm8askNKEUh32uJWDVja8aGpOrGUQolZhpOKlGNQsg2zYwzCFf6Woy4gxUcAp9irYWwjEXr2hjHYQFV6QumM1cRvIAyA3xIjuTSQJX3JT4OGp06HZIUOGaaiaU/Ye59TiAapR57icVGwrZb3jQ/i/BUZPuRyHOz1hL4Sje49ckXLB46+pmVFBNhK7IGDFi50Bm8SFfOnF3YYr+YRimG4PKXgZ16EqXpTSy1Xr7SgMnEZj4EHicVMEnCkiZstLamUVlRLG7mlLbdbcymXU4BRU0hkx9zCTE4qCr9asMlC7blbicnIUOlRb76D4pPcu5rgLXuTNcZoTHfxlFcak1UbELuVRqqiRFdUbMMXub326d8qFC/xonXUPYvSMaV5/kF0kNnq8C7YXZD8IIbxUAO200AHFZ9yc5DmRErhG3AUViyRreykGFJSqLIzt/ExbL9uR6Owtw1hgMP4IKV7tKNOfqzqCIeJNeYDCc0/Fe9zCu2qZ3X4lq5AFRoRih9STdw+qfrFv/7K7uBwVBkB7o5Cke4PgtnuKMjP96fSG5Go/gxUvrV5DCr9+8ru0euV2zNkDfb3jXTFcmtphPf2gi7J1DfnwAzha3MoZKP9StHqraX7ltjo0y8OxGZoDR2MKe7ieZrKfFB9hR728ShMJ75eli4MvRIWVIKHgqvsZIBXoy7JO6l/aBDaF9HB0U1z3uAlHcd2EwStmxF26154q8cRwgmdJC/suTdJv63sbxqw1tuDv3Tokz1P3j+ywYG5+8eac7MY0Qyyc7RvTTHpjD9DQn+QHXqy0/dvUudcgv1Ih+vRtP8VJjhXSKpT8SGz1en2lKQt6YpT9EmK217u8JtZRfpWuo20fo5nz2mVFjRyWcaE7TzS8CHSNqGYk9JwiZpF5zl2DFyMupeQOJJSB5ZPYGGn4fN8J4yWtEMCNajrcI//3ua8I/cogTYdZfNFVMYgnbcu43LmeunB5gzfanc95QD5PP/cRt9ykjmc8J5UwR8azrH48E6Xx30snNNIJbVP7dVSH/OyrZPxYLKgg0mdrSxmNMClvZZLKSaO9Wm3lw8GmT/Qbpnwweje0WYzgumsOvImV5YgzrkijvJPpb3YyQL96KS2l+WoTeoHI7RIHVbMQQEaJzhxauvHmSpmxk/lbmUq68eyWqPq9dq9QzDabBq0XCbC829sSdboSbkFyVuXb9TehNvPlfjoK0t0daLb6vBtWTPrV2cSzXpH5ZQrslRJotXK8blDOiJh1hi5f7PoWA6AJ9h8lDp069sVlv7NoZJmMAaVoy1MbWHsn1ZUFNkopkBNtMJqJgx0pQfkFl0K/MF3fEC7EDXJeufrqEWj3cryFt/uqIrJgd7LnPUTAHPj6h1KDluV3W09n7TW2ZIKX5IlT9Q6i/IW7N7ngnKAoJ1FZ1DjZZSiwJbjVSKYbVut8dnKFnx8yvGkjoHM7BTOgWSM9NZcxxl6aWsQE55Kt5WAygwgZAQPs7jQCNXKGi51BF1Ge9B4sq41c1JHNoYy7orW+FYXkPg4WvsCEWkKWS4WuSwKruuSh7J1tm4BK1TiI5aGU6ahZGinRXr3T/Kqx4lRyn9nYnAMf2wQYCBaLGB9YE1nasro/vwG/3Vevuw8fuwT9qCkwn6cY6SwAoOB0UeMtGKWLZNxaxEBx4XwcywXJ6C6Reb/n47/1nT8L8wkiRL0f2MqsSlh8dmZo2Aa5g6M/ChDqd7MIlMemwl8xRRSlP/vzZ3/Hnnot2ACENwUmv/foxFbFcmAN7cwI108B6HT+21Qfe8QB1RPxLPoelqSNXxMZ8068Im2QVZhSqwJMieoMVG5tlprM8fv2kRKvdq22Kp0vXn4Mafo0SNg7pzIJTZEn0KIYQEZHy3gvK/5tnXpZD3O/a1TLBIm1WakTBZuUhrUN2B8JwBj5aC58RAfBLRZzofPmnlpHLfdol2hZslSDkouqTDWE93b22tLJWS7XzcBMeobOnV1BoBop9BTUk0W9s3BFFohpSK71xsUQeJz1O7PI+EFmTFgmcqEYZw7hq9aclLXSlyPKD1XVIOrvXLZRhVKR7H29NZa5ybsXe3Dr5ztnx981xD4BX3h+Q3D/jWD/Xv6dYPtLDcdKBC/7BkAu/4ax5gF2FxosAJG2WGrB7fRZRVPfvNT4x8gcPyNzBtZ22Q1lklIHqHO4b5rEzQy9hJLO2MqN8zkoWGhR64180jETUbMESZr2+VE25L1lFkvDcZP2k4zEU7ftJIh3ga5b2w5C7RKV0jUszMRGk+m7bZ39SHR7f0CxtOvwfSu/bc2zWAnGwfLSQXLhWnpSCszOMa9OTiNOPbv7HhnCAbejCJHj84LD75B85XZsHd6L1zu78/o6kpyge1j8sy6NdxH20G0lVqQimtmLMuFM6CFO6AFFN1olZ6ZAQ2oLeaLBjNDbCLUZ/2P++h/LJb1q6phPszCmTFmNZEUUcWAFnjeBeKE7ARnVtdYnwmznZkwsiNQnwku/f09rWR9DdVVVWZhTsuJ7q9qpjUOadWmBMZOKau3qk5CK7V/xj7NrbHBLE2ZhlWqoi328zRz7uwVP5ejRoKp9uevLgfvYWssiFW6zT3nY9887N42J78ZvlTRvso94+kBZQEG6DvovtHG4oEc2XZV6ybt3t+pui9cpTCRXFcDDCTA29UlDnpBRlMlaWrzQ2hDQ5NZ6xz7VQ0zHhiKZKcfOwGTG4yu2BrSQCrzMc9xJRApncWz78DU+BBonwJ9MvNcFYHqblS0cKjolGJP046uNLtKR3jtpTqVUHHEfwdkv/GnG571nXN8qIPauQ5UZFKcxyRNuleFPqx8V79Wb9Ck7ILPWaP0PA+vKueZ7m2Rjk3jm9wJ9Vs6fK97VsEoWetUYHcMRmqaTvf6qHz36MOx1MK51XwSstmUSLJzJ9RDQ1GWQaHTExubIffK2mGTvf1g9ygF5gtePtVTt0hYFyOplbTatwg1oB7dUNWxjkP6PoWec78Qmb8oIqku6EJ6Uo+151stNoewM4Z7aDFGl0qpjIFqLdpUcqQ/oNv85FyJxRXaEgYwXGhTTA1wLjVyz7Iv0UvvdeX2odyrmglY4yuzQ7n8QMWC1ZqhRMY4JVEMeMGnFXbxOsEQd9b1Nda/Ro9eahO3gXny9NZ+7JZpWn9Wqq3OjRCteKYzDsDqZkaQ6fSGMvFGHNOrKvgIsozjRDUrhizHrLWSl+k8jUzKLtk6HvLYgEi9e7UmFtgcRq3jj7HXV2Xgrg0QtOvzmyqgNLbukG0kAJtqwPQWjA3Ru7dNNWBE9AGGNxv1DguLTaS0faCGVjsBmYpUjiqvKptS/eCyukPVjyy3gf7aPbzk21ZKewhP6FDPQekezuNN7Iho/MGmGpP3Uq2gUvk90IBp83adiJ5pzgr7QARggndmTfDSLHvmx7dTxGE6ULE7IzS94/iV+kRjfz8fmJjYGYUzRtvgVRhzVG0BL+sw0i8+B8qOMeIxPUV8q0T6hULc71DVtwO7WweX7Ny+5ZzaqgNO3Bl/hhl964hvf3aDMpvI3n6DGTFfqVK5pklRScl2VBhCFU3tUGjIDkId2dQ/TtnPykbQyRy/FLUZ/pq7oRfoNvYfOMwC37teUogTffn6TzlftYxXr//I1/Gaq9xl5v2QQ6qvk1UJnF5ymLfK5e2Q85P5onrdO2epj7AwOV8g9XOYuCuyhtH3rwkCQM4bSWlmdyE8FJfVA804/AXjgvJ5Vmxd4n5nBYUcxiBa+VuDhabKV/9m5SlXfk9aH3q3FdCGg/4pMtMObv57OLiuGalqCDcDR+2/iIvaQPAwaBTsVivFFVeVWrY73drIoN/zzH4vo3OY3Zat+znXN12m4fd51c22lW423/NyQssE1/oaVwjxBDoAgr58yncjY/+SuwECuK6d2B6/120nrlFIyfANEdkUf1O0umGvW6AYyo4xLjzIKvFiOTyKqKWi/xoabahiB13Cl+MIn9sp5KJxD2QC5JPU4DgO05/5QAGTSb+eS45/c16ZKF+uqsyu/+DzVcmsMgQGt46XN3v0UeztKJ8uyYORbCEbM5z9K6VW2Xt2YSeTuJMBG0vHWQXtaXr49veRCVOH12jAt+Zry/SkG6iZMRgMaaepAFcAGcBkr5uyFUHPs1BdVS+yLDy6mQMbCpLtnf53dglEmXflWMuU/wlLdL5AsuFapmsvWSrwmGhug0jTLV94w3LYnuTRXJJlA9/AxBfT4ruWdjTzqo26pdtyxwwHWX2/2pFqbubX+lXNjv1KN6uZIK6PkngRLMMlckLFFu8IrPZ+2xTjA/ZsLbSFSUYXLLG1H/NfE237OHMNFccVM8WFY/M3r1r8rfGCzGk46Yw7i07UycRFOOvMO+tO3onJWCUsB11P1TXVdV2ornBH6t04dh29lNN07F/pkPLGYgql1Z04KGaIgdM55qApyOTqYVZXWtEz5DUaqhh/jqnMHkE738LUBQElkZ5uy26Uc62AsDO9hV00qggKIO4tBSBWTDoLMeusWT+7Epfh+CASZ+H8ID82ljsjrdQlSzoxhFpPUbkLTXoDKw4p/Rky9AWGjomsk/P00MtALhYXh17cwWge0f3ewLvshF5000sPMr8z9Q+PxBkn5Aex37nAhBWX/c5cr3NFSgGmbnjWqVZQVyXfjA4uhYS/Zz7ezBgUudeu+HW7iKDjYvQDOJOtScyntgDCp7KxHCunm2N1XE9u4azXUGe+bcNKrgaDEAf1cn8ff84Gy8xDvvnvtB1bzu0WV5zDUgQ/eyv9sKTb7R2KTMvnK+5jihI89+4si8jefJXRNdrZA8r6uYhE9+63d26J7rd37t5Smjf+zF5UVvmkCf5TPF+WsyjpyI9L+BtBq3cr1EBPEOYBgIhvxbdNJWCIQJQoP1uEBgJ6D//06RoGXunAX8Q+nqnVevAI8x/p7IZPG9pf+da2/U63f7d3JI66/7j7Xb9exk4P6oWY1t/t3uofiVvdO0ffHalSuA0yysvZDgao/ieYJW53v+3fugUNuHPr27v20zhnIrFMnGNE53M3HxGQawRM02yOrdv56JnKgFZ+e+fbvvq5RknLFH6ZbTk7l5ME6uvU8ic6fy7zEUXyqlf6UmVUxiiDfmfTPFrMGpr52skUR0JjEyT4XF770Ymb63xFqh46dulc28R3Bqbe2C9qhx2aVKHLzg1eWZUtZrzp/SsXxgg+z0rUFMUCb2GMC+RsorDbv80bW7K1V+IUYenVrm2N9veLrvkQ9kfjuxNjDpcNycAP7GxwCUJgJQ9wRwKgRH+LR6sFq9U9sx/kh1JkhymG5WJfKgp/NsyB5GeHR3gRSLEVEYVTfIv3CgbpoXTwMTL4YJ5Bua+6H2Tb0GCtovMrNQquFlEeJQkysY4WU7tHKJTG6GQQhfnuHbfoFt81RaCMYk2d2dhzDzV4EQgs5QkeItJmqWM8nSxmMNfaeHtwtK01XHGxyyxMSk9vBaTh9MWEEv/exiI6knZDy/zOMuvEa25IwrvqgKUdylPosL40TSSUQWKgGwoP/f7RI917Fb2i2Grw2eeBiK0YKcF0iVev8XbmNj4ZjtCjrMAfGG+lCQp7x6N70fHBwchfqj5lACFi+OOIS4saR88OnHVT4M/x4ZsN89rEmSmLdjWLS1e1NWf0ubWlWo8HcksuUPYPmZuP0XVUNQKXQtxdhcCNZ/S4DpH1Ds/x8Bmr2t9nZ8J8wAuGrPEp9KN+h5EDELxDWsR4DK+LHOFVwSvfFkwJa4xeYdu9znZUcvAnU96C6IEpdAwjaJVOXbfNtVYwMdzhSs2d3bm5MVugzcpJCZsSXZ+Mb09QwQvPiyxZT7PUZqoEnV/QmqCrlncUfeo8Q5FpmjipiPSapKVl+zmFflpviqtxNiIxFtgprw3MqZxAo8ZWFrmM03F2OeCfroHWth1EOlPHG86Wx3kz4MBdan2R8RGPgnJ0M7JbSNwBYQGP0D6Qgkl10QDRS03FTziekJFmV5kJGbJEMcwNGHKZOaGiSArRUYDOsuA88yu+SGeZ1vrgDXqrzEzL8L5n1SZIFMjnI8dAQOhAIFzFzblbiHbsQfMR2Fo8Lx3YAJ86xh/IRdrZgrVGe7ayUvC9TxgJ0lRJpVGtjIAbWQj91NYTz9My6bINxlNk3Eg49sVLBlJVGEC0tcBzeQ0K9Bfefs9SmNg/v3vUpnvS9/evgKchvx+8+k08+PfKupTyfBytVWl2sF7gtNQ3PhrT/huZs7eU+mppECI52GHpazci2Z3o/jqOkc4EaI0wtMhz5fGMrW1rFH5yPYp22/Ci1gavrJuxDE6ypuieMpAlTTLPF6+zr1pe8iIeyTfxSia0393vB85HpugY+t0LureJhj7Jwp54m7mxzh5lRpnVXiRZ2cGV2GkftA4Onjih4l5lPEwl3XmI98fDFo+3+L4gj+Kcnh875+sZpXwfj4GTxSPLKJ/Kkq9ETIJEOBfp4bkax2AZqYf3xDosReVuvWCi3tEyDy/4xPhoJmEULYKxen8ZA/uZxPMYNRuc9DgqZhHupMHcSeGwEsFaqPv2gqmYx6uHsNrGL7OxDC5EPI+m8inf4rgSC+Bsytd0Z9ilIPIt8ycXqNcLzgRUsJBv4VNJtgDnwmj2bmzFlUXVS0bBg7A9WuY5fPyILx90MfJCY+QkbKewLNo1VHyqIOp1DQ9P6oh6u4uYR25nXgFhVXeLPSCzO1JaFvSjlTfhCeSMOGeicoARfeAP4O8JEDq0zsN4ojcGxKoA5dON94M9CzNSMNwiZBQ0lPIsfCcenobj0kvEA18Mn4s3p+Gi9ArxAt7ei78obyRO4O2p+Eh5E/EJ3h6L3+ht6h+DqP4Xkl7DRy6h7cvwtcNZjiFlHD5xUmZkYPbWjWi72Rz+84/iJp2swq+51HyGhS/CR8CvSe+hr6/Og08uIeMyfKV1cMMP4hk1alljegnPHIoo/CXzHorqZGD1vJkP4e+Z90b0fc1D0ViUCoX4/V9C4VDoVJoZ+N0ztPPTqU55H910PVOwrJloz3GetKvZMLEwd4yR2MvSybSTCotdiG9tlll1+OV8p412CWL+WrR7bfJ2ZloRSrTng1ezdDDlpU5xaE1IAWBUOlMcTIoxKbM9/o177K5wrPcC20VqDcx1FjxmrpxG2wWDOZeVzyrEALPPBN9VSr2tUAbMPTe5iqSaCDzs6xIlGCdB3R5Ll24yydWRMa8Hs3TmSt+Hey0s0SEF9k7ZeHG73G+2FcqkwJ9/BlyRLgX5/ouQtaKffvEDpnoK/EMVIqsW9vj6wlzDMXXKI9F7upSrknikT5kn6Sje4RIe7kJ6CNMM/Zw3Td76pCiJ/XX3glzw8Gc8FlEF1YnGZFFDVH2bzMwGSZNkhmzy/v73WHkb6+pQ1I82WQfkfNN3pPMppppjdoBhI21Ox9xQixAJQxQaQsVeo7yC80bVvOr3I4ZZ1mBIUcAQS4aYaIjK5xPOBDr9a6ZsHWZkjoECn+sIawbIceqM9ejgsRwsRa9NmG8roeFdRgHO0VPduZHp/7LhUzPtmiFUuV8YRgV17VCq/C8Op4L7wpAqqOuHVQHUh1Ylf+XwKugvDPHDpiF+n2kzZBtBmg5fPfeG810T+/39TAUhO9CC4v37ffLfqx6TmPhjn7TrPQUbm8XTWWsUsZkmoKLbeof+ZvNo3cpGwAq0LmcypQJw/NBBjTFrCgHguqNd5b4WcpVzPe10/DP057NeNgTXbf32d7zfPmmHTLniviVr8sm0LnrGrxCjt+ORTyKhBAySJLAkKIHcCJOkCztgxhqJwrkL7eZfrBfKTfS6q0+oQMzxMvhoG2KkDBvBw67HUmgBhdZjWlmPuV6PWW09xpX1GJn1mPB6LLa4SS+csKDDUoyMLKnPL0UkYMWfXudIvuVYmAV5iJC1anJaN8+KBjQdyR8G5x0pB0CwPy4DC5mpkBG1IBIFhYWE1THMYMIiAVGapE6feFEYvaVslZWIfCjvMlDm12601m44fKM1fPQGGHK8zRpKxy9R13C1jmUybgERDBPjloG2ItQEvKcNHty6txy0ETVt6lP/s99uXUhnu36a6WNjRlGsDrxJh4QaV3zAOIr2HDga4JURmdcuLqbBFBgBvyuj0cyzwQ6UwpdJx6NZnGBwqRR4RI94UnwK0b4bobYUb/1jRmPqBxHFNa3eo0AGziI79vLwcaai14GgAM9sXlexJ/KPtRqbFE8cCgEa/Fum4rBkoTbPMKEM4hAl92OjCEu72WUq85Nfnmm1lyGDiA48VAZKGJUlxnIbt2GOmfyFmwdZaRdTPJ+CD2kDpiz8c5kn3v+4cRVv/T/NeW229SK6FWR3v0ot517JdqzwNZDDzFdAZ8TMayhm7TUA6Smo6dAXfZWfq52pxljVpltK0ZZTTBqePiHfmJSrqzH0d1ENw/nfxHCkNp6SZir0gUJYwsTRiIxcRMbbLSvKKEz9lWvC4RxLubGmqpGmHBOOpGrCUeBSKE1b8aDStHPFE4GeYT9O9LPawPNO1DH53AhYO52kU/i4Bh5nLmrFb1lYO5SxaqYPzkHJU/tsxhI2M7w9ix5ewaLVOczcSA7aK5pYGulKyhpE8zNSiZrVdM2fSFdYroE45Ve2ixpYoiRnC6dl6QZAkKGrcJBQA5sbadpCWgm7BjzW8rWFNSJ3AyjL2lVYTjPAKKl2ci2qEmhFeHWGoFTXqlmBWWeSoNzJUFJGCCs3a8ukquosC9nuJ9dS9Am6Lq4HLHnr04NtKI9V8QzVkfR5u8LPPVPymXurDR1vsuIkpfBY5TqRbCGIxc3jVecMFQKdOdB4bLCrIdB9cqaDenRq/dVwkWV9Wymdc0EV80idaNqYp7TxEG15rE4u+FBDKjrz6sST3RQWRQE1y6ILexjQx7YPixrG7gEszvhsWUpPLZZ2nMLqi5WOxgGol7OCOXku2sjltIlC6WPmerksArVxvVJbFxGqql4Beii4Zl4+lMA+YKhezParmyimoP7eouv7rGFUiMZUzTZ/VqeDyhgYhPvwNXBa8Me/yg7w7qGViOl3LdKB63/gkem643hweAQ7WRUEvszrIF622cS+aU7buKa0xZ/2dB0dz4TeB621rpp6fC8Xb9ZO4MyW4zv1ewU0bQDlqfFDFh7+szPwhh+izqfTzfCPo297nT9u3b17uvnjj2Gv84+oMzm96os7W++P/I90M2z9UeLDH5NTf4Ag/+Q3BelzQfDW+Q8UhupQS99/yq5zB+NThfGd6O7Z7TabDLJpldj7IWN9atlwE5SON0s7QgtnrTbnON5F6I8WoTsOfNIvu4s8W8A0XWMuLH5YxTaquw6rvuMRoQ7XoHp0tEmZblSO8MrYuyIW80E6mmV5UG51VEipt+xU/EtBMK2scYiG8jcONaIGUXBIfgROEmxWgRcdwA9a+h3+s8wWNjMPDv/JJv82Le3EgZcfwA98cLplFMuYCVK+HNFxqtARcLdGPL7iqJpZqNRp9Kr6HovJCjUgpPjIcvSWGq+CUdgT4zVdbsPdCybmEVEyCycVpIzNu0LLwiSoWMcTYXiEYM3HxlM85scne+RyQdqaleCtLLhEFginHlIvFFFDJlUU0Tv8hHfaDArSinJynMYYPAIE/Dx8i4fSbgqD2MDF9S8Gqc0MntDXNjCROkwBOkN7XjagrwmRdKgSeE7CuuRI/9kAaPooWcL2BNOmTZltMVSjYPJEW670E0jysPueKoI9WYXo6/kL3kVZWx7RYBidwsAx3PpauGQwTPA6NGHbxyNf4bh3DLZJzDf+oL+yGNNoWonjYyig3LXA1QSBqm5FPOuM5W2Mt+1MpLUeAnp6Qc6ddL9L7F2Qf5ncOvm5ycfTTegWs6QKjPqpJ1SoiAEGt3yi4j3Xwj9LX1nUD2EXQ30UIuOktB6kV26s/VKFgkbnU3pSimqQC9lCZau9Uo/TkKOI6EjvClDoCHZboqnNo6Yrr9aNq0GXyknD8lQHxKbmb52QeN6wFLvnE+lW91ETUOP9i2nWVWdnIM1dk0qVxUXrkUTpn5fpKjwYqcc1Xj5Fj4Z0hAczN0WFBB+7aTrm98JN1KHEeXiBaIQz6U1VnUA0Gu4gUVdztlfrdlCzUKdLt4IGp/E1ysxtKA/XqbIzwgJO0XXcW+nppUkZ8gvAsqtli1WYVUaLKtpsGu7xJOgOQRFCAZ9Z2VrCvjZZoaJvsm5Xo41iADR3WlcDlqfAY8NEIAt6E4qdY87/nbqp6jVeycIz4xJ1GVgrE+Mwj71L4STgpQ6GempGmv0Up6Ul2f6xZS0cs0AMdf4Kz/+Mr1YclsfK1qxCqAHW4x2sQJcPKJKMyyowXibw5mOMfzLFQh1qQW4G3Qw2X9SjhrGuLgrPUq+CVZHVTnvNVuMEHnYcH3gMSF7CK3tUXBK8l2i8xAsO8Oo3PrUfbcPYGVCMkdJSnhPnkiJzLn1fa9zQ4kOt24ng0mehLX8cmhoWYaEqmIdQxS+lFw+XBp/rcILH9VFeFu9j4JTbHfaywLtvJ+FER21B/b2N8j8brPFqYqVIgIQJzCWlQcA3f/AkDV6nwafUm2kTg4XaFBe2C9yCaagCZSxNoIzl4AEFsMJ2Bi9Rn7Nk9c10l5WsExyM/sYzHojOEjlKruYinCp/4eEKuJTLsH/YOw1/L725P5gH83u9wXBOl23OT+2FChN/qsIGkHqQdbahEwq5dusKbERmdoyVfaSJVuMLxN1qf/8SfqB2jAWOcZoJwytxibRxe+zEnk3DNk5kQumgDFwMD14gVtrrPhKfo7YfOGOh8laYt8K8E3yfCF7tkwF+oO6RgBeAMDZ8WfiDZKZkMWjPo1U7WKBdcBMOtLNz4b3CXtN5StblKfccFr66v5TSLyrnLDMSQfGyFZgbY7r8xsTz+TKCaBvO8YK37ZbWcwRLzSxBX1zx0heGFBiuEQPl86ZHpw+ukj3DpWb2UXWMHodEMrNTK9aHsTUGyzGnDJvPIc39E+VWWb9qodhWmhPB9g09xst1tf3q4T9Xm5UWAnLfqhlyQNYigb55CgRH1T+mDpTaDhb17I4lLBIiiXpfY4cL7WNLc9c8vJWjhS1KWvaSHvsJjBMpB0xvcrKrdT0eYzRJLB3nSZQNQxnjR2WGmyeluNcYwW6hRbsGzpICcOijGLsoZQ3G3KtdVh0IrRedQzXeQVKN5+SNygYPNaJoc2ny75cmHcHW7BHO0ZKDM1YqK3ZV5XvOfoL3ZlkYk0632zqDATyxHYkvs7cTirSlWVxyVw7vW2kfGOldyXtg2EbmXctt8Av6qGreUodylnoqKnZcVuxUfGG8o52rXWPXMVdxaMi/DbCAksQ/uQ3QCp2SfSeQdIkJWtnowNMT5mnbPjQ8dQMFRbF2veWQEyjyZtuK+XpccUGIjEIgsULvY+XGUriSr04cVcRfnbp0ZGCdNjEBL2Z04VxzNP/Npi/GdRGtyXJ/UHOhjbOaxyxMI/aZNR4eynkWrYyNs+qe9dlwVJ8NDDL52nVVEcMh4O1UDPEE1fWCzDwck1z5kvR7Pa1WgUcUUZSLJJCZUegVncg/9JKOvZZ5tL8fF0+RuUS7w8HoXvdo0D0KRvdvD24HoyDOSHYyrb2ONCii7w6sVL62VaHVnOVAwXg7NGQ6F8N6/W7/5qzT7UMr8dHLBlnzoAV9H8FujkGmNXdAdPvCeP30exgtRHeTkjn8C3R/0hn5N+VBcbDUp2KLMB28xxB0g/TaSWJvkLkr+ncPZ37Qt5taxDJIeBCJPc9gNII1Fd3vfUZ352KsheddhtWSYRLTiVOKQxbTQVTp34zwXNWixdHOBn3gLvNB3pSjz/TkTS++qTDQKe3NUfqZFpp/kJr7ofQjLzb/cIZY03fUe3swk/dydd8Q38JhBuBOTyxuznz/5lHv4Fbv5t5ednDHiU2VxHwKTGfyu/hx8AKbATkPFk4gYY0l7Y1lAgGC2M7n3TqwsPJHrcTyrYfFjUO28Xcj8lJgQzMx9aywkYmO41BfK4tX50qhg/JubfDDONQ3w1ZLpgh9uxHztB/U57z4zMWLblRl5NZrEylHRQEb2MLW6MTEzKprAi9Sib3E78QYGVKthiJuDuUxijmYn3I7EosVev+t6WR19ZZvpk/Cb3uWXSy0enGENHBZcZNKwoPE+vzhfRTaqBopWoGlq80xFsZpaLv1nbu/sp1vjFljJIxLEXk56zY7TcMW6fYBD2VPpDTLUAjtg95aAvHUdbhHcBjlyq+feiv+ebINC1TmvYzy85OSAnHiSQ/HJA2LmBR9IJMBcYEXPPpewgq+KnTBIs8y4L7Rd4oaiY9b/nwczpRqoGDzlFd+p3+sncIWAo34Yedd4x48xavU8KOLcD1Ye3l3svI7kaPrCXpiFU4HU8xa2yxUPveOF9UjoYuDcFE/EppXQVYH4bwGokjaZajOz4C5oRadIQG9VFY80CWSNwhVxXEJgkslJSx16CRfnAGHQtYeiFBxttmUbIOB7NyZAVML4FzcOA3LmHPxbm+YWS9xqjzYhrF4Eb4c4HXLIHME49iLxbkvTsIHmPYA0xaYdoPR/km8Fk/EW8c1xHDel/T3LfT/bThCZ5bkQRrPcTmmT/H8w3vrW/8+tQLO2N4BsCGUUhY+RmoHAkvta4+kxreEwMrtkHTN3hkKQNk9udlkHLEvvYel+lesMVeECR18yEvorDuW0B1JVfucbt1YFAf0ibVIT1BT0eU5qYNTfApL8QTmdmUlGCizfzHn+mkwPA2Gn06PUcklUc+OMxBtEvBm98marBNoSuhpkoYjoKdqCRKL8FqjWNPj184BK3AAr3EyuKex5lAS7aTS63OP5SCtn+TaA03pBykss3l2Ia8rfLBzEGw/z+kar8993lC6Yx50fb5rH3Q9lDIN8revtbxLyqmUbjJCdgioy3B8Gr4OU2Ba1Gjt758NlN2mb/Gth5J0uU+9iT+YwJAGE1qEn/zjojuOi0UEO+4vSH1xQpkQUdaGHGPNU9U8UTab9jxbFmTSlenJ9I4su+jgp4tuFNAAPe1gygITXOBmpoBxN4s74YUoOuHKhGSM77nUbbOJ70ddokWGtBGbM+gDW70Mi3sOwQNKDMDMQRto5n0AnHkLdu0BkSG5mdQvqsqtamN003sBeABeW6Th8qZ3gi8FzkcJvGd6Mz3O75GPzQRW0zjMfctoTyC1zxdj9elqKTsQLwD3HSAX4Qk+FMfjsLxZHkCJ20feRIwN2pd4vzBZj7yIC9j4AVfaKkSmZJfyzhefAcL59CWYMWx7bVEx5LADWlYHlDv2CR2I1OhTDGqcgsphE7gpOcCYjiVwcoWnfVx8tAk0Hw3MUwj7o90DYRiekFVJSXdgo+sV/Bc40D3xCiYqe9Zki+fzuRyjYfCbPFtE04jtG30y2fpMjxMZIVq+rsvOPH+kmoTFv+Jn4ElGrq5h6eoagNHqi75wyfJkJ7/bq0LMahCYX4UYo3COs351FEixCtKw3DrxpYHaAzlEj8xhenog4Q/s3UE6UEbeFLvXCYULG+PVGktbY2nrf7O0udt6uhWxoo7QcUu1lqpdRmcYSKSTLudFW/Gt61jH4jrsf+c4cE6Rb8WrNs9RYSH4gVzDodH6/WU8DnLz9gQvGucbmtFkyfkkvIg5OJz5DFNymwKfYoprc3URV09+lRa/egKsL6237EF8XSwvG8Try5F42ESsctRMcW9AorCh21cgX7K7lZPbUSrlHagOHXWYbH2DRWajzlzGKi5NnI/MxSj80iETrMD20c1TRok69zzW0dFH5ybxRq2tmNlZudn/6LlZazer52+vlcXVBNHHrGb0Vs7U5Eh497WdNH+CMroyh7qI5eXDDE8zO7db8K/fg3/GlpTB37Np5Z3unbvVjO+V+aibk+UxUCIU/VWCsmBjnzuVZmw5qwnaiLPfvV3LMKaWbVKKtBuy2WTT5JO6lIOnXmcU3X7ZgZpE51ZyS9xKOvCnja4mbCFu0XlZ0Uu26qiU/zVUMubKOtI0Kht6qKav/gJadwSobOjT2f9tfbqIcq/TIbuys2h0PqVh9Ovj7M6Pr+r+rabOn/9/2/mv6+sOkv5Dnb/xrxGHWy34d6d155ruX9P3a4mCQwC+aqH2YJVe3HGXJ3K2L2M37MGDmG1LlU9Q6m7urzkvpdNZdgEj4RbDx9oYFLUCxCeyUG0qRPmncUHoC6B29JM47ItPcXhkm/Xa2cx5D3d38NTZv607E4aYQX4j43MiCo27v6+0l5UQuYVWHogRapiqLnWuswTGlv5Oh5bWd9nkGM4/KiOvclumcX/rk9WEjlVi/IlKjAOKMVJKiu/vHArkytYksyUYSSAb9iAPLQhiiltLZ6YY2QQeNuFJjMylqSDr9FUV92GIO53/SB2fYnNE64wfWoxHTiSS5XXBd/k2WRyD1F4de6ybhSwViVsRK9E86R9HIJ6RygTDlWslD8d6CiMCUt5Ao5rl+HXW2NLLhLLXQymN7XB5AnF8j5fxjgU5+q0A/xdRQzKYJtpXJSVjZz5Fd78oidEnd0yyfF/qZc1sFCxadCIl71/kemHkfArPNLr+i5QsAvY8+wF9sQM+58ZS6KadTCANbbxNzqn7U1w5QXwCHD6Hey2dqKzSDe+aqrMtq9cl47jwkVrbvvjKEpwruOu1oiJSVqLG/t1ary3BuWA7rs1T15TKvQzDuXP7dTYY9kXvNBjiJTq34ZcMA60qjUiVuXJBmtZiyCio/xeKr+Mb4SZ8VnpNMg9em6BffPfk/11ci612hZJVJoYkD/T/PA1i9XwEz9E2TLWZYmIvyyi2ITQ0U2HBzU3c/FA4JLKVGhXLR73UFJSOGKxXr3NjBcwtjGEiww/Q1gT9rumge6QjlbGNJbabu+403uAiHmSVntjLMTabOKQ7MvIB2qrRNrYUEyf8nCNWms8msBzIQmoSTMLL0vvgLUNsHPvpq0vjUfWg1SnS+7pmOv2emY42NJ38LatIooC22s+z6LLXEcebMgVF7nXuD+OK5QkNfe4MsXsfCg1xbsMTKquPTA9zPEgDt49XXOVHuvSq0kyj3yK0oas4397gIA0oqTQ9id2e6No5+0cKxq0jX9VCUYWwD+rW4f0z6E6rM2V4IE2oKnPLmVdC6uGRH9RLrBYygBIC76AE8k7g262L1OexCuemWvqOD16fxKIUez038kED4Lot3u4Avr++RAfqr+uLc6Ce1qAeNpb1sQHKlMXD9zgOHafwdr5Ejw/2CKfjNOabqhF3tsfsBfFb3KKzxPE1DhE2OGEq1n08djuiuYj0OHZDnkdhXKHJSRijCxuZzXoUjd4Ec7FBAyuhTKB4E8PFRhCsghwFZj00gwBzGANHAYX74nHsa/cGbmSYcogdk6YspiEZyMVUHSpJJBSoidTk2Hrl4xHpGkkveWkl2OQCGzWilXqpAlwom42J6/dR9fpwXTwWVQeQObn9G7SuK0idsv3ucU04YwdvkhU+ZNQ9ajSn/KxSsMH7+/FWvM5ET0sWqKdV/r4P4N1nhhdoF+mVPevxi0oELVY/y7TfG/vU9tsiGah4KYG3OFh2xrgWdfbRZ7PRXhP3pad4gdtARVY5WAezg7UBgRJGBiSyx5EDFWTlIHKPKDvTQKXD06Qz70xVu58rTKTq/UGs3tGh28hOyj3ow9cujD7M6NWROpCuLQzlq6yXBo13fWGsvzSlxar/xbWzOtpZO6vmhbHeWRjsSlBfGuQ38C8tDPSIWuHCWP23FgZlr10U/1sLY40LI9qKHiyN//TCUFM7dqf2wk7tlZ3aABI3TO342qkN6wintl1GziqbHcDEd1fZ0TXZf2dhWK9jpSNCg3s8ePiJ7q4BYpghMYz5SuQQdkFZibMafh+zNQYwFbDP/0YMNcIKtbvw5+4O/qtT05pqQtOPFYKubE3vv1DTB1sTmjKaz92avjcMmGN5W3HwlM4rHeSpCnsoJmjvSitQ2GzJ2bXC6pJJOgBQGJxhCeUdNxaFZqEVryXrOoytR0tSfTmPrOslcqBJWbjXO87vpXTvYJMd7zA/RUMcZabPVuao5djj2Hl8k24ujgRaZh8g+AE84R1H6DmvswG408nhf8uh5spKPgvx7i/TKFRRxdSe2EcP52F8CjwqlIn3JulvTVzrX6p8DoYja9dDPyoVdyXEzS039qPWrmkG6Pe/wwBhBCyARhf+3zne8w/kYPpT8IMvXM/YiODUSxJ62odVBVSEbayNEnugvF2dZFYKBG2Q9seosaRAyKqgAgoib1cHHm8dsy6vToa6dqxWEmsfg1HYp1cVkwtdC6jFry9kDrz/JdLoLM3IcR5o9CRLy6fRPE7WwTj0ZoP28v/l7u2a27a6dMG/QrHUakDckEQ5dhLIMEpx7MSJFDuWE8dR9MYQCIqIQIABQImUyKr3qm/m4pyerpqaMzVTda7mbu7nen7K+wfmL8xaa3+DoCwn6eqeU3FEYH9jf66991rPk3rKn3XUo7abwBgIXg6zOD2iLTGqMcHzj9iGOU7g+PaWF+hCItBf4RpyOmPXhCN5BaIKOz1nl2ctdmqdO2hTwlOxs4MRJbVxNwzfWhg6wWRIiN1lOoZJ3bpyY2VEJka4ddn922nPOwt/GWz/sgN/e04i3nuw5/nlenvxT65hoGzkrTNyl87EJTrYTRzdHyMYf1AuVrUtAp7b3qJqhaezGcyEBdIm1wGx9664EdxkJhy73LTCDnIT77qtxGlAKBFGWoo0ZI+E/ShlDl6YQJjE6WGCOJEZ072VvHXnR+PginW1Q5cJyj0Zhckuf2ZE5v1dWVaqPq8MLM1eH3yTOkMRWfXpYGNDWF7qUYDmiwNXu2LdB5fGO3Z3DDQ2Aol+L0wflTMfAOgqrTKNiSSYot4x23Ds0j8J7lJD1gNb2nvxc0yYn2ucKKugioSynbIKRfcgFs733/+gTijvXDHvCFMBSTbUfXJEMqAINuCCGjsF6U7r8ZXuR0luOTffZlOI2LrJwYKhSPfR0hytKU1pjt6+T2WeQylUGdphP6QWXoYWtSaInFFJ4Q+EWHfzNsbX9x1eIxAa5bml+94fhIbjAF26XWg9nv/XaAgPVeqhOlcXoQMVIOSKFNcms32Trk6cfPQL011jHODQwk6BFvYZ/FZp1RUAVOLMmr/QobMKovyUgxqYygVjnLmGxZaDCS2kv4vWW5t9CmZS56UaAA1vBOxrnltjhUzNRS6yl7SM6REA/Vb2etqjHKwHssmDyrkpHEKhDMNul5/rxS6bKrZQNgxoKqJTw51P+76cicih7019p//oE6+/t7c9Bal7j0zGp3g3I26MTCkNBLQpCWj4qb1ezTZyJIdumIgWfwxFp4aXHK3jGvcgsOTs4Y0XdAqvHzZ9EblyCCXajnrdZNx1/WaAAYSopS8raFJ9CgWGYgRYeraCNYf4xcGeQMgbClO6lVyHKk01V+tk90hKhuG+AQIrviLEAeEIyob7Y1XEQTQPcis7THj1K/IG0s+3KV/RSYNq5VrDwNM053gYyfzC41lNd858z/Kz3LPAdoenZ+5WcPaijGBHRETcFmWJjP57Kk6BkQrSLGcS8ZOHu6M/l9Hnjeh5JPdKHCwKK8qLxKqcGGu6gs/CiWtISycBmKmF1ArAZ7ZErai2pwCy0eur5X3FF9euxjdPzEU3bJEe0cA9T0i8+5ZOtENbD03IsktoZd9KzMr4WlznJ8Zirugk+cUmWkGfKpQqxC8h63/Ux0GlK3Ti/BysO5t51TgiRQj9JH9Ry3EKi003Q2VKCqKezEf9TL+lTIIAUvRlSqFaURq7np7R/StiThmMyacc6RPkZoVXqpg8YFOZI8uOSKA2d50H+ePyQCBDBn2p3IYKhEKZ7f/5v4Qumdf1ez3oZgh9iUOBbfTPYPOVm4Y2nS6BglphDsCVjHsh9tmBe9CI8ksJu59fch4khx3l1hbMq8Iv7/pGWntnLO8Ri4hMQZrtQNLLpRVyiX1FdTPcLBcBGnI9wWkIL1FY5j5JiFqas9yIjTQeR/Qc/GoqEBL0hvjp3S5pEkASVbgaJyNPsa3y0yBTW2rRydIIdsX+w0fs3H/0gMX+w0/ZAJ8S/+FnbOg/+JRd+I/22ch/tMdSf/8R+w3/XPoPH7IMn8b+Z5+xHH0L/DPBwL/jn9J/8Dmr/IefsNp/8Bmbou8VRrv2P/0cphTwmOPrDf459B99zr7wH33KnvqfPmBf+p9+wp75j/rsORbjK//TR+xr/9OH7IW//xn7BmN8i4GP0PfY/+xz9h36vvQ//Yy98h89ZN/j02sMcoKvb/DPDxjkR8zorf/5Z+wnfHqHQX7GP3v+o09Y3//kM7aPpX+Ar5/4jx6xh1gbjzCBTzG3z/Dpc/yDfWr/c9bd6PoP9tk/d//Z/wTe/hne+qzrdPHzuy7/YdwRWgvS7+7wt12KBw1Ibwf8J+z6D8HxH3//X/n7P/7+3+TD/w6xP8WH/0M+/J9d/7N9AzUyoiFJg0rRmt9KuUDKCEWQHBSP84MimEd0Z+eWvSBFVvXi7CwMnSvuGvb39/w02tHG64aCbvaHM9KpQ5U+aEka9ha3+uygNo4ZElsey5fqrG0DoVcSQjgw+U75lsXZRSC2cPFLvnvh6qkmzCI/imBsoFileO4Rc4FKaCkvxX+gTEF7mdYWQMxvuZjcDGnZ19EHomysKxVelSBthBqthGrI2G0pTqNmWCF+G4FtlEgCcFSHH0qwlLiNxWMDoU9hzaB6z+4+44aIQ+pG8JrjUetpJVwKD9y8rJeCu2GeXD3eC0tfTm17CBiLWROLV6/sSQ/qbJXLPQXn13LtR66rOgip+PCigMaaHmfDqKFqAZ8tFr/UGAARDJAM/q/0whY9rg6iIIPBwgdFJOutwnojjTTiY+9VTwRoNeIuHqS4IERP9g7cLIiIJW9STBxYNDwdTRzsRizx0rMlRKtAkqbVIJKqC6ceaqgYVgLRB1oSJLDTVLYTnefLxkihMWqjMVKrMQwzg5aqyo0zsw90FegoulM0O0REHaLR8lGj5YVNdxTsnv4yuX1ajM9TRGn/FQ0xl+DybFz8lv56XAyQerdcnvV2p3M2huDoRye7yeDXV2lcS37OJQTQXYHy1PquSc8EtjbUBGuEOyqfwrb6kNTXcJZ4Ejx8uP/5I7TQe/jowf7eutC9vlbVgDgYlOJ8+uCTT6T5dZ+Y5t1w3+8zuwQiwAUvKMgVk2gni6qaMGWChMGrRJVcyiBJYAZyW1PsfLa/95B0k6wvE+Xg9QIlB9lf217YldWI+bi//5lhJhGtKf7YLv7YKL7grYusc/6rBI/jhUaDRQ/V0GmwDv1Ref3OuwHJHiVcl+w6Ch5ApPMoeLh9HbFLKMWgjK6bQnKyne+eRwf1DlpVvSlg6Ozh5QguKfTmJWQ9wj29kpXcoeEvXrn3csk2G7npFPLW9MUrekLsY6VB6ZyeCmsQ+IAzdtqtJinqEm9GZwhwRVceh9HHXXmUfhFAhQishlSe+EWcAszPgkuY0uQNhTqNNa9DYjrUn7IhHeqnrL8PE8OIDeg1gm/4KD2RDx6Hi5KKYFMZjDt37zobH62cW8/krXgZ9ApxiEzpBEPrPFsg8VGVNPFH2jefrXyi2Adog9GYTREY489jSfIGUyCSEt0yMk/YI3W6Ls/z9DEend61HlLHxqFxA+gNYVLnfkanwDPUl/Fj2UJTWf1DutwXriPpOpDdaiK62hj64lyeIF+wK32CXLSdIKeNE+RCuRjnxXhQjGXa2srUeXEePMnvdV4slPHbbv/Xnw7r4+ALPB2O5V2/f4Wnw8PG6fDwrtPhzVvRShygDPYi2Eb0MuXp6Iz3IK+pSKzpPkLHtTF291vjkDMeUCtbBEpBLYIJ8Sq8JqAW1Txj6uIwcWHCbO6yfOlze3ip5H1XtJqNME69dJ3msXfZeux9FKlJTWgr0JSGGKmohdM8mEuaB3PQl+lgLieURBxSh5E4mCuYBOo2aTWj1UmUH7KVRn5WOnjAZx3u3TTTmN8jjcYB4Ut7pY7KCzr/lJPX4/2trQ1xhQ3CQs1qQXFoKkc7VAaORmXokcNeKpL4z4iWnLRoWYfJ6d6ZuFlQB4NG8V5Hxlz4DMt62sWrcDwTo/M0k5/5aUtgHorxSGbg71oCi9N4Rof0ZuA3LYH5naK6SjRUdCNHNAjVSABVjColsmZVV/0t4hqaEYLz1tZnv/iIJIaQxtOWNF7dM43nER3rf9eSxNuPSGIIabxpSeM3uS+AhED48ssmv6ekFYL9sRTX0qBscBHBTsiS2jIITHJeBUFNNqMYAhoqFVN6OeHJDo0XGX5kuPGkYYFO40uukxA4AhYwfOSjdAUer6LBAFmsxvT2mi9AcxiaFxLJ+8pQW5sFWj3nKtzf869cS5Ht2vIXvZXA+z7Z843QQrftfG1ypOp2aadGfd5KjF/Pb/JfUUXH4g2FQf+Qv7zkBLBHBm3iCUen96JZWr3HOeZG3wSQwuwEioK/Y5fN8XduYMQewyRxjHLDMZ41q7zp/lAgEzTHk8sOgzRzDmEyTZ0JzEJZgqpvjZOJW7NTlKoHSZm9CAzNZiXfp4Kt1UBpj4Kkp9q66yXjST2nE1dLPM2CRHeOSihxxlKJk5pgGsSmvuEQXgczfwRhSCVGZiHV2Gku1ZU8wYod64r9MXJuIoIqNDY60A6TZQfL8d7kEkYh1a6OZmWs1INdBfanYnmpNFh+oyv1Rt7LotfpTf3eqPey8IZS9pJioBDOKiGKGVGh7DnITku77RTPmBrr9kg3huOHBqDRW0UP5Zrt0HUql19iN/uPWQPlvTpBYXaC1CwEHgOZJcw0SN0D9rmHp/oKfitynzzaCz/hIGpxAQ7b89SlSQbVIypzEouDZjwpapu1yxXFRCtY6mDTwIkoFumARY89fF5V+zJ1roaic4+szj0IRmbnnsArdI4xhNE1P4eOc7Gmo0ObXFmdO2nr3HPeuTs0UbxfNtrIbou22rI+vfFVakuKnNZYnGbvHnupl0H3Hvi9Mfyk8H/mTZYm+ofet6jJdiihvE39nTIjojAVqEJyFbr0DH6OVDIJAYSoMcEXNXtJk8visDFQRtZAGTTWvXuPGmO1stemxtpjrTQtY40PM2l5I3XGvk2d0zP2AwiDrZ9GUY3aVdCt8iAlC1LcANzqUlr4oA1gUAsRFHeLoh/C3o2rqy8WERsFx2HoZIYStVyFfBoiLhsERxDCXI5jf+h68hpDBic8b6epnyaV+hp6aWZqevTRqreyUU6sIwPv8z3XX8nGSs8c+ys5j1YzeI9bOY/gda2s9iTJwFxpqozCB15laqqMwqn3wN9TbARmQQa+Jw44NDs15HWyFKOZSaD5U5D7zzQu362pHXhaIDlcxuT2IWmVW0aW3LJ0zxDX2gbDff7/c9lzdj/Zc34f2VM2ZxI+sCTLNjl0/0OSp9Ebmum1CKL7/+llz8aW8j9C9pz9KdkT21uJnqLJSPac0xI+I9lz9rGy58lfInsKWbMpjN4le86U7Dn3rb5G0qc35LInSqEfkj7NyN9Gfv3vJn/O/yr580Md4S+TP4P+HxRAMWL0eO9vVuUqgwS+FLWZJUxXk9GCrJUWCarS6QOSKXZ9JZgqdqwRdp0xdf35B7v+xapkWrd1/YuPlky18Meb/w9IqgjoyiXV5lgwBFRfC67/w8qq8//hZdXZx8mqfLlS0qpa4Ct/eqes2iJproivUuBsCI0JCo0jKTS2SqOj5k60KY4mKyJmEnoDf9AiUI7CGERNtT9DUXQoJc//DALm7/c8IP1q/VHvlx+RxLqj3nf3TOOn9Ue9v35EEuuOer9S4vYc1rL2I4CZlItmfZCFHGPrXcgQ+7CQWXuvYmXCzoRAeFGmA0sQIU4oKHhsTeY/pc3JPLMiLanEVCTKHlP4OsK7StPEVH3djL6ubUmZy6+b869T/Vt+wpx/nDmN/+mv++rDXzfjZrcp5d/6deAgNkn1uk1SEuyoXVIe1I0JHse1OcXjlgoySlVRNSJYI6IdjUcyLFblbFxbs3Fi2hrm2oioNMwIC2tJTU0zwsgwW8yYzbssZEfF7QzTNtFpToON/pINFfgQq8+CAV6NsVMcMRNUbRHTjy8I6/DGjroD//lP8h3MIOWEdceg6tVLPa1qqNuWKb2117gJsgg/4wCJ219zDJnUTlaLIJhcxWI2lcvkUCBLo2K9IDDLFYEZwjid5mdoDVYRrNdoPXGZIivLNYMGguRLGg9ielN4OFy4qIRY8bwoxxEal5Lwga0BNXQhx3UefrbnP3joIq9cG3nuGBbpzBmRllUwhs2ntGdVEhTS6o2Dr2FvykZE5+KG5gZSKgqdQu0YRA31ThnlF6SqIUCjCq90d/OlM2IXriSE49oiRMDm1sEV/ira3h+E6/eRMyZLb5n0wNWBRhpZStiBa5cD8qeqai/jwD3Igzcg/YiynR6e7Y7h63JGuXL7K27JLsLVwUBSqoiQ+UZgZEk2ahTVLDBBMaH6XGCG1VjbBr1LrVM/SJ70hV26IuqsCaEx/6ckQHtIV1gTIfcAfWYofqHi/AHvc9wB8dN4wvAEJR5o7a4mex1UitOgNCuFVTDqG0g+mQp679uoRMVEv1OPEuq7dK5BO4uqgwojUdmpiw7SRsJgukDs1HpEgTnxB+/drFMm1TQjksk0h9A8gZ3Om3LeGaTDIWF+c8fwvbsUhJUwzkQHL4kfsnbP/AzGWyC5LgXx6ffLZRQadFkjWGPGbI76p5IU8MPcWFmT+hV+TXZVtCCWTKzLMwMqCvcoZTAVtfmcJDoIe+VKlrpastSVBrcxiGeoD2yjXZUgPQex5qDUj6i0AGvt7VKfFRVbWza7dYxQV2pMx2QCC2XjDwR3EBv05UoFVuNdConzG9PLtLaMzD2akNhXARcKaDYkl+EkXQQ0Xu/oWSw0rUzyra1vayQ1euHwsKR0HYY3hW/FMV+cFcP4MuQsY1DcVRrXArNvcCU92QsR20u7u2GyM61jMc+i2RM+uA4kqIuLpcoQVs4vDDNOZXCk9Ef5rAg7BwUsJqDH0IhVqIN+a6hGGoqRTb1LUqOss3uF5TqXyX0CewlXsczvE5iH1crFtP3WX2sQq2x8EAVd22llVG1yUyOJkUvE+CAmZXNzU5ibm5Tb9eHMJ0waysWihIxhEimTAa11qJK7+zcHRl+yQAKlxRzmKVdBUqBWFSZQBifUWVClmwN2o20rniYEzobBT7VYJHpKh8/cPf3Hv/zrP/7l3/7xL//zP/7lv55p/ka2kUqFxVKhpadag/qwRC3rnHLYnWlwBRgxeudbhKYXTn+P94R+hNxG++Q0xXMnojhwl8JQI5VkUhSaF+U9lJHzLXErA5GE8ESPDnyI8MQ0xchWm5o8lKH+9b0Pqf2rmRrlf0eUf6Mo/8ajSLBCE9YyhZ4guOiVXjVSVqK4AnuPIksii+KuFhpYuksYLOrTiToZZ7xoSpvK2D9EZg+25wHDmihzbM5KQxdVacQLpfk2fjC+/uHCOMRlv8kPabCOVJlQjcNZBKVA2NtMxzmuF4bw1xCsA6IjYNU1UpqQFB4F/YfiXd79ROJd2I5XQWSe4uCBvCKvRo1iEuCHgqhvhGp5Uky9KPBLp8H3hTMl/tgIrfnwC5msPLHyoNKqZKxDrdVBetVlA6lOSdl12XuEcPB42Yg1zXjzQMrgHExhV1QEdPPrMpogbgCZs4xtZmZYNcfBe/96BFKEs2MnJlLomM5u5/aXvNNBPpgsmvudYZbMDtCFJBgvrZNx5Xf4gCR3Mp700rxKByDBR/ih5D7hZ38e3yH7nf4E01n+kt+/LL5/TkC/okxYFK8awaR06Xf2PjYxzsojkroewYd4fLcF3RArkApdSLOwDmffIUcydtY+0hAJC/CeTXaoZziqORChYlWRWPSDVX1i7AJ3dAAJBgEiOdrktuKDfyAJ/uFKaZdbuyOyBn4XMoAj08raPoJV89F9YpzmnoB+6zx4MOGBqfkwOb8j6ntt+6H/nb0yzXH99T5cEBrQXsmL0k/GqtHu30IcQOEjmkhE1MfLWiBYB0/wBpoC8a2dAmNnc0F2pg7tiPgLim20PkfCxg0tmcl3t7uiRdsbUo4hbZfvd6p5BTXmTVPWqaK88iDBdHiggqF1PlTanmg/UZdyPO/tPOTV2dqInSed6upCZGq3goxojrartErPs4Qnt3k7hskM9lpiZIno/Go3DntxrzuZdflhmwwj2AAMdna6B+iNKKwKZiMH/Fg4KfJHwBKSdaV2+bcF4r0ItXIBmJyZxjbVfHxeZF3Twoqfa+WBxoqrd0YgFIW478lC/rJjmDO51tGRvnJGnLGVNLiXTEUEhK+BnYF9wKcSt8/lUpU8X/pgLdx5yPAi+hMEvt7ZqUirW6Kuc6udAe48hMnOAKcJNgmgdvDwh4350wjv6LPtbFuw9mjotwkKfKf9M5aS9Q89RmT5Q4+0plfMQXp7GjJofKGG29VFt4Vx4bMO/Os/gn/KV7R5Jt8FNTxTBhmCYIJOQ7sEGA0jZ7IjaL9df2gG9MTpKE3gDToOlQKhNI51CgM7qE4jbWeriFYMSZQlBZqgaJOzNosIIVRAu3DTiBINI0p+kYGGX7yUbJjhiyqJ6qa3goqYhPVJgVYdErIEDXEuEuJM2gCxh06PU6S3vzjH/Q7ueAh3cS3fK7GZiiz54UbViUou4SnOUxBQNjSAQreMxpMuJxinR+jxkE6xYurUklmhM+MFb89NnkFk6tvJcMKsgFEG3dP4fvGdyzMTN2MKCWhZkMMuYhzaleXiMNKWR2lEqYMAzZqAyM4WbGNtcNCVHaJW1w4JHgiVrgUNiSDYBvtDcnaQ0/VFHgj87+QMsvcxXFBoGj+Y6T76G0z+MhyyspZycXtRig5B5UJslaBblCD0wWyqzjfCrlyBcINGTc6MGU4supoHK1/Dg6VTWalSdqsuNgxsGyyYICLb+I2QzVd3IVLG5t+lmYrFV8AvLNngMCqyQYeGhTi5c7CrQaenT0TiCGXxntExkGKrd01BzZzaxIRQNievwp68BHNx+0RFFxUwoepJpQShpplFt7+390/dZj7ClSsBlMLGntqnpYLF1kseQ9TiGELd9hfBI7ExSoP9TxSHeRR88kmvMK76s6D/mXWPXsEuy7pJj4P+IxVF6OHvqc0X76WjwEm9qVe5u48+MTvswNoETsQmkM6V/TF2WdlN5sbO7gKxwORBKOzkcvfgAndyF7i4TVABDVcsoV2AfI8DoqIh4UPEmwXCAhHkj1U58WLpYbUq+dtCRuq2imBdKywHServNZo1bbZotLJqvt/r7EEvTZeCmrxt88DFx1XRURS7KXifZ0V8ScKblO/xcMFySPHMGLaDsZAaZ3zxQ0ly75/ukvtWMqedV9uObVJSFBIStdBG299rJBcmJBEl4Xd3uK5PalCuEXpyL/YUmsNlMJZcBuKQkq++iSIkUGeXLuPLyabkLT9m5OMfWkvLkbBCPmGT9Kqo/ZslTPYwKx1pdhs1qx+GRz6s+WkSJ9cpzHpIL3gkzmPDtIQ4kNyhe3AdXDonO3ExmTsIwPv7FHo6dA9HHMHxnDkbujNlKRKWKkb3Y5FeT0uYN8aR+GHY393zDyU2jKvpfPcfPmJlcAVzdRukGvT1KL+KKljKS87TGsDMJ0hYg76CpijRmJnA1aCjdfcHEF6ibiAsTRnkXv8gIWjgxC1IWOagmjDJ7ZaIMYdOr6FN8dCV9VnfPZipbpyOowvdumqG1LDbXRBcZdsbMqMcTDSfNAeUl3mxdIQuB2PzKjnURO1NGr9ZhicTsF4MYV6HRexL2Ff+8PoID87kdV1XLSe4Qm7qnnDMct0bBihl1qun9YNQHr47A7zgwt6Q8AUCtTEj3LWKwzrEDZFt6SFa8yl1B3jQdaYXI3tZmbccYByu7outtQbq1xHj5NpJvD6OzLW1bYR0vUbw1srnayFNXLANHiF5Sa1SSVxUnEpgTnZqEHrwWoCq26idLyKUo2XdHP/p2jj+cG1c3/H9Splzj11bYO/9+1TDCfKnk/205ODptH2FYY3+3jbjjrwYRRY+cyY7eGfJV18HCs3vTwkEeCetOEPaSKi8jlhLlxxIBGjrFmoV6aAZEgUHp+DPxDrdkuuIb/JblkO++W9ZUVc8zN3+ZGW3f24tiryhYcHgPaXrCmpu5BbWUmu5tTVr4se2zzLeI7vp7O26VUyJKtg9x8lBrMcldlBxFMHFNAlStyLLTvPLvLjOpShLC5TQpzDuE0aZgjm9xYulCxD5z3G3wvd6eNli7voMjK334Bo5mCDD2wqGmzCG2z73vQEdlPENToIakGrzc0kQ2bWP+5Oa9iffG0Wa6DhzHWfzzjhjff3QJxt+sWiJm1r7YjlZqpXsKSn5lE0GwJyLDoWJgcgJwe3NGOfuhcIgrGDB8AkWOCgE7Wo/kHsawHeekzLE6bszVYQH+6IMvQLhDDXzEgZlRghckTlEVQ4LLfYnZ881ypvr8so1tVB4tbCwFrSwakQn3DmWp8VZ6NBWMWI1AjchpBxL8algvV7k+ik4BPit8NNfrvlE3TJz1Zq4B8PGaQIRIMYCKSZek6ayQPSd9zmyQoDQpUJ1DBFkCImSxWfBZUb8DjiscJjVTIFKCZoHnoBBRAIJfYn4JhZP98UfLB8nfaHyze8sHx5WzVvKJxIwGIQgodXyXWXO7QwpvvtI8b3fhilbBilyXRCvyxpmu7lIhe/RfYE2+7J2JL0eB6GQeZgb/RlEnSMrOHrO7yzAbH0BLkQqdxdA5WEW4NqYoriKAAQqiMkB5ErOWa3wPGqJoXZH0CUrzsRB7nkWSMiZjT3j1v6Sdu3Bt6gsx2RSmUiqUknFS1R9U3eeQdvFZh3BVkMdJPB914HUlntd4w0hP1R9zhUOCRX9N37YOmcX4llOvBM68w3m/Oc8Y1kTaUjqkQl87L+AcTyZTSJU+xb047hc4pIrjwWOBQO5VF7npzNpNiqmSV3rcIci3HV6cWFgEh5lqwzecu0SFW+iFVUmOBuqv1ic"
-)};
-const _1pipeyl = function _plot_part_2(){return(
+)}
+
+function _plot_part_2(){return(
 "KvXWFh5+HWXy+15myDvaXi1N0cXA+8ZT9aisq7cpiGFdD/o1zLJh4Zeyupw8lJB1fdev3daKIwUhXiGddPUUxaQZhqU8eCL4hmGZR7G1RJjcpSPhDm9azmHsFOhwSaVRYBqFnUY1Hd+RSudpJqRomViyg+TLk5OirB3SKCORG2To6RhDoiYcoc9z94I/G/lxlbcoj5O/IFtYlcAdN5pVbeV+ti57fgftFVMNlwn9QUEpdp5lzs8EOnf3ICGRQqoLhs8y/3XmCoDM5wZOVxTU7ClO+oRlFLmc6SNaD8XFZxPVuStYOSIY9M8S2Kk7tHhEKNQ7fHUt5eoKs9yY1ha1I59KrVupRzRw3iGbY8mg6qJw5zQ9o10SuuQNWo8JuQ7xcKva2qrgecpGbAITOQpHKG8GYwcLb0ZzUF3vOrho9zhHIM2G3FTosTUNuViP2oWOaGrRnlPOZXDFpX/X9QWX8dxtJAcT7U6F3WPuNnPKG7jUqNAm5mvHbZ6t13rDPTotzw7qx3thElzDY+DM8G/i9kC2frIX5qZrjq70zl+Xy3MO05mrvpVtbcFmgs3YNVbmShMusUHYhM0NWKVNIcTyewA8ATHFz6JR3gQEMCgvP2aHdq6flKRaWSukUASu0qkfZ1L1bqUOGjVYWsrBVKrcrLm0UZL+LqoLLxZ9kFcRarTedvDXg86Ti/ecvy8NweZwfXlu/2SBnKKHCLVUGg9GZc5/l8sTHDeY5/JG5m7ghGVqCrpdn7apHXwcTYQEbjZUhjFS3oxp4MkDryrIlCivbCVxAvNyMYfGMkQCoz4NihCncL/XS0UKEd3ueCidw7Jfkw5y6oaRVxMsIJp4GjeD6ILzSYZdbRqc7nEN7Hg6xtk7dleGaOZiQXog+Jf8V0kpfMKvoMqhh0WefFcHLk4MRdrd703xKmobZsTdoYt1ndK6xus6t9CYT6ST2n4kdCRZiwVGP4vKMZs7ae21CRXfo60J/Rpoaiu5KTBfsWEsbLryFALItkJ11KimDX8UpMrZWS1kL6EzHGth3N1Hvl/xdZFrcsQTPXzd62m198yLcMJrjHk0PIRvK6BJEtp2wa8xjl5mdy2lt/KD+DoaBebamn7EukofURZZBpN1eg8xAAS10zPo0gJTebq6lY7cKcy2zrQH3f6CCIVZJaDvUQFp6mn3WLnLDh7rOX0H0oyhhSrXYqh4ZtZLYmAS/orKxsoIg/fg0sEmZHSXalKXN9J4TgTHXFirYZLLzxgy4EFplRsVOcezeHwozRI95ROXlNmkLQ4O9qGzEa3sHbrSGEaotfudm65c8rPmROToBIVmPv8y2rpq/XslHvK6jfCDmXzOUe9T7Iy+y2xGYTzNlIR5b7KPIEYlyuDZvmR2tAiBW1lN6aRKQMKDOM+JrcPuOe1BpNrkh1mDjWRKmUx6VzKzVWbhFdxZFSRdSz6csO9gm/JFJglT2YvsI7hTya4J6kUcC9CxBeQ6VZeShgXy0Lo5Hdn3pg0eVX7jNpYXsXMCW52UBVpEQOHx1rMwOIevTDComWWAf22gRp0LINbbcuZfsnLub7Jy1oeSH9Pvvn8Iv/vwfkS/+/6JIGl1ssUixov4i60tIj6FhSULYoFA6VSLxVT7RuhbBVzKlQPgBnmWtOm0xZHq77GXQWR6R7b3HyOJXdIR6H35xCjY8WJxuFgcLRYnoXXJ2goaS2+vYEu/tRVL9rCeg7Cwj/Ex9Gb+uesrYrHeuT/pnSO97FQxyzooQT+uKPS1f+X6Cmi2d+UPe1cqbSKQNdM+92dm2jeQ2dgbeTOV/pRiGOlf+ddm+i8hw7k38K7Nr9GEZL71/eJypJUyF2lqqYzqohJLxLCsLnyz9fXG2XrF4W5VJCwUIcy68OlWJTTVxczc6A5GiWdUSxmlceOde1BD9EM1M/Fm3nnzdsYqhJ0W5u/x8rz0rjyoO/qBOhtCraGDZnkroRIuzXf4vs0WjrcWtNsvSC+HA2kkJpBGDtKDMahL+SqGdSHfaWCnIGLQRF5bzOk5GrrYjNGlctJM6oVykxTSqYmASiVE0/wS0XNLwhdHQl4Ub8i6Gn3Qmhrf9wkeh88qlaELWYS9wldvadhLEeCEzzrx2nBZ2Mt4OJyVpka4KOxFbenhrDVcG06kx+sKZq0YJq7FYhiitScWOagYf9oPYnqCbIOpeNoPhqhLAM9IfJkLoxqsu3KOLqV0MaFfM716aHxtXj2R+PxMfF4lih+jqWsb1y/h+2aoM+SyFn++tcyw2Vv9+X4z47Y8baZtpNZHNmD6pEINDY0X05NKCfiW9WJIbdgaLjPCVRjuoDbUJWtD2kVdTDYiHhM2CFDZi02CAn/GQfpkwObB6MmEXQTjcABL7xX8prBizoJ5iHzk1/A7gkXzPFCzSZ85V96FuztlzjXMA7DBYZfB+bYzDudh7Ff+PMx82GxtSjd488kHiizdIj8Dt8qPEYRKuMGbTz5SQHt/jNoubPN21vstcy7Zobs83Ly9RJfLZYfr71yC3Lzn91GL56L3VoTCKMuvN2+vPHDZZMcUbxOdN2W8TR3vSmVBQX/cvL324OUYphmMd4zexzLesREPU6dQEOAa86MSHMJ0hfEO0flQxjs0yknhMQsK+vN7S1Z/m9kMHERMopq6NjGHV0Ma4fzaQIizQ6K4/AadXqTOKyQLt8A+MiW5ykNtHBWLBeJf47YZpLNvUBj7nimb8/6Sg4FTolcZJjrIKF0TAuSDCc8g4fn6hGcw4afORCbM+/c7WzYnIJf7kGMQRgAiHfy6PgED2aydW0ORZlS/T6My0amKzcFX6zcHxtZAwrOQTIfXNnxT8KO0i6qFhl0Svsv8XxssBWPU+DFYCji+cKnuywXUtzBlU7I4jP5ksXih3taK41rETi0RO7JF7MwUsSshYsdSxJ6SiC2+c6jXYQtndWBjWxkr8NgQree4SF6IRfBKzPIzMctfi1leyuKXQdUbw0QUe5E3gMkn7Y1gupl6mTcxxN5hSIIvqcD5V4vFbLG4XizOuStJpz49kqCGojCIt7Db31srJdtSrBZSmjK0cFDoMEMhGHPZr09yj3jZN15QPe9YvYDPoetrA8qVRDbNRDbvTEQAudxdjvVJHLsmdNdHpHLYKIjRCJSG3A1cMphu2SGvXd9M3qweo1RCrN30LpvS6aGnAqGEqXThULy8aBMmfzLPP3BO+godxCz0tT2J1EgWzOegq6h0PG+SFbV3HsWXF6Rx666ZlZbsh8zgyLxIinFSY4m6XHGuW5Ux/FU5oQvZE3QVm82PHzyPSHZqsu6Xs27NpyzzunqH7OC2tgQlwjeKGUHGQE7r75fq/l/QSKDgiitDykgCI/FLMuGwCXwB2VkrtD01O2lwl6mJEwOi5jTsTlNP+bOOepTnFq7BrG2AyTTUnU0wmbFJijwP+gb93UWwv2fh210xrlIIM4wB5XYdKAxaky3vnF4lrNtl8JmoqE2JWEOlPA76+wxnleecG/4w6A7KYuJVo2hQXDt7nQeTWecT+J90ikjViO3t7Ltu1z4vUsdFdKxT8GOdDZDWSRvtw3RBPHgk42U83loSIX0+1XoiJM6UzAOoqC0pHi4zT5jS9ekV5jFTtj69aCmqWgTdXDmH+rqxbMaJQe4jvBo9FMPErNtw7bYT/ly5K1hxsGu5ZhohUnmLDhL0LkW2unMEvWPhpvpHADPBoYEux/tt0JtrJ+q7Qe9CZyG7ZPBN6pyLyGrkBBsbU6agEflYw1yGrnalwsBedWS6kcIxgcBoR4msmBA6rXLmQw1dx/alZJrDXOnSLwWWKCUCrfG0Pgu+pkOGA84fpSjKgyqiECITSVcexJYzH63BijrDDIGXVi61Z+Et7zazJenSzZbrWJvwQlsQJCHMVcWGM5BuhnM6jGS3ZLV68uNXQusbRBypDo7G8KkSfQbGVDcxp6GxMQlJRqdbcza5sOaQK3MCmcnwWlS7NqWxczrOhPF7iYNzE0feMaPzyJl/FFyGIbz5J8FmGB6imHYTxGGMwCMz1zun08NpOMX3uetdw/vpM/baJJpiT4MBajw9c9l3wQSfXrvsTTARfKBfBG8cpKnEi48X7NWBMLFG063QeRF8kxnoO6I1StUr+DqE6AbsVfBt5vrNGDooD4MQfrzB3gb3Yr7KI1NUM3iwjra2sKVPtrYqxYNVBE+Ke/FgtSoa46bcIr4ykJ2ekuoFs9y+Izf3vdsqVTptZ6hKnZbwnmfKAoSXvKGVm0Sou6N0UJRWAto2Cl1fyu+ghYy+VWOXrQmo1cX7rWGUJSk3GFC3Oq944SNoLtiq0qVlq65S1rz+jIx5w8lc9ze07xOLkpo5UHjjUGHWfTZIXs3rVQnGJe0Bgy4txTlqU+C9c457WGiLwQAPBTEzRJDlIJquYSn5G1kJUhoJk3c9ArJdY7SjhBaGkAfL6Ufzh/L7G47mCis+v25nGRHuznkwwTmbsIy9YV9QdVVPgj0XdWcltWllUptOkX41F+SlDD+NV4kDu8MN+MINuo4A9063l4umwUl6iDBmmfcGDX4opxqywRtxM7Fc5VnbeSrb8UB34dqCEgBZQNl0DeZkKzZeJuP3Qve7+4+//0/QU0BEjdcksF5vHEqcG/FIQ2nUhBrAE2WWtiXP8+/843/5711bf700X3WfL5R9/bRKSo+PLNXZWWTlQXOjyCMyIf4lbOkt31nXcmedwOS+Q5o0YVgcvBUD9+kozQYwMp2VUZ5L4rdS7NELmVLKlxG8/vzii2LmuAeFiT0HE31qvqd8Ss8CgpJTWwcFXFcGTyGz3g2rgu/w4SWLg7JX9K56+9sXj2s2DUqv8K48eHsCMjds1FPhl7BRUHmp9DvIghivXYZbW3h31dxGjBosEz6Fi5uwR07Mr9Gc4WIxchFjqBkRIX+b0Zbv/ZUcl1KFhQscaVnx6kaYSJLIIuFAg68x1Q0sZAT7qAWGeAkVkCMfMv5K9cpaaFDa/NV4Nuqlu/u4aHgR/I7QlvEKdWpH6LO8ETBL8G2eBep0DPuJDCGFGP7BaF6yJuJKHJ5fwrNzIKILj0bcKyyM6WeWwoaPEkl6uhyJpz9AF2NNLPHlCc8fCbZFJViJGF4yPd7o66vEM+vEa1aK7DKt9eKtVowXNcrUrBhRnDvqxjMrx2vUTutnrK2btNFWum6WSydjV+yCRCMX5rLGkop4gtCncW6s3LrRq2Gy9tBKuuEMk1/P7u3y/GT3b9AfnND3FpuuwisLdz7/xMt9b2f/cy/ZzrFAZq5CS4mNUb/4eTpLBs4jt9dNEDm/mXO7edfmbdvYu3OUnXrl7j4rdvfP2gfTac6SXn62MmB4PKhe09NuZAjimbEbntg0GEDn3dJxIXsv8fKztr7Ji0Dp2AHaimGkYqffS8T3Wx0EpVJUpXurjKqr9DzNaL0jxQSp+amBRZ22sF0OJIWILztp9bQAST6uk0H4qizGaZXslElVZGhhtlOPYDV77vpdWHuSIYhvA+PuLfl9Cl3oME/HaHmaP8et+dZWqzOkgcVeOd37OeOHKni70WLVoda3ssmISrYbz2rSJeJ3FT9mBpNp0mQi/SYzYHFhlbxdCvMqY/8KK+/3mYNSL5mR6Ld5197nFpaoCnsqQ7UYFSalsv8GQVBs9PHXJQVvQkdNFBxxQpZbwcaeKRDnwWuuE0a4gxQgxzqzs+SWFhyMY7HgpVgsfshINAZBGILWaT5NsCwCdhjzFdmiDC2POXXQZv74GYZBh8B92NrS2DP5jjD+OyFECJUSL/VyyWsN5SQUZ2FzC9VB1UCVhp8HbvD90ISw0+Wec9Nzjp4rZxmmGqVuF6GpvQooaqz0qDbClbvDMKcXiSQYhqdnB3ZqAWKOpuuhRpUJtYYcBfGdG94pjUrMpZluYioGfYMbh0QjGvo3xVLjLmrcUqWszJE0eSdoMnQTj0K+7L+H7ktP++8J7xD+K3kMGKH4gBsNp5BO9JCspJYGDcxd0t+sT2HSEiFT2vPBZiMFmSwfvIBpYoaQvDUC8tZkj+T2+myPnZYMmeAL+OuyFnBfUz3jW4E1ys8l8qWNVcarkZ9ROALgFxVtjDvabQL0TeRZku49keg9ejBGajBG7u08TbKBhBSpYPCXqL7M94xmE0ZnTgJ/MMsD2efJgmPWp5RgiMz26bDFGod46SK8501vufsuIV0KCwnIpPo8rFm6nJeO27tR+bB1jOqZ7bNyZ9aHHSkWUtn6z1Wq8ztSna9LdY6pzs1UteawbgnUM6epgkNtErorn0Iq/cEfU9d4b8p37HrqqUI0CUXCco4kLDbyCmdhJcjSVP1PKimM6MslAW0mjGzQGk11r/LMS9QjqpG/98nfdvzH3//NjkQhdaZ5JYewHKwld5FjNsdVx3TbRzeNYYa6RKVPSK2UV2GmXqpPCnJDqR01hFO0oQ15m8C8p0avQNNNQw6eA3tZ9WSqyheVdXHOSQhygYBTijuAglXTc/6YsjiiiwA/Yk3eiC+TKi5T7lvB3hf2b98XTr2j0G/QUkAb0+2Mo/KygqnZR7Rz/uYeTLkyNiz2pi2X7ImW6U8ujCe4xnuOl3DYK8Flg3OE45etwlrUhPJ+K05//XrJ4f7le7lyr8YNP4Pdv80M1OJwmPq7f5ubLqPUn6asDkpnXCE8o4vKVlRtnNvDBNuGD25ejmAfGKVqvyxJrNR8DQJVTuejqF+e8qUXvpp+mXgXSeXmGyxAVKUwDcu1J1k6U1fbiZpCfJuVp3UnKWBlhNwgR39pmzgUwQVB+UJpDfvIYr0SOpW3g+GNLwZJTmlq4yo0C65zmE2aWt0w24PofKC0sTHo3Aqq7uBgOcCgcUVHisry5dfSKQwLaoUMnzIyZ6igs3MbdPoiENyxdVEDjMM0No83p1pmnIDExobYYvANI7KbIbugWID5qhTAt3IG7HR4Rknj8wijxQK/F8ZIc+dHvVYrWZfEkXOLF5JYdXihEtHvnIPVI/CGXzEkh8GbFhrpUwpAj7fkPwxEiNEymEKC3HUgXSeBNEYe8NvN2MW7kLkIN5bh5ircWIdLsUg84EUw5AGvVMALAfoBASMsMw84kwGvVcCZDpih4roDQvLGEeoBgpB5XdHmGcYeYWdNhFa3DJPKMHMZZhzMRZiE5GvsTXj6fBFcNdzn5A59ULhr/BzKamOGkzSu2oYXJ/MQXnPL6wK8LqTX0I4GsjRkJP0o3obOSU8NGzoPPm0IJ562VD4ZKLqyQeOETgTn2WmFl7GKMG4c38n+SEaYYjK5qJxzds2+jBjyFFVklvgi0hpTHEh1ir4U9Ir9GqE8QEEv2NuoQeEOQSMRdM5+j2Bc8qBj9kXUYNwkE20edMLeRXh3RkEH7FVkqGpR8jn6nsPEB771qsXX5MNjdrozzatROqxxdZoI+GvLYFwto3gaPMSrh+CSrj7xqLcUq7TaDuCxZNNNCd9bWxFsTuKyqCrHMLshgxsysuGQCwhCmKIcDZuLNEwt4xweIvUT8o3CqOE7N3x511s6A8ZNj5UO8lgbJw7DvHDGbChDt0x7Gqwg4UsQiOCc0Ug7rW5KR2QhlMgBsCHgHXnwijYe4q4GkpjJ6xp4nvMSof6/nFKT1TunWyMdWO6hpCNtBIyguUX5jM70Bd/LrZIUn+xtbSXiGgrXjbEKu/c42UFoIPTH38djKVyKRGBjhTScwUYibrS4cpVw7K8YFk/pFCGZxdl0kHA8S15bSvYZCXs1XUukYm3V0lel7eA2Thcgo8tk5zKZ46fDfIgIVjAL4vzD08PZhj8NRMc/PZODfn7Heodm1PJ8YmWRH0xxIxnVCUIzXx508AaFHjvjKU4mSWeap79P1U2l1WC5JmoB2UN2lTCEhYvbPRfS7jnVIdHYyWCcIm6hmtZ9lJ7YXHzbXQnIDnWBQ5jW4zlGrdF23V6JSX7GyaAMdh56LwsQ9Hce9uA3Fb8Rdzd6pFYsqC0d0PwuHdAl2aFqS2yWP+FK8DC9ZE84VwZiWDyJ6Nqw4nKtIHjODFxM09IhC2GPZnM6xw3vokHpPG34pxaF87DhG7m4SFdBr4L9QC+GLUBvyoZBb0ilE/wGwSMN4zkIopTURaSnLvmXAo6qNMsrHQurlNI1Ncom3aBxe4YRTeWVvamXUjlHQW/EBkFvoAQvVQpZPLMiP4Klk7YmNH2R5set0Ta1kWRiInKHNar4m3mUDe+40TZFw39qtU3a8B3iN8vLTpC2k6CXwB6zV0IX7mH/7aVsInYaRp9N7CI1SmBlqLYck6VzASs7DMINe7thKzwOEY4JVk68O8X1cbFIwyNkavGTA+jsNyioR3SP/LKkdVGdrlDQE1LKxMA5Bc5R6igpcAmPWIYrjaO6WSLuKq7W15jn+TKYscuAlGQhIQzqX7FN7qBxrYe4qkJw0qJZ0em2umajT1qdEfYU14IoWvQs2DMfITER3ntubZHJAYyWhB4TtTkxmiGcnu6dNXKsw8yLT/tnzayTsPKm6G6VoQ5jTCIS3MhG4vmOerZnqB3jzc5CevFXMxvpgy/L1c9eOjNe18cIiVujAcuxgv9kR0HCdQlwKeGYxqTFcqiCCCUxLpGdBEcHxzsN/bHgiB3rc4gghje9cwoiyJRduugIs4Ke3bUhCJ6ovwI/R6g1yqgGNZ8Qx3KOBQ2CT66OXMOQMGJJ/YQeKL038krN4WcPsB6V7i3X5qnhe8dcj9Hh+hVk7I0c5LimQ0lNhrNAiHQkDOndayJ3r7/yUbHEL4Tl8xhW3hPkRg60UVMSzKU5fK4lDY0olhiMuBzpQWqJIQR2qF6RSg3aLq0miHVNQIuUywmXuDY4eaN4gyF+osIS+SRBvui2l1cQP6bJ9Q4P0E3zyRQk/9vz6fl5llSojoq2K8pwd0X8owslWDrnrrq7MWWDUh/ZrYiq4aZ/yQo7uDyEkeIpPKi6mIGYcWzLzwWFJnEWH8S7Ae8olE0qQ+JVblYwmUtzk5FyEHkjxMEQedKZzUhnFDNa2f2IoEIqjlyZh+D2I+UsdRLjvAwuJRKBi1sEmKJewu85HgY704of6t4IudldihMiZSa/WMhN1QaymSGO0UussxuSpI3rFSFtjjBFEL5I3+9GkSMyKZQ13NW2wl5nzHNDfskmmx0vPRg/Tj0wriXptHRrq6DbKnqBKuasPuoydumAcEifiwsJtxxQaHGbOJkf2K1wgXtB22mGG9OGE98VVnjIjHPaM/ZaS/24338WwHRzrW+4YOI5129LZm1Lb9WlqZrPtraCH0qht4VPZHorKCjBMw8JgYNqdGeGR/zieQ5Lq+2H2xrt63LcJEqCEEQJboto92auJ1Ar4BFmR+E8d71cOFPiYvu0EivHvOQ814ybYNZLmPyeuey1LZ2bS5q5JJVL46IxxNkbNsKEseF6pY8abHsg/0B5cJuMPqje6OXcR1E9GEfUtDThvo1UxqMLXGgEb/qKbgcucq2Km0jlQZ3Yb/Fcp4OBqaF6SkoKmAjA6lyzcyS9NCZBPDegSVDca1SB5PdIzPnrWG7B+CL9VC7S3y2DqwOlxXrUwJ2P7407+2eQ6IkYS9rlKTMA2y7padMq6bt1MPVP0XD0u6UCyscbDM5dZSAok+NA32t013BirYO1j5cCT37FYMnnEPMHfzXcvQVsHy85pj1rOqLm5X2R7suWswqxPCiZQBCzVhaOnJQoLHXGsXkipM44OKYarg8YuCDLqAIkU5Zoalx+pcf2TATe5lkSQisJg4OEVuNNsR6LpUeHPxJtR4qFeDdCN56EqnVgXiojZ7O4l6/NW5VwB6cbWErDcCPixzpGabgip/oe8xCHL1PonKFGSRjtpP4eh9wSH5rpD83kh6qUk8UClU+wchYLSOJFjfrYLMPbkWhnhg9zeJjjQwoPqdaulDWTUc1cGjWzEYBU4aQgnlpDXOveu5Zub+VKi82o2TdOrXHUMn64k9BSYsacduZWWDd6viMDuZQPxJqRGq3piXhOHC7bcl0u03CNzu5rBT/0JmjepUhZwLxgPIUdMM6ZsVLBjQJEysJai/CIEKGvhYKFge4J0zCiGk8zFAzwCUQxBHShszZXy1GlAvXTKiEgHxyjNHE7TC+mZeJ/Ic49C3nomcqHaLF4o04p8U7uC5Srg8MmWwJPqOuCpK33P+9xFvC413vwoekLT0O44VNXiLtc9YxM4U5kB0gr5xCBh0f7XUErvoE0rbZ/Cv4P0F85g0T0hh3JCJERoeU0gCBSV79D3Dx3NW+nTAMFmSXkGyFUBMdFhTY5MnYaR/yXDaBn1ElHvFIJaRW0cG4NWC8c+Jdc2qFqQ9rQVRheiSireOVNdlFsd9ziCpkOs+Rdp+0YUaN3SeSumOt9lXdk2wBhLzFzpNTlHVNimmUCMwy6Zym6Z45Phdk9l7ILign1hbkblhcBWSm/LSuDPRaVgbSrX+objBf88Hx1OmlC2D81zIz3LROFrtdHZdTW5R+SWiNZyM6rDBv+t//+//7f/6XrttsEQJu+IHhdbByhNAGJez+cdN1l55pTrm8SdPeLsIt2693lTudVliDsbjxK4ktiWMeqKWAMvYfmNfh0lVYIKvTZVIxNBttypc8b6iFGRzf0xmgl0ezPhCTY34UqNMjk+YCDiZEuf2D3aLDqGtHbAGrFehHWPva5iqAyuEk0/FtnEi0UsFbgWmqj+74BJ3E1INFq+cWA1AbgGSvxGkY8t9IVMjP3DmppW+jeGuo/cbVmvwcbU9rpJXpk6ljTyjyNlJT2anXyy2Bjz9Z8WCw2bKUHztJTMCgoglXDvlyBbkRGSlkAC61oGDyF/S76zkd7o9r/tUbLLBiDtBWlA1lhSUz6InwiQy4SMZdlpF8iE8ZLJYNAjdp2RbF0M6dFCXEINUmDVi6qzThauivo5kHfma1TkU1JRVbsg/EOJtUCBkz5iLVGt1z6/Ewo5+E8N0EyLC0oaXT3nZnc2bLSdJ5LZ8wExCKF45ojjuu8QIMavMcS1/K48S7lK1kRLZdcy5Oc8J55udovBit6XfXKZWUZqqXcr+WtWW5W8cScB8QFab16QSrFYatXGXfJta5ObbSmq0yp3IRhGYaFLXcnq8vHqu4NtibSzCnNLrGSyDvdJo6ppoSxlG9ITydZVb4hPR0tUyg9HRW0sPV0GOnpIH7/qkbOryjho0qT/ZFW1a3V48nwQAt7IiFgbRiNwSuQzK7WKwMtDzLjgtiJ6NzqSX+xIIIHcS+ckkp0SrrPp3hCdwYi+2n/TAQG4fZp7WgtKSSXf4qy/NZWBW3zli88Pi0udpPwm1MOfl516gLmroS3YTKgVmQdEIZh7cn/8ff/Vkufnc6bEb9/5S0NMgWlXYE82OEf0xFORn+IUKyQ8bg7xwGA5DuC6J1yq63EMZqZSpngHhc2MHG903kxJGVfHrwaFdNsgFfAopysUyX1mjzhW2GdSQ46BfiXyFzGiICzTKqKpynW6875HJOp8XFtUsMIBj8s2AbPS9XEU3qdOBJIiVT45lzdlDmOQkkjjNXIOlenExyDpERNsCI8zXeNwZQFu3/7pdo+h0+DH6VWCPNM1DjQQrt2xNsjpAKLSZOTI/JHVJWF/pPSm7R5j0z+Qk6o+LrAEqP9vYHuERu6ndMV3c4h46q9IywDMTPS30Npkc/fYI659icyCL1yn5ecdmGsalna8teMf9p/6Dfd8S2N4i+dLEScQX0LyZumWgbRQQ6TyhcIBQK/r2CvtlEtFlXiVC5OMbRY/JQ55p4jtoCrRE1oxhHtY5xB+Emv69HRg0K/4eSoEqk/XyJdAemh8gUK3xClU71zthiReCEqgfq42YMvDJVqmNo2qsThhiYiFfOwWRQkATEn4aRKElaGNyvSVlerHrJxS6OZipVmSnWnkfnIZD8qlSVdtpmfSGVSpmuasoNYSYjhUJpwbewJuguuVyxd6WulBEEwP60IGXXIeR0NCpzK3vrSLtND7cfOewNxvRgn8tBRfhpydSsekdz6nOsWKbiN7TdfuVbiK3CJigHSS9g9oYIyyiu2+CaFYJCPxUNfF4MusZWAUms1N8Fi1aDSOoUtpImly9G9c+RkhMUTqbTwKTGIBtUOiagKiJQgOC1ZjhSE8NKzkxPHP5eVSbB+HlVp1WUIXl9eJV/gGzJak7MXZ0WVDGzfp+SmwxQTPMoyQ7wEF/Kf5nhGrfzolXuMJ97M8BhPflLuc8v9HXFtR4LoWPo8FQ6mZ7OwMowurwppFVmGk6WOo3oMM4BXovKkCkNur4txI8RqpjKgma0O3shZBpZ5Z0QsqQJwnknt0cyN++ucEAymLvLEqNtj4fST5T9f8ad6ziPoTUY1f8ff0auqk4lyP4EX6ehFQwIHMbwO0UX5nycw6BIrwBfkZLF+b6IlhvVZYr9wN8GS3JZc0gFpO9ES2eqU68+PKE9JFWPdXosSnCd1xE2K1IEEOuEJBbGMJnmF5bNDCFcZKMomo2Yi5GbQmhhnG8dYHYeVxthsO1PY2uIyaEBc7isfHh5W/iafCA1mEPPQxKpvCwr0iAxj5miVNM3rrqRw41xt3/FEm4YRiZyNnlbOGzQBSdj3fL/D/4BEw54ROqjBVUH5zP5wPpTwm4qYRzAznlPNXjfyuaF8OILeR2Rliigc5oJfJSvBBKb1N+LGPw/ecLsXdioOC5iwl+L2vLabq++ll1q9iT4JKkpXGlXZ6yam6svKODTVhzLhjjxzkZ1M7gXLZDCNYV0LpjkCTBVUF2jvQ8KOvY3NiXOROK6CUm5Y81NamPvvuZd8WQmwbwbY5wFqp7DIYJ5JqyvJG1U5RxWdSqSpNCIweCJWQ59UdKTBQ8+t0E/1bkOotwZxzsTHpsEgZ3hFj3DOgmYuQ3WFCo2zWcxRuYMvSPcswd+kQYqmMW+/TiijVxWxS8Vo3/YbGvt9T3RmHEVOCqKvKqeL2XZZhCHTQDImCP+3lQZZSjGEuiX5iWDlkOYQAS/RdJLD53Asf3XswIPh8S+iX6ItJFkZm6D+p1M2VDx4K5x4z0nNinPiiecrNjsT9y95CNIElOJMcj6Ep2RLeeafwjR/zc4p0hX16UuGTAU3/jHHqzyUovkRIv6dIFjYDcKGvUTEsGeS0/s1i6ewFEZ1CjPxU6Z4myv/O32M+AZb6otlELPTF+wVZYnkwm/PggFB2p3+Rk9H8PSc/U7+b+H5S/aOnn8zFbq6NzgXx1tbtzf+i8XieIlp8/t74U6lf75YHHIvgSklPMU3fblYHJH3s8T5AnbF2OtiTQwzDYgpLGdQM3G4czo740RhOTvm3GA5e4vcYPjwG3J+QRerGJRoxOtuIutuvkREbKjrTfxzGEy3ts6dU0jtKBhtbb2ix5NgsrX1Oz3eBPOtrXf0+BIVzob0+AwfB/T4GtUqx/T4FB8v6PG7tdeCILU7ZMGZ0IOSOre2CqUBuG2KurBAIn+PrYFxClvFM7xRLJXVtavzKChKQlB9VizYDVKswohFJranaPMuRnmOvSvlHJcIb09Yocuz5dIvP6aEeOXZLCHPK2nkxXFJIQe/NfmiNflSJL/6KVbyxOoy58kvRVvQVuDNKtEPgqeYmv7uAWy7I9sJ9YXTRqg1LGBNI9OE54HM3iC6wiyF2280HuPZNF15TithdSWU0JiQ4s84eV4bR+lQO7HwyNjU9Mhg2gKP75yYTs+vEXJp5waXlY10sUh3+MoGsYYuQtHSlvxNr+eyTf5ciBDcgB+VC4bI2bW1dSh5jxiMoSP+co1GqGHpj04dfcYZov0ebMBgiEzw5laFnEDIyZqQMAJvdMg5hJyvCfkSvuglDzrcmfVhoKoX5Ld6Dd6vpcscvJ+ql313pR2xOxg1wlvJcFhe8tiJEjqj3LlkZLzGu9+mVGG5JB49mNw25CJE+o0hIj9OsfePOOfvlI3cpU8zv5rhl2bEOUWchEg7PMF+PedkvPCMEXG5UAsCjwiNfAuzpX9Nk2sLpkIlbLlu82ic+DUrpvVkWnMdNknKZFyKgXR3aywwtVx2EnOlyfVKI1QYEWFB7MwL9vEJ4PBVRXiDcomZRiLTyM00Sp2Gmb/Gi0FZCNL+sSZtN3GiQBdk/BGtYQwjc50hhdGvQWKF00WgcPoVB5oRTpaOQsmXoLDCkHxr3NmldFGnU3xRWTkwnRAENMhWqnbSXS7QKrhDXaOlrFFUWaYL2tqsWmFTgerYEujwV052CHl8i3cPi4V1Jimq/gcOVt1+mDXMCoTtqfmD46ZQNqRkBd8vozoB0RA+f7H4GRnUtra+xR+YpjK8x8zYqLb5QnGOh96bnwUtmRVhAUWEdacMWvaCMBX+QIguqZ86uGuAz5IHd4HNKUKYL2/S+PKFqHXB3+eyH1A/gkyqAlWDhBZQis+jXU65w5mDHelK0IYluNPJHuq9yhA5J/YrhXZZEGMt/8VfiZvrlQ/FlcL8Cq5iVxAQOX54XHIdg1qBgKbVc1wgE+RTwchP9qRanoFRWO82UQvzXSSS3y4e49Gg5yUs3S6e5IsFEkty9srUS3r9gzJYYXNdISyMDno9ZLxHeJ4EnrYLBcNTPIbiFIHHMTrtMm2vlGkby7RrlGn3LyvTrihTGSD4j36UrryCK1mx5Prv0q0OsFuh7nwlzoCIDVEwTkZKb5CvdqcRKlNGtN7yMumv7ONXSsZK/Fgdp/b6GKs+OzOoEUGuC5zy8V74K8zWsJC/q/wvK9eJ+Roaq710JJTmfydmp8igaBK1E/xeNfi13eZkn4PY8HUtj5BaKLXlgX0rQ/awTJLBOMq9QRpBHaWVImpO9PT7XAT6UoQRh/txUddtwU/QQ14ATMuLpDXRE+4leKrxiEoG+r2ScsdT477AmPVfKV0BOf0mYkP/1lTeedsM9qMM9psZ7LfK2rN/wwM9N4M8N28+7iBqn6lv+El8GOzIpdMP0mlfOf0onObK5WvpouP9LJ10vG+qJiX5LF8lcZeKQ+d4osjPdiTXtSbekcNQ0eNIwqX9vT3WbFS5Chj8Os34OU7gtA/UZFCCyxX1Yk/PVuXRwk1PExgzFWrB5cQe68KoCqXsrQz+DWnt3YrSyZfSRV0IGZZbpdxmifHMcnWvghTONKbV7VLCB3WJDyskvblbynJpqBhdrl//VLnUtc0+QRsfeJ5drN4fLdZXjQs0p1f3Oj3EBFWl6jTEkhB7Ej6gzk4uroV+qoJbY6vk8+t2ohkFkb5E0forOp10l+zr1rBzoiRthv1hbboYLF+yH9sD7KsAP6/NTQT4pj2ATuH7yqJTicokknfGHCO/3yRgoqXUpGX6rQDJ0nY+BnmhzNJxWvuKoenb9bqBH6JvZTd+xPhlBMg2/PoAr9M/ROq6hqT1LyJdhVKJEK/pXLBJhPG9pEq4CSJBpYCfEGxWIKHhRMuVMQ1NzXWcCPh1EX5LhiWvAjrEiRHlRinc3guCX4Lu5yalaI52UytQ+7+h6esprNysYvGZoF1yV/H376AUlWRNSnMXb7qwgyFNKdaEoyvF3RFYo/wqG4HU3Z3ZHr1FxOy8M+dvGX+b9emtEn78LRas3S2cQnVsrXdaMyzMY24KV6KVblEvXdJq/bZ5PZTEpiLo3M+DbwR46WvDCruj4l5lSMzGwUnl8BdgKjAPB8E3Ia2JdKRvZJNb2cyMbJ61ZjPLkKZNYKCKGamRDS6hdBcgkSvK2BrzWZpf3ofHbf3QLuI/PrT5sI7UsM7+o4c1Dt0yds0Re4zwIAhTlCpOZaHrINc9HXgjCA6rrS36gh071B8Y3ngwgvUzFQzGf2i03z3SW0g1Wge1GsTTgH9iatq7t+E9q4vAmJuqCyGpxN8ShaW45mD3T2qHK0l3cT3hyvZdFsNeB/UP6qTyT0+T0xSZ0tOzM3Za4nOBz2do+Z6SeT7iJvHpimxPtQRBvq9pA4iZTy39+YwyjMoa/YRhPU44jOYZ5VQpLmDG4xC/AsuXDea5UmIQpJKpLm2djtJY2t8qMQJnH+wEKbZ+hIM+M4GRuQpLFEtzN7ozwHeuOkh4yEUs8JAzM1mZpImNHMWG4rGxz7q1tWZv7Tt/WZKzVRRc5Zlwz9s29Vtz/4YQnXTYcdCaDB5VLmWSEEpMXVncEFdA+r//3NUuw5gzmi367DyUM1x1xwyX2zMc1bgkZ8OWPIdofhYgjk00OMwvYM6pgkf89YgkXxjsnwmkjakkT6ZO6Q+DKX+F/uaP4KW6TpKJPyDonNVJsmyfJIv2SbKVDsyeJFuZxWiSzFkmJ0n8wIAUDLNwf3/noa8wdLzPBRU17q3gOZPWzaoqEP5HufDaQDAgctL1EPSGhhPUBaLxcEtorA/jei7oc82U5sGXOkLIas7tS/b0NdeBuUOTRurzuoJem0dTrq6kjpjjJN+l0iA3aA8vplHZqNsje6V590xul3tqvyw2kWjUHlUxVCLaGKFxPN/nem0B0WZyJWRvboek4pqJIsadSLQ9qJFsThYQzmA9Uam8UIywL2UBdXNctU7eIulzLlU9+SCa8v4/NHr/yOz6A7O7T3Rnl0yk80Axx/vQdmqmmIZ9BDG6CEbb83R3n10Fg10YsC0rZLGWPVSukIlcIROsiz+/QjryKD0JUlw48oCWlDIgSvkiwNVEHc5RtxrNJwUsil7CCo8fasWPg0lvrLRV0GIYUxRU1lCsfN+BsAziSJu8kSaOvtqe4+FhvPsAmaj1SFEdd3sI1cZmZu7xLr1Aysg7F+M2GcoxWSzGeO47e9xPHmpTPz0YBnItUoOQYxHSgmUTu+VezbIAv7IyM+bng0G6zRP9HRbjYrvwqu1q9xN3Vwo9p07dy6FQXrYdMyfplfDci7bjsyWnBsBL5OKMzQRQ4URRBsSxgwVkszO8Ms/Z5Ix59bb+gAkep0o4w9UoKKmNYQdkxBjDuJ/2zJbIvYglXup6VutE0DopyhzQrAiNb1FgYTWkATZhZFZGjXizRBraC+rdaHvC8l6Q4gMUEq8pPHIeQ0ch57GU6q+DaW/AzoPr3gWCVXkXbBPyGPFix0WF9ITHkN9IfkiOLod2mEvUnLDCXJoU4cSSki83b6k3hO8Pkf2bKMA7SJ65eTt4sgfjcm/ZeQ+yXHeJNqcMMauRBAgT2OQM30fK40iwdx8tIUZ3iQTdTS7fNvkJG4jmJdFAKVpT30qLiRL6WQWfkTBreOGuG6RXJ9vOetC5vHQ77eXb0Kec/e0Y2d8joweChzfdnsqvP617EG8K8YbubsySnlNtT6Er4psUTqa2cHIelV0pPwzv2iGRBIGSaezeykVdSHmSRBrE5hfqce3EXM5gYi7nqMNFpM2ZIG2uBGlzLEibxW4Cvphmhl9nUqgcCYe5dBBzx69cUVo4ToQjh54Qrh818fL4ykTxY2dhCpYtFtVigWRTYRtBX9uJRMZgGWKj2BkymLXgd8QEleZKp/OtNImPun26hzV+2MAaGRiGy6Mm7shEJPN1wYgOOTXfIULU0v/VAICW4tuGpcSv4TBqSv7UTN6lvWPk6Dyw7vRKP++VS2hiSGlupERIOHZChFv3gXR4z0CQs6VdMhu4kpdJMqG1lDc1Ccoj0UEz1MGqQ0tZ34cp01PnXgZcY+alXgR1JLol4fO0fKKNTVdKIJti9dNTiyb9z5TJMKq1zqHaBM/WC/UkzHGXnLs9OpluvXJXIdq8eQI8NvwIe+2BnpaGccvBjQYynOlTG9QXaD2isXYfrWcxBimyefzC9/5Yn6tHMTDd6YlCHIBTP62VDCec6FATh4jsjELlLbcHS9nS+Qq7kz/HU9mw7BU4CyiZijTRkNrF7RXNfr+SlQ2ByTMRvT9tKUBk9v6srTSphyx+kZfpMlEP4wLHeeVgyTzSEsRQCGlCTTy5fxPLrSsp2JlNvGYn2XqWtmSzlv7wsU08X23iuW7iuRrcWO9zs975lLUylP9AAzemkfacmhCniuFxpQSRNZn8RU2sLVTjpoXqMZ65LRaKSX7uf4M99PslPyoaxPyM+m2Kx9SoQ28apn4wtRmkNtepTWJ+FP1biqfRPDUuE13YMlGcZJkSiq7u6JotBGGrhOzJPTqYQcN+rxmnZBdxsz82eqLohoalXtxeYuP8ShKXUXVdyXM6k7dMSPF2fQ2K+v7HW8aplTa0i40LJkMVDZXut7YMB6H1H75KHGna7nc9kGBhPwUjgLfY5X2PwcRxZonyKDe6jVg1H58XmV8hlhQ9Pk3LOEuYQfPGzw+4Qv4EN4Z7UiXfVD/Tmm+LxQkZVYuKlmgz7ZxghhLyUXK3UVTSSFGfRdZCnw92nZU0EYCSpoyXaBQ+8D/ZeegerHbWcu1pW8vkaocoZYiJDFF2peVG1gjKa1uEn9qeogWE50gmxs317WEA/QY667U84iuDsXig9ANxHMcTDAaCKk83ZDBNnFgaDSmkBMW3LgpysQzmWN0XCroUe3otO3mC3hdE0SQslFDs4qqTQXAhON0EPVRjSAg+KYgUhq2DxU/C5KPS4tEgNRqIy7UE9tDiEbRpRidhyF0/h2Yo/aFsmpFshgHd75TQqMJnLH1kPZ1esCuLAH4WzElVzBo/18FQmstMtid8C/vqhVxaKmfikk4ZGjJ81L0RFn5rC79lurWVLT/2FmkGtUkFhOpcvyeb4X4CYSw4bCSMDX3cd6HQJGFA0C5vis5X0hkHAboO0XXiLn0zKQMU84fUgsU0MsCTByPhpYvnFEge3+FNAqFHqMPnvvfHoeE4Rhc8rjAO/YZbW4Nw7cWTbI4BJLczKKNrJ2dY7m36I9oML5T84YcTmd+dwkcW45oikaKSOpy6K1u0T2D10oW5cvX6q+2wZvPO5fGjGD8v16+cxyu32skfWDr/Km2Xw/teiQt8+xuY/flVb6quwiN7n9V+E956Ef4BzZTjWGmmFI17brpLNO65W5RU/tqrbzlZqqvu6t/vqlsptfxZhRZ6PzLuePU0UH34dvyOm/EnQh37VN4PpAECS67YJHl9IrJzMCRLhT2P6/qFUNFVWxmtoKvu2I+nWZ2uu2iHncvSvlF3fY4oo7R2qnZlHUtXx1DVaZ0Sjj5SYj5sG/faVlqmFnzPTM0cY5JRibyunEY6pjG0SugbSuj7OxJ6dldCL8Uxj4EfqWiZOKsljGJEsDGYLXAveYmDHnM74UAhUI1PY7qmPFE7MHBIuEOODnmQ4qlOeCvSXfpPUXajACUGKDFGyR2IY1eKm0v0KLhHanik5JEqTFJOG/Me+cxXhGVhOHrfbyOLbnvm41EKHgXPHVgUvI7J/oRl/KlEW2N6KvCiiJ5Sbvg3pSNdBEMbYEYTffowZkL9d85ukrLwL7Atr4wZcyYDXPMA5xjgcikKJAJtitdjGfhwyUsq/I+k+8mSf+ONgBBTq9ocam8u7JqvJdb9WD4c8YeNAMUlMr/3uQWzio92fdci/lxGm63EH7fGhyn5RCLCHcmHQ/kwlw/X8gHKtfE9bLxc6TDjDmQCdBKILIzSCba6je9iZw5hJHKP8j8H/3Puf234N2ph1kIAiQxQ1SSJ0+G8M+sUZWfeNXCJ53dEpRZBiK8ZEZanZVLZkXUz3BF5riPPuuqeX33YDXzYTdCo2ZOQduy+qA3x0aLWQ7oR8lVFy3YX9S1qudHQUNSNZzEE4L+ZK3Lg8o1MTLVW2C2nWSL7wI1QOaAYo2AzZsNA2msfnJdJdCmI6CmtEQ70bLVvhOdGN4EgVJzwJvYvjLAZuUPxTmL/KPYj/L0x82NfxGTp5UyF7b2RP2kdQ/4b58ZnO23Ju2ES+zmlyyHl70iV1wR8VfhV6v+Urvl2apORaMh5SK0QvsH2g73P1hY1TjiL/XHs/575skq48xtsX6gzCpZRsHnsfymDHepuIVOyA6v0IZZyh4yeg6SG2GCw6GLPAC94Aq+NjDtiP4nIMZKZjnWdiK8TFCn+WgsJmq46m7c3aBuBc+lL9iywZtIoFBtLFNHU8+nwzK/C8BikTNzYxsqjTid0zPA6uMUwh8qj9E/k83JlCEN1ro7COMrzohYGHB0Ev4PBjOiBcwPlWbSF83pnHlyzlwGvyy9hUq5cXzYo+MKumftCFb6DmVr4gpwmuxvMkQ52/lAkItvi18TniZ5UPnc5qvybCirGyg0bz7FzcBkyn9xUnAHlqIIMnkFBlFoVrUV2oBMeaC4DZXw9WplsoaAbkBtGXCzw94hGwAhB9OPFAn8T8ft7xn9/gsW8OSdnzWROVDJzET0Xv1+KZL7CZKiHhMS1Sv1EPOp1VzjI1Ve80hK7sbG6CtvBr+3g7WuyHeVQvGLCctE73toS8tDxsrFg25FP+KtcvOnnxXiS+a/i09EZvb6k3VPlP9NgvTLEyzPtJoO95oU9BpHXHxoi77NYYOV0YAtkSPSFYKs22JBjg0DeUI28zYPiQPotVzVxmhpfrmC9NpU40SR3wwBn6x9AooifJsHmYQBrgBlTGb2Tk1WwODTTo5D4iZRFX6IA1HMDesY8hG4/ydXlWaOPZ4IVKGS5DwTe2jqs9fEwD777t8kvg9v9pULSNP0/bOw2TMsKFlO+bEbqUYhefLUViKbitZqOxRNsCCdFSUVtOngcEkIkkFylkRFsnBpPXoo1IN8j48n2SSIVKRmk6uWKUC/jRPpBL9X4hRqoD6+jJDRSvZRjpzaRA4w23f2bE/rysxdUFwv47IX+PteobsP0v5kG1e4C63WBJWuP9YURa2OjxnXwupPskNF2fkLMIhxLt5agEk/6YrS8iINbEIZ8kIQISPOI//7kn/CHdyizoDTyk5/wh3cobaAk8ZP/VUoP71CWAKnhJ1xz4fcdLL8MFURg2abfn0BQoId3IAowvPHyZxAyzWHlwJ+fYMXA33ewTnDoYP9XQcn2k/+leHrnv0uW7FUctGA8CCeJlPIitkiA0d4wYbTz1tdAb/WNHkfrIqgWfqOPGxY9yxiXQqXxzKlXFOZt8P3SomO3YbIIwnlGTKQG/POsr104yvNsH12ex0S6btim2oWdG8AvH1/Y+b0KO28Wdr5S2Hl7YcGhpmt0fajXKYPXwhy00VR1s6VUhLe1QlwQtGjrcbnl9ZwE5uOKi6gEF/yGe365Kb9MiMkZefGg9gQSCGy0k/olf8Zt+cT/Hc8TENLEQIF6htS4ivdY1t2vfC+OZHUCZYQnTugitDigKmWmvXVWCafKotMTMqivFVXPqm1sbqCREjxpGiY7NCwcTuqW8mMmCTzv42th8DXf4nfVSyIFIztcjnGTswhx6DNitFCfS+AutQR3ySW4S8vAU9/Fa/YD2Cq/x40lbnWPKxoUUu2uVURXxdfYjneEtJc8a7GVhvoFZ6RASGwH1poJTFURQoRD7A7hjWBNHHRSkHEIC6IjC0DGskk02Om6qAQxEcTZmC0a/w9wll4KDqO7wCm/jJ0vqJD3WG/j6ZgWUBH1XSz2dlF+qRwhPdlVE8REuBS9JBfnjzzK79MIJKcsaYvWwtVOkA20lJGj11cacDKLXAxmPAPdRfvwRrbrbdOxd64YpX9pLGuqdoVypWakoyNR4o4S42fDAMtd7WDQpCoDnjQ0dIR8GmPk1oQXHrVrwVu0GYqXdKZ8FhR4Hyb5kt7FgS6qONvmhNd7qxIuUiQFZS9I4HdpqCj8GgsYw1WjDbq4vL1Eoj1ihb6EpUACNrJqlJJWlQCpTvE2Jo258qAlOadyadjgS0NqaRPcow/SHUEykD1HUsyJwxMYEQbec5egl4UfbA7SzPREdpr1/YJ/kewZaBu3AvlPQQysfT1+DzoTTj6DsP+8Tjrdzdt02VXj9j3MbBt4OUJ7BgUm8mSvhUNIlomOCHKDtsiwteFSJje4adG2uFPa7nwVO5U1C7RjdRjCsI6IBivCWYxukoQlDIU5H6AKVdt0wAVkiVIRH1iispkTd5Ox0nxNNghq15aNIWA3YuCdSFsUc777WhRMi+1m0aSriDhIh0Pop2awb9V8CXWlXOvpgbmZkRObcOXbGiUkEZPGB4h7Gn3Gxt040F/Pp/0lkk3lzOpIfEThZvPD41EEVuX2+iDhS+gVHHzSRwCy46AzAq8ff2ImUQOQOEYiY47+ypijxdQcPClDPQeWtsGLovPBWZMYfXr4JGgA9xqQQlA2mmrTCkI6qFPhbm31epkKVsDUXCEDLcfLQKii4nEFcQoVp+hBKiIeS0/L06KXw6zNjfNq50VNRYRQ+GE+xGEqJsbyvGy59D/6e3QBvRyKtMeLpHIX+e7JfK0PyvQHYdysPa4q89KQsH6ym4MbsxVGcwhajburO+sFuZOeFvy2VIapoGhxUJh1XT2OIUKlI1RY2YhUSCQ4eEtGjqUsNsjarMJi47lZ5slYEMOq5JxXssw5CrzyIKJKjKAi8tNIp4jIDRGmWOiSRlSJuSwpxs3a40YyrlmJXytTYDnkQ7NoZF5C9JfI6GZUYgLPyeOaKlGdEdVBeYo2wGcHks1oseAdrHbDXi/1o17Qq5cyjYw6tCp6DZWcUYdWzIoVJZidnUFj0FMPYWpU8rFMPtbJx6yggIno92kYUUcXUSoZpXJDz4MoXtBDenJ/3VcfKPM1KRPZ3VfpD0es9nD06V4MpcFCF2dni4WuuSwgC7jIS9TXypDi8yC08REpSz3hTV5m6/1gGnIbsqtq1YOmRCl6W7nTcFHFQ+q+wm6U8nEBxSypR5VYpl08MFyuJr3SW6RJVmvdVbruMl13fEK75QNVVN9qd4JuhHeSUHE1w86+1AOX7L4yqF05YMUEgGlVvIJFb6p0yplMOQt6mUg5o5SpJSreErsRW+l50OMovBfEzCNrD6N9fuTtQPUiS5iCFFxAnaZUp1q2BwkbBisdAeBsLIZjYaT287rUYBSmT4LyADq0yV+OoAkiwVIlWBoJfhMrW7Nb3TJ5rzzIqcmVPI9p5SItOhTBc5INXgMldM7W1L9flzoUt3gS5FBc0dA5ZVBYGeQqgzyAgihTWCODb+8xd+l6wh6pu/VBShh+xuqGPQLxJXhPScVMU9Aztr5o+Uhe0sKKiktg5kWt04fO2EusnHu4mMjcdfJQWyXUVcpq1/tGP5u9qZ7+Z/je3b/8e3fXfG/yV3yvzlF88F9R+B/bC5z/OxSYt8tfUeifrUKLaWIa7MN8D39ZOg0aypHRNNjZZ9k02IDJGnxRktYb93jq3OY+zNFTBhtznM/5BrwMsqmijgqqqaU/Bbt93NDLbXxNWyHYi4GA0Mu3zZ0dKUDtuSpVlaRS+ZxOLZVPBNgUKp90xdeq8Kkscqd3WuTalrjTqVaKbLW//euMX9PgSXovCAJS2lhjk9rvMmHZ2xfbFOW1r7z2G15zFWvejDVXseY6VsNM1Qa+oftHrfjH63yk63w4vYdSLIdEKSQkCtlkBoVtlRkUf1BL9i6TNNdAG4FcgxwV5Aw3njk6R/c3T3xZcPvEvrTh1Tq13KR2iW2y1g8aZZ1J64etdslitWEAvG+nJ0zXmvaxdtrS0K0l+RyTz89sZi2v8HO0apM9YPDnegC3j1R9gJtONnpAu0Z0W7+4bw+gXFf6AGa+pgest158WfAe0GIvfW9L7pa2hH5jpcgNTWVTCltUO+nXwur5YxsS+6GwHG/po/tr/QzS26nW1t3Z2clX1GtHU6HsmzMaCoaZ41Skvy7qQEed21HnU5OF4mLKsZWvpgbUaq3P8x8ni0X9JA9r3DlajIdGMnmwv/Nwe4YuXh+ers3EzCPBGmTd1aSuVpK6VknNGkmpQ8z6cVtSFFxzV8mrDoizs//QZP9bH+7Th3JVPbdX1TKqiH5HrKa0sk7SWZIRA2ffOMi/nNrqIr2a44eTCH/HETPiijQPCw3tkc1Gssbhde3+mRz4lHR8tyBA0Bz8IlqAFygjXyaMF/AqvQocSW20p/grEXJDumeG+2zfn+rwhQ6/7w91+FS56+oeBeWOemPn2bT0BzQ5QhNNCjRw8ieIDaZ2UQXBi0MVFkzAUyim5ZSuQsArZRKdQvkh2UEVQINWxK+k3GNw//+q+/butm1l3//vp3B0XC9SgmTJadJWMqLlNkl3W7uPpG3iauskNEVKrClS5UOWYuu7n5nBk5TkuI99z71ZKxYIggAIAoPBPH7jY75PAZV0fkkmmJBfilBMKj/EoCSYH4rYS8ryF03KRSpXp4ty+/tpBemqYWnGY/2sr54N73kWLQZFZwplcJiqBA6BVhN5KjdXiZIM33c7b9wamm+d4ZUoEyNZ1SHkU9ScO0EbjjsJnLmKlnd8UhNJpkL+i6DyxSdJ02vFFgw0RtMqka0ylnyx6qmvEjjgca3LBqja6rQdnF112tvudITCTdFp2E+h0/FWpyPqNHp+VJbmceJ+kiHSjsZ9x1fwWUjSJniLbZ7N+6iLbLzPRdYCChXTisz6+qN8vLtOZkd5s6Dy5MSST/vj3e1VnzZQF3Imy6fLh7VdezqUT4cPahttXDYClodYE1rjyqtLrGouWHJDN3A9zlhDXzcUjh+QE7w3YQ1MNjS3o4mLCt+m1l0s+loz6bs/MOWWzd/Bi/IBhgDkw9c3T4jMwMsCS1v1c6mNutc+Gd34+t6r0nG18cAknbdvvNjYEHwJd/crhmz6qrVDC32uOTNbyMV9XG0096bBKzo8okI3ka4iajiqTtD48wOGLS7WoqTWYS/QuGjUHZOV0w8lRchTRVGFZjl/TFDhVi9KZTZq+SkXd3ZVqg9e6Sb/NXUSJpzE4SmckrhohXVtINgwCwpfeP+pYgR0vsf3DyXqo0wHExbO2uLJ8XBIzA7FzcPo6jk5CE5Sv0SLFIQJiAgmgBE4wOtSKqrYgs/aJZvzSTtkt2bbXEvolakdDUTDaizc47WrdvXlziJzLCK9sld82lySOQJ9qZvKl7rCjl5zMjWtrx6L/TxeIPN5PGeZCHiDb+sU7dJtwsmjEvqGpVgiVyVCt5nUSgyEh1C9NRjvKVvSiN/AlBBG3/cUuoI5QbCucjpiSZQ9wJEAHr3mBXyg5koZ0h1yv+NnAVTxQlgJkc3+0sthtz2UVGjKDhUJWsrHLvghIi98lUIXVvDMyaSBGHQXsq5vcOY9R4HHFEMDnvMz6gINdtZ/zab9D+yq/wOshk42vXK0j787HML9Ltzvwn3YDl7wkydPmqaA/DzDYa8ex2VVDYNQnJ4S7OGNEaN7zs2oaF2PK8Z5t+ejpPV4LDQcwiDb2dVFtAvCoRcduhIVMXy4C/OWEr0x/0CJkzH/gcl6X+gIIIoyP+seHQWUolFyzgzRdtlFZ1EWZvTOCKHkz7n7a9/ZCvIZ0YKGu+1UX3GpL9GRPty4B2LdH94ao3RYjy6B/hnASJjEG/d9DTTNWo11yDRrFapbCyD7QbYMztBDrHhF1g1M7BEWnhp1vp0pStbYRd72SNAQFL0/y4KwAZO4SHFUf3l17uzxZtVSXzhvE4XKJUt1+piCkgYskP5JwvpWoKMg5kCEBNRDln3LG75q0FrbYx/9Zluu9+qBCQtXnwAUlkkjJYNGCxLs6KjRxbidmOhRAt0zKRRWVgDdSQtm21DBYcGDJhFEE0/YHqu8hx3SDegxQmIVOuqkDH4Bs+7WeEVbKEmCOnuKBsfMCLfyihDDr0qnShtfK9zwVKM1Ks+eaFjA9tcPWWByMGY81JuYnARzvLbPMpOXYV7cLq33+rD/vSIbf9LYGCPpjKXlc0DpdQ8DzCUi/wSD0mUi/wQDysHIXaMyFGHRK5YnP5Q1XgIHXTEQO6xzkvsOwwUchtG9ytPGXOZY/CpwhOE0IWLISAIm+lsm3hWB1o2sjjBONtyjeOL+/qOY4GfVae5R+dGSeHYT1s2007MFkEo8r4r25T6/5ov2zN7tpwpmRkyrvTv6VG/6q51F1lgEHZJvuLFbXjZXTScdqjNTv4d7K58fL2HXXx+vyLTncDsaaTocSjChsWssKDpPBgHtQIFrtO8IYny6RN0wa7UO3ZvR4Zgnjg/b9jLICidsZc0rl5XqetYKmtcuK6r2zDfKnjllGn6H5ow8a9xUwH9QZW3Lk16URrlR4df0MATNSqjUWBCdbBSPT7t3d/j7jAd3d6nMSCkjQTe7kXVIxGxgeVpWFj7qjnmEP+bkaFySYAkK/r2PKCUiee5PnU9PXFsa6Mi+E4KBMmG/JTD/HNZ+gYZz0zjIYe7O8AhT4ob9PIi9MvHWZPSNBvDK1JwZbAMW0ijEHZvNz5qpS3yGg4I5NqMiv0Bbn4vRwvtssjtcdhKQous7pOfDb8rKYcq2NLMWnjbJ97lAtdVB2E6TYdCHv610mAF9RXq+QduKOtfja/PeFn9s+FJExWER/mDQJY8SJ2NW8nx00gzGwF5jIhrDysOEN4bFR7ew+FTcxORS3Mbkyth4lGzB5hjNWWPbyZwrU2bNiPO7NmVkziF3pu2l23TK9txtOWtKz9sLQUoOjc+cYjRjYYgE3GUs9dznlPLGY2swrJkHvG1xekPsoFmh1v0rFxbrtbB2Qu4e53XxjGd3dwEmg2e2557mJ1udJzCiAf54lq/eIclVxBsl9EZR5Y3ipnfarVeXc2fZXteewPHAJ/JdT/j8sO3ErVxAiu8qsYIuZs1gEI5WYw7Ej8XHh+yM5fD3nPnwF+cqm+HdnrL4OajLl8zcZD66KdrnE7GYYmnompOVHUKd7CuT6TIp37qZqpuy96VWesO6tErfSuoMjKlDq61i4x9UrfxlBRgE04NV2D6hQPQ67an8nkt2diqdU0wy5nM034U1Ikq1eu2MiIR1NeNeO4f1HwOHseCICz7nUTvGxQOn1Sn3YRdb2kjVM8QnroCz2ytH5MC6UOtevqE5xCDyOA+ghRTSOc6/tq9oxPeloo3us3YvaD89OpJZ2Gpz1ZZX2GJzaRXBb4yNNpdteUUP3JzyLhIaoRUWqBwzblu7dQcxmSLEZiOJYT3YppaDnMSIiqc4mPC8FTVjWtvBaDI2JCq3n0TrvOi0tM1aFtwpWzNYHJ+cDB0gRu7xSb8dHZ+47iclVheOFmPorOca+edX8ML4tRb4VTOdSqAky/APFh8U0A3uO6m+H7EUb/baMtGF2R/jx14ID/wN/XOQcxGLAwe9hGGCb2s7Bn+1b7O10PI9XPOp24qbDkHK+5iTtgvKidrGHTfHY6L/rDvMj5285bv9lpM/862t/fuyLhQ+KJpZO2kGll9maYQ1Nl+Lu5pX2fiSJmGz1LfOQi5WtXUKfy2aGj4rBzYDBFMU7UgzQVdL7g9qnFAiOaHUhW0INlng0DJ4gdJlnSfimOT4HK5idC+BPXpUjhVa40FseY3ewzgw2HmeRyIQYD/BTsHG87oIFnk/4ycVtsImdHrFlTQyfmVkoqaHZKA+MinTyEjMBDATiwYZ3OrYzGlsPDE2Ez6zbH5hbDxaMx6MzVwaXQJF8YCeBIMFB25DDBbunxM5WB45+E9Ee0u5SAdOVEHJH+FsHrfXLJepqes+Q1dL+EiWvrKJ+JwBbM0acXAtQyJgIIHEbUZs2lI7XiIyFnanFi70fLkpR3NYV6IpvcGU1vr4prY+lPqyiRtXAmQilYrLH6uKS9zo0jL7a6HNLJ3biTIZenOPmPc2n6cp6tzRVErZH1CsdMsvNOLfp84tHhd/LN2Ki1Lm2ucFOIpH5gCPi0d61Vdd+bePT978KpqWaZkfyJc/oOcQM4NM9hn+4Q2RudEtaAVWwY2GSCDga4249usnV//+H+houqmIHajXsm6UWQD3hcpH+IHT78aWc9/j5KpPgPUXSEl8La7YbWWEkZsgbYgIph2ghYOR1xcoFrClKk7Gf7LDsmMnK0oOrVYwQnLZoG63ai1iML6sqOqFCVgvEc4smwgZ6ng7MrDL4ACeWQdu+xwjQ5QA7WEEkfuhVPQIt52SeIwQeAzrLLyQku/5zhPuzD1e6EPwemeRCRaRB+opnHNnwKmsjyfAnaRiSoi/wJuIKNN7hN4KIWzD5yl1Okbzi5tCbhXAUeVuc1qXfXtYIlAlfGA96iVKPko7K5Z21kz2ZwxUd5RQ8JZt3DzNRijJMIEb4mi6gxsZS7YuIg/YHPgeqhH9e1XoM2vRzJtrFmjdrybSCRDY5DQgM2pZ+aqTx5EfwL4Jnx8IWKGE7uq+q8dQyHzd2ivcuEIGfOIov2X5ffVX3FhyYcklX9knT2mxuEdPNxRBxbW6TsUYV6dz8jzZHbYAvlLhqLBYVgyuR1tKwCWedbVHvoqMjlKnToKjgzO+cNWpdRCNImXZ2hvDKWvgRp1FunD07d4Yt6aoQ86RBq80Qo/cFa697TP1yLbPUenfS9RL2+Y2Kk13xhvnxrW0APxqW8hWJkAyEPQimBxYxKDiqn8raVv/ekM+xnSROwK1whnBbBtDmvYTMRVEGs/AozG7wIW2NSsuxPwJ5Pc6VIeaQ5EPYwAr6YphbJVr6ahfcby/tUEgiw3UeehuyZRrrQbbJVC0yvHP8bSVswC+DMc/x8uWXxFPHSrx1IURT10lMiCsGJCvZD47JHACcofFbVOxx7fTIJ0HRaZtA37abAa1XVTUJyuqLX6VjdvirRCGkTy1sWoI54PGWiXErvNI7BVk6BCwSQBLPDioV4VK5O13UAGAxYfkjx4lGljVoGBW9jSL0REaVV0eeaC9cKp6TDzUQ8Yccc7THwnL8+8BqsK8uf2nQqPFjhClbYEHb3YpV363bdai/GWURKi3dIUVnAXEUWqDrToMPazhV94kKhHelGO8rcK5XeDNRf0unvBH44FGAonF8vk6gl3gsqRoP0L3IQxT2083FKDHAIXIB96qB9b3PmBa+A4feGe3MFn3v6hg4zeuSOnRIKQalVeki8aePugqdR8mq367VmcchEWDoTJW5ZCLOtVYpzKxW3Q0f83f+1ma5zMvypC4mRub99rCLkK6E1uHzz/IPFOveGU9cEvEAPFC8Vd2JEX00AghxjzSRcSGUuQGdavvM5wQkRcD7cz6pWayhBHon6xYaD7gT77Z28RzfIfSnqHPy6pAlzaHYBj0K0zc7UoEz2ELNBtcrAW+W04mPL6asaYnq34JpUO8O8MzBCYmtF8oHwJa+9jjXBkiyroUpa281gzvlUdHOPFLTMNME9wvNrWhR0O8LRuFWSNvrxHGTLZvvfVlWZGkSYOQrO5CkkrDiBQ9SRA/6bU4gUVAn8ylMp/wEIxM5wpU7thoR/FF/lDtqrNcJBO6jgqmd2x1+d3Duoyr4SWeGVPoo7pQtUeUI1/Cw7NU5rTbizgt2leefz0l9tltWKXUk7GVJ/qW8yc73+1rkr+groF6UTEwUW+rX9NUb792br3219X5+QpZWke7rzvWPMEOauhwVPYBmRVcNSmIlIXw2+pBeyIlHAd/I5I4+9eeOufAQn3Uqac2FJ2TDfulWh8qef46HHy1q79Wq16mWZqk0V998d921vZX31uKKr69z6j5H4Of32Okme0z0vxgIp3UIenflpWI64fbSPQPC7eRQ9pHZFILUT5U4TTIWMwKp7Hg+VDK4DC27Aw1ypVosxOXrYWDhHEA0CiOvN0bKLvfEWrLbrf4z0yYxWo0d2QuWI5/fPxTEiuvQ8PBkowQMrxAkKoIfjDKudjL8QjJ4lEy5gsEjPcxNcdULvIiOAmLvMjd3QlRTwYpqFYu5NuZF4fBZAos/0SoQaeWZnS5rRItSCtQ0yVO1LnXMqQKOEaYGATPYAOZOUvksZeIurWpPjq1H505Uyw3xUCvPfcTdW/sDhTj6QhmcosLTT/Kha7r0XmVGLMeHT78aHT42A4Fb0WHL3dFhzcs7lpHdjxDNYonuPg/z5HjHBdRWXwrKks53B3xoAqbVlZh07ZHbQpDFiCE2tTtUxROqKScE5cvcusefT99hM7gYuXO7QdEcEJ7Tr1md8QR3BEvcA+BiT5KYLJdYS8eEoZim4ig6UmFakyqVCNEOlKhGkRHqlRjbbv6bK+qCVtszfLaTJZfAo7WZlbPrVk977yTL0eul3rezYUF7v+rE229c6Kttybad2ai/bTbxNr46/5L7SW4e3IZr0mNjhXJpCOzdCNF+PBGfinZq8K9p9p/lTg6quog3L9QssqGLA4JH+gE/x9aHV5tadREzoUtchYGi9aKSAeOyrCEuSiJLSWvKDe70DIXcvLh0HcVTp0wlREY9dVN2XvQpmw2ICnVzYX0UQlJyNTAWaCBJB6M/V135/Ku2S1HLBlDdb8FdL6zEG1CZ9s0iPTxFpJRwLuohVD7mVJohsIIhatJ8VUQx4S2uRN7MrNOoogbm6sPFgoDLeA89wd/xjMtyX0CbTTPRCV+xbz0AR7qFgmIj46wWqQEm/+ELMgXlKLmS77ZWv/JfUvTXpe/3bv4rWMQfFa8tIiAQUoMLY9D7UwrBeyZZZyaVoxTo6pxqmcbp8a412kKIZl8ZxTDQkvaEcva3tiSk6ShdiUn9twoEqX0Gr48Bcghxx9cZqgmwRNkyuQzGiTBC2sHK+Du0U/kL51W5PEivoeaVc4UN8pVklpTR1Yl+rBUoz73QwLed7z6cfxRF4kL3I5dcm7bvv0fOqW8KpBzSet931Q5C/WOmvru0Q0WVSTPXrdLxuDaxxpPXkZhQCCWSujJjRn28KTbbwFpNlkeZu3QyHjDzug1xQns4Bf04OuMhz76q/dbHpL8okLyyaSBFGGyizOed8Sr4VMqLdXA4kwKnFDngyT6DIZqoQ5aqMLQNB0WpFxDU+1ks+ElfqwVfI4b2kWw8RAtAT+Od527mpI7SD34s0d52Jl5OVH0OhS2cAcPpHR9NN6g4Jldo1wfTmCHKIIlpYpWxDwXC8TBkFYUnXCF+84cg1rd4OUNXsJ5QoyHQ/ECMUhgv6cUOBi10bWc5yN0cdlW2sTmsAQ3z6QCxz6+EfbxZPgmlSwi4RzrfenCqI4S5B5F5K8Eob83FM/jXFpkO+eEAIrWLVDfG1dha3XrXgNnbn0ztHyWElSFiRMdEG7Yw853mPApuzuv3dsIGROy/c206SRoiuVpEdJrPP9+2DEqZ5VReb09KkT7dqmjzuHsLIp/UIwG+yCPvU5xjI6z10dH11LL67LDo6NDdVE/M1+5V9rqQpTJ9fUIvQXGeg8/MJV27Urhora9v64KmkVsi6Mj4UYmyce1okoiEqmQu0Klt5L66LBU9WJqLqgSH6RNtyMkxHUahmsdGJhQckd6w1Qu56XKFU/ofBU2cFdgwH2HK921f0gpdWtzIn+DEalpn/YoqWxWRFjhCsYWIw2McHvBDaTxAf4LitAYW7j7fmhHOJB7786oBqXa8nuIzX9ix2JH8T53dqPeD6Wcfvht/yeDI9CPrfKpVT4aSrF/pTxNjpwtUuhdtAxI9u3zxn899r0vnvQawGBMPX2jhBufnjz9YtJtVATTIe9ValD5Mx5WKlD5E8iX03FRk2POYQ9eo+/qAn1XmR9HC5RMwd8lE5OsT2r9m22eKAQuQrhDC0B8uI6Fa2girH9S6cykxi3lsxDWaj8Rvy5zbqmhDY8ilWSqMAwe8guobIuA7UfUSXKAljsUsEZo2134zp4PCa8lBtuvDN1MvVUWOSs2wZnwCLsiX5zeFKiJxcWpgT6wMH9ReRk45V/tUlnp0mRHl3r3dkl941qXzkXLpIkVre396OIDUwuPurIJa4WEYQ1bTc/qwJrhyRC2KvyWhds3BYYO5SUuCwznVAyTPhW0SiZDICqzUETltEoGqqR1myokf7jEchKjcrTDyoOw5kiF5VyGYXLgiMN/LQzGS9XsLqA4j++kEkg+Zp1PJvb55CDhak3D1CSGN8Ngjcmm956lInXynkWcnOshzxOpE6WnhUOEYf60q8woG8O8HKVjjFMNtMFAQzw+EWf6md5l59s3J/rmmvsjvX6kS2dfen2OBw6G3z7LSKrqnnaHC+S0SDywVqYeUxTKQhfFRoY9gn55wJLJTWxZvQ/9nrBRNAZuVNxf8WnnjzLI1q9po0Ajw2nDHQ6n7IYvd95ZViTcqw7hZH81i+IJ+sucGA7lq9QR80TsXjh1cV9rQLNyN4km6G0vd5BBIjckqsuxK3bZTcfHxPdQkniNPCjOoIroqiwCp4FVt2kXY+/LLHb+CyFt3Pf4GFoWZMWXAfQZo3bU6jHCPxuCKXSMqUghwJQC+ziW8JuUttd3sHoLEyzDuAeuxBFgLX6MLY6ZyMlGOl9oQ3Itd485mmKxnMfKTsnfhh7J8di3K/eWoB1gbaJmx5OhamtKiZxUCiNfSeZhJxBzbHfUj4DZmne5Yn3JZAn9G3AwfqAwO1SRcl8RwXyJt51XT+AwVn9aE/lPhaVe33Nwt/SCYi9dYDivjD3edb5Go73FMOjIafCxw7Yqvq4Ur5+8s63Tu7DeRriTuFq0bvxFPCXlqEeNozGyx1cY5IbNQ8nBZjzbK0jTVUfQIXTNpog2MiDybYbiNBszLUcuoIDDSl9bZvtkg4OqIWFYBCXYnxK8Bf+0qM3DU2q1T8TeOuSZ0Sd+N/qoKM4oQUM9XzSYGHxgaxuGmVG5WsO2vMB909qU9SezwjXpwf9pIwRba7HXyaW0DNHxweCehVufD/GMmk6v8+T4EPHiiYBceIu6r2ogt2iOoNoIqg8/BksMIy0rkHDjMEfuK7aRdM6dvN11j1H7aucHiJi0DN3jtO30jnz3+ARdQfK2jy08bmrb6tB91lOH8aBdwk5StpzgtBy2e310XIKN3G85+akvMtBDrZ3ATp63s0HRLFphM3yWNtNW1IxECNQWNjfs9dv0tM8zNW4z3PMJpcHfvKcXmQDlnAYoXzfG8ROoZcJvKY5cH87nRCqKvqKVq75TttQLQbPLEJUAzaiFci4PNyxyXHPZpENViHNwrHcgTyuEZK9uqoRxFqymGW6YDyWO2u5B07ervfTt9ipKBDEtEPCWuMyACz5T4ggKKverQsS5FWWkjdqNIh2qHsR+LPaL43VzkfJGN2JjryI2jqti49wWG/vSvLtUkrMQj9Az7sP0YhNetmNMLLjX7gIXFrZhOgLDFcHHn/J18yIA5mgKFyt+0lwDu4PQglPlbissumfHK+1u6wdR7Eww49Au4ixaS/f4xmUXVjFn3qbMVo+d8ffzLkyt69BpT91NTKk1oX5AYululpTQt9r2PTEbz/mZtYEfwgZ+UXPEvdLOt+ct/v6CHg+aK5yPhdvUNRbNG3dzeHtmrBCrhFfoGbsfV30gXivOcPirSleRUT4uUkgsAny+Ezjk2hIPHFgEpBc8bhbuMfzIlXJYXSkClWXbOohYD7kULj661atIgCisR7NIJYaWU81jWVqgB03O8syHqbgDdAUmJpmB/pBFMGX7YcW4dMZqgFdovyjx9gUu4Va48Iqswkp7w4h7vPe0v333kbxrbnnWrYg0CpGCkViw+ZjXYxU5cERB1cK2l8Dxf/+70/z38bEW11BY713lnKs4vbpDQnkHXyW4mxXFgv7kbt8S96BmWwFBsPW4P1rLdx8Pll52sJbdRAkysl8pnC5X7IbSkUH1Wg5PmkstvRldsWsq4e0tccguqETO/mlliWbZph9l2cT0UmF/9xSaVZQpV3tKyYmphaGVmzhZ5Z1FTRkjuMBDRcqhJJ/buHk3kjuk6vlFBUXvWnGOSwmnt70aECoNATAvoskl/FcAetYK4QEZjAh5q1kqvAxQ0b0HfW2i0df+jO5XDLevRhRDdYdq4GY0SBMyd8mMj5j2IVLlFJLKaMlWRqGT7RLb/h1t8sM4XAVFtROvqcHOUNKH8JJLNmcGRGpNdxA5M2QrtrbuSOApY1ugV898OO+HmH3SDPHGSXNRx6Qqh9LMxTy1Hq73PWXhZpG+6L0YX+fwFjVHcI7vT4cmb4oZZB1Rf7yd0iyCWu7upsNfImDq4qH0J+4vN4vVweGtsZ5YQYaqSGNiCUyrCRZCE72+WghWkZ3gWvvmvPUczXPVw/rM/2uwXFStEX3Q8L73o8wnlDEcZnhHGC2DjTg0txfinjUAZmfetRufWacJ29FYgmLDqXjcRmTs45N+gB3J2ggAAVeFHWAQDjrP0IKzncIdKzujjAQrUyXQNqSfiKoS+hj6VtTP2pGFMKZln7hNZBTXqLi765FUrdsn1iFYLZwPwBS1EreNv/Q3cVuBOHDE6VTEWNBXvXahBTuPFJ5JD3fC4hSqgTMEVtY6cYdZ87XqwHHQ77XpGh5HF1b3OLGEtK+rHVV2RLwXtB9jwJ8enEqgUoTLAM4xhANND9jZHvCyvbbfLI4FOIDlfXoa06EkxrMcFDqeDPJTVJ5Tbq8FTESO2Ai5Cw87TthyMuB14dTWhL4jHkVzwnbWBo220uMZs3xh6eaMmmpyhxpzmzMmm2lDhdCK47dkW1h/E05Ef6eVyGrnkXntCA5wp4+D9mcYHbHV2gWE9IFYRxxkOWMRBpqPPnva6X3e7X7R++zki08/6336lLU/f9p50n3y+KT7GLJ6Tz9jJ592ur1Pu198fvJp9/PHUJa1e52Tx73PHn/x5LOTT590e0+esE632zvpfv70SfeLzx5//vRp77MvWPsJlDh5/MXjzz/94gl0r/c5mj33oKj81/sC/gt4jowj7h2HGfek84RlbTgStzpPXDP7Moz19HSQwut5LR6N0vFxq6XtlHSxE+j806cnn5989unTx72mdwzzOrNw0aQoHAci2YJqrsxBIeOmGRfyhOadgOk85V3lmSoynvGeyujJl9H9CWhREDqNzktUXsxh5Ug0BVyOQTODBQPrKOdRy/HMjaSZ4rpxh5SzSG+gaN4sWA9Kw/rSuQnk0jqFOwnCflRWtlztg9lprzuYwUCiV29XBLNC0hCrtyAgFSdu43zzuHOOWyUOEMI62/0tzeeJ3VZokwq49mGiH0MSDpEar6kHs9gpj+N2eEyF8B+MJxnqQDknblHsOxhRO6uFqiQz291TIA+fN2FhzJ51XQGeohE8nBPTGgwQjgXUAsfyJwbKXcJM/JEVMI7QjwQHlxXPOk+GSb+dyEPUi+ohCg21vQz2oSnsaujxoAQPVVGDrRXr9P6U28jfFte+epi4turGEfUj3vniCR7X/Eh4cvBPJVLgX4iTUjWI2mFW/SI0ZgFy2494K9Icg+gEb3lA4bqn0vkWzmUycdq7B7jfjwaEVBglB6MuO+i56EkdoSc1GbZUm7g3jq0ZDajBQwDnjzDT8NrCHhwGNK+KfP+yLHcHoxsL855YDqGw8dG87365g+AMBZxzBfi0Kov4UTHfwh1SCwwq6NIoNaiZP4hoP2KIcMJCF1GDo+TDwME/ygMbgJf6KA3YvwpVbWJq/4ke2lEmqkI+K0uss491+0sPQ5LLbvcd1D5tqvYcBoIpdIwdC80pDxc36tCq6jW6md4kQfZcYlFXUZC/f+0EnQTOdTn0OgDGejll8ouJd5bmrN+bhf0qvMecVRuYy5cxJoQ4LVNrjSsx4wh2ujEPOkJ2K+3xMwFdmPMvQ7Lupq3kG5lmQDBTlBfnVsQReH/PQZs3gcPtdlZdSmLAPQwwCxk9nYHXGnoA2ke8LbLaSRPfK2Ar0a8hp5J5DWGlsbu7numu7BjK/dDdB4V96eYcLyK6AJKgLIV//r87tEllaMnyRA4tEpV7hnalh3ZdH9r1f25ok8rQJuYsj0Ob4lDS+J7jkDI5vu+tlfKl5u9NqFBkPE1sWEvJUhhjxUCoWVDbMsgwZmfa4jnD6J3NnHn4U2yUbrhQSuGcO3EzaiN65jEiIkKKhtdJ2zlyVjo6Bp54m0XLt0Cj1BeoQKoB/S3nlZE4Vo2pmMws37aLpBjBDp7W2p7bbMLnhMuMjmmU62KmRlw0vEh+7Kjq2yfkIgHsKpA7k6dMMIShpMYkjGif5X7T1NXTPW05gejGcWxc1eBcVzbtUKE/hs4tEh5S708CYiwwakRFQpuxIguCc2+dlhhlK+jgJeW9TjM026ZkANSQIvLBpogZ8uGYLl4KAV1OrudCjxLz39FYG2bF8xCNX+2QMr+EqFIzAl+BxxTbwjCD7fiOLHZCHs8cn/0SKmeR39EdT4hyfzdwL7Bvz2DfXtReELr1IoDHHUe4O2t789J5B1kIaD3jE2c0Rs+TOf7STFgb784pmqou8c8KJ1CBYxGifTCphI0TA7vhL6G/YifEvR2BISkx7lt5pHUTF2jvnMILXNGOhHhNR0cm7Yx6rAfduoJtVX0BW+iNZc0dxxsOv9uCbAjdYuSh+9oonY3p5fZDIsELJnzlVP1kRHQZCddBvlk3KpwOsHBJJ4d5gt/4ykm26k46kyD3gTh5SYFeYBo4J7+7I2NtZa/baq1dNh2hzTiNC0NNNRq40UluzWboHldbk6Eb4JvhQ8Eogpcr3M1SWQtX3GumyshjST40MCF22JiHNjvwZt/aEf7EGW9clfNFe6W1kylv/NeTJ0+q54CIm5OAwTeALGvNxVtrLq+vOd9ec6W95gw4BAInwporcR96jiusEn7p1xBeD6e59IfOdLer/d3CUaDq5SqYyNW4wNU4Y7/iaiQzf7EaSWMhkqSwEEnSTFTWaK8/RwvEKVogrtAC8Uqu0Fl9haawKtUKjfiaVqjHl/Q74zf0O+fXesVOzYpd4Vy+4mTfv3vFpmLFXnDgwwcX1vK72Fp+F7uXn49lreXn71p+iz+3/DJ+uGv5pfbyc3aQF1ctSaCxmViSMAUuUMRiAJ6kdVLBCi8DEtRPEOSJ3JWvK4szvLsLxbCb5Tl12Wo0HQPxouVZ2stzikCwrp2XQJ6n/MStJbuQS3aqliy2srnauWhXatFe3bNoFxWcINjxucCzAS6vGk8oi+bw9XeFFaLyKgjQy1AGCBJGijL3j3B/YCBcjQcyLq0KDCTe+GXIb3cg7UxW/adMj5RGxdNxZNGJP8CI42PeLuB4/Ue9GtE3gvL5aEVtqyZjNPPcVjpLTMa7u51gcEX/nhGEheVlRf4mgjXVwFXTb7jDy9D5RRjKQmpbUXqgnH3RO6kYb7CkBSlj9UyyRMCqIy+EFrNWwXf0rY8bAsbuGI1LIUP0VQcKx4WCYoIeAncpc9QtvElN3g/mJULlBXB68PwiXh/AifXAn8H69jH+oeJKAqgLc7+CFz4rnK5r8aAGLrOK9A6dQDPXr8P7mve9BCUd0AHEkcnhLAOHxoFAmpABPgzLrbnWjGLGZXrGVzqXyVl+8HXYR3lJgtjcj6yQNSRqozl/AGfuIXnJCoDCLsvgLNJSl8B2t9sZw3jt/UohtwXDb4q1eu7AqvRtuFUrPPBv+Newq4YDwQkeCE7gmL5duFJUYQFvcFB0jJyNhLSTa+/rkH9xwt6G/NPPzLT/lz3tz1Abf3S0a9LTBmCmGs1m/IL0vMFFxFIkVVXzbjeV2bVIzMfSsc0gH6UGmuZ8KykR3SH5gbrzm32HYCoTL9Z3YUaYu3jwq9wN7LuTYGFV+5NdrbLSlve+u4cAYnmB0arpnxm7Xz8ydvAVUEOw8zsEtDOZZ/CKbCT+6qjf3RWVbCHi2fU55J3KB0lmzrehjB8n71c+C9z/rXa/OsBQ4KdagdowQ4nvVIn/j2cEfqi9M+I3exEWnWhibn1r37J3DmH/VdjoqoN2O0Cg80fZjFb+QFPh7Qct2pmQk76uKSEn/WQ37UxqtDNAZB6bdioCF0h0AUW0EptuJkg3E6Sd7iaoUSxZBBWtLl5GE2uH+6k6UPRpzN3vqnfF1zG3i5m5/ehRIRwCYMqZEoFdYleBZLa1FQtWIRkKFrhPTizGZX6mtzqxH6MWWwElSZxx+mRI0Ok2fMLxwEWVH4nye0eJDmfV3ai4VpKgpzPYIKIZf8y8Gf/U0PR4VnWEqbiTZoQAajyui1GGsEqBk7oD2z4skZ6zJCv4nYyuIuM2YY0Jeooy4a2pBdVZ5QiV1o5QUV3l49U0Q/G28ieXWc+BAfDQ5QH9EHROGoaII0mBr67pDCgShFJEvnbi+kUyIQ+7SQqEisdoXnR0BD8Tl1Do+nNu0Rgb0m59D6RdVMRBf8otGoR86BKhKlc2huSNfcS90kdcKCDzrrlzRRbgeOPuTqT9uMRI08PGPEKKEkwaaAOczYFcueQbdogf6EKcd23w9CVG8cXz70XHHJXdzmRlBcK82Wa9TIcPolzGw4K5EkbTMvOu4kAw90Lb1bB8Os8cAyLxXQRTAkVt9gvLERbaFsuzrKozNHNobY+iGGOmgCgv0I1EORrzdeFcs4YZyAYbmdFiarTG5J4Yofj4Tb1rldlizxXVGQMvP8wqna9tL8n/1sSXg8IWw0N/1+BvjfpWx9UYW3PKlYgG4hg9t+Yg1HE9HJ05tzZGKvERDVsWU9tfNy6rPYKwqtsP6G7RgW65ccf9M0f0RTGz/qyitb7xwjAOGkpDXM60tmPi15E4ygSGNeA9NoURT+CXVjIimJQxvHyMEiB4/WhTwTaazcieDqOMKJtErMhEZOpiRCDKh3p5K1FGk1A3n88cFYpYNcLXM1QpSPVMaDq8+Ac7vP4PdNi4dM7IFVOL52vuwMLLknwro5pvJfrLmegA0qW2EC4FVaRa425bxeWoAzx76D6QoZFntlZ6aQtS12dmrpQMjf1gixATfiYhZO1AugsMpDvnfmeRxutpmkgsj9GaTccY4XWlMsgAFDLWGu6/QRsE7AI4g9uN1kGr9SplV3zxMI0oPtVA0XfVz1EaZa6F2Nu+oywvl9u3ZHW/wEfPgQyWOVA4bO2H5Jc80Cf3a35Vcb98SEczjJhpvB+vaw3DMvHQuaeev96Tr96u7W3f0++HNwUdihFZoloqgyZjS6WydR+azh8Y+VUoy7Vx6Tbi94Psch3UrF/B7p0mASrMHXRdt91fUR4Cq+Jm05byGWUmIEf3PheKibY4+NNYD1uWt79ElZi1U9RvrqxAtKqrF4e3c3TAxX3LaZw33M1v792qwQWVk2648r1cU0YZPViBlEWW8Myv2EKoF73dv2w3lskCBqDAQ4WhEAFFprDCcQqS6TOipaUkECH3RqnEL8FwZKNIXUz4dUIuvcQue0dH5PntwZ8N+Vrjc+ROjc9scO4tqErj0/1OzOp+452cwmMnZhMRn7NWEunlu7UpsOZl05DHSTr3gFUoGGm7+4HxLpyifPh4OiMXiljECCfnZnard4apofc9ZnkvGRXq4niNMiIxIksTc3BxPGVrDD6y4vADpM1ZtKfNJertr/gO0cQcVXyIH9e66c9bN+yao/01ob/orcECIGouWTtorsZ9kweXDPIRd2hH/VdY/xXU314cn5DhyhUbnbHzsa591GW9cX/UY90xe82VIz77YCHuvXbZD9ve05D7YlduzXv6tcBy/YDgtZOZ4ztoaX1cwgbrzGRqKpCWDo1c9AOhzFJcjh8oRsLobNy6QD/vF+LyfNxSdn0W5rTceTRuje1Grdw/hNf16L1/eJtt3usgprArXY0/Ur6wy6/Y9X3lM13yh72u37gmZKEXOwrhctnQerm3ECylWsjVyUwZVqC0+FTHSpkgLDByH8JUVVuq1kMw6rWCFWFgLBbQ32QHIlbQzsYkc6BHjU9f2zK0JLtu9XEz2x2w+CTR1q/0GGVEdpEAczyrCGXElVrQQjO3axEGrnYtmFPatRyTOQCc8lWYsGewBYby/N5lORCEUJ/mc6BbGYtbxSe9MaLBiBTwep8kz5J27+7OUWXhHuT7z2JTWYJZW3m+1YAHV2gS5LcCaiCSKZfBy57a1UeshNxaX0uKJSsu94WmrI1FuzZ8ahQEENBCTaB+j65rn+NZ9XsNR06tQKtaAKlfrf1xP6Chg9vYWtCGS9EitS09C8zHhBujBKpxLM9GvNGyXaWPqamxnIw4JhZMxey+EamOR200RrUJi/FXa8PXgnUCs/wEvpkcMvh88HI9NBse1aZ3bSjg2U96+Lmx7zAsvWf0ZKXZYLtZehRK40MP6mEP56xriusOWV9rx5iIYvVvKKoMnnGoddh50tfv71rwNfOZlNkb8Ju7u0fkaKJIz/cU14nEdl0733zWPUHJi/3muYJrUWGStJTUAChb8kgD/FMoYeTurb+iXJzONAazgLcwlnHGjKptifuWtoxUtHZrYsX0jrubvlQjmf50dIEh8lQFqz0gA6obAAP7tYqjo6Lz7l2QX6STMg6OjqTKe5GlRYpDiCCHP9wkP2YpHHyLteTiWWMShB6wQQ13iJJiSveLDSpLbmbsasauZ+xwRsqTi5nxkaCvfDhTX+96Njic8R4VK2qlrnSpm5kRhBW27TQyEPhoxNNWb5CdYpgu8r/weNZKnz171kPviJE3HpgIhskQY90Hbj9uB+4z3h06Efdga/HaPbefca+l5eWWK1Twz7b6sEaT3Y1m7b/U6KlslFpz+9T2jkazf7ZR/rBW03qrdmORbswT8QkUYqBszcPWvDbp6Lq2B0o0iLEDGY9aPWg60k1DQjcd7fK/28EgJ0NV0gLC6/a7d5nlST7UZpY9uJO6ffGM9L22BIT4YKWmyoMGPf0K/dRuZhh4rF85fmF3PROiyuSheQubFv0tcY5dWuehSTKLK6WDHaVlHkKzsDjo1/jA7dKUhyDwLPijXjrbURryGEq/No4l864sOiEsiya8EHIztGzhgRSqka90Ym78iJAzOQbS0bdllnIWAcpfcCcYBiLZ78ImBXPJXKnAiptri3qJTeoRbE6C8Er7DqW1gR1mIRDGB5WsCW0KA+EuFhjSOqiuOnhJekOMDDghg118RfqBK/GSgfiVd+VLBdaFKqlvWVdwT7y4fOva+lMObROEPhVdSeyuJNWuJLu6kuzvSrKzK0m9K5HdlaKj4pnmZMmWKLstlpJ01Dzm3fMYgaQTOswP6MimN14gid2+k3TyhbD0YD1VL6RM1bFiCBU5zOC8mp2qzw8bKBziRt3xKQ+EWQyWSRFtDPLpCJWqKWIbS+fb1RoiMMieoUMb1YzxJ4MBqnMfWLMvxkLVK0KCag00aZ9Fe7DCRomoKFMV2Zh/1RhORdsyUam4QGKEiDZGYNTz/u6ugH63MQ6jJdKuPiPvV56R9VhHVLnodi44WGoD85ZkzGh/GfoacsrIb8TkiOJUIpvF0h3IQR0pIH3YaVBnS+F1RmMRnE84ZG5VTu+Sk5Z3kGNI0HQYSehe2OxOc2hx6OmMWKWITfJ5jIatUiOvZ6Uv+oURPkRqJjCpAidlE7R6njgenBHZwpqhGHXgVuoX0oIXm8QsgAr10tp77AgKL+O1U9TppmsypMMcJq0lVbgWYZVFKF0rs2GJ9GQynTDfX9Phdq19NcAqKC0VasE+iLPlVG0Ern5q+GnTMd0UpXvus8cC/3moozn17XfBXjl2HtrjBxj3R4baxWn4rNoYvaNuTbzxx5pT41JpTxBQq8Fbtf6ngVMbDaARoUvWd+qeTUYDNgNaXRs/Tc+MDsp6Rt1O6fYGP1IWzNNl8Kc+0oCGyP4etitb5bOIYauPGWyyNGbAAQ89PWYnaFWZc/OlRNegR+7QjAxF3rZ28jZMDuAuHTwx5gpEWt1xGSy97mDrk9r9rX5Z6n1tRn28u+LdtvorN8u/1GE6AetbWyMsvgRGv0W02ZPaM1sLylrMlSeJvtaXPHXb7CGpEGBHpupBJMoMXOCs4Ya6xE1JdsGVedb4mNkem6qYPYKDVA1EJBIslbVEorD4AeKpas83mfggkVvh7u77lq2PTM3W7iEUcbNNxbJhnQGHOStHjKEi7D0Rh2z/IofTykM/XDyW3w733FYrdu0vqMuIj1uddXtoRQzTkTa5/D5Ck59uEZNKD60boxy3WepiD7uY6y5WC1Eft5ZitXM5Mmb62NhFikUIulSqgr8gprKhSZWZTe4GFmkxdQhLXsVVqA8Wb30l8uAksAbTAhHKQeXlrIbErPpYS/n2eBdMOycgP1efLq4ehG/klrsbh2JQGQ9rIpELXG0sVFVKLKpZQiKez2q1yN1fVWO96f56lAWo7tFwe5BJuGtGeLhzcKDI9qgk8pA15wvrkCXbnG+xIjbPNNQptVcXaq9GjkowYMieMm2yg3F8GYEds/nWDlqYqYcVSNAUblqR+4QhDycCU9yxGqVYVSjlCIxtIrR179zXLVbWFLZYm4S6pr0TSMCUBOpz76+09r03TMoQJ0EYJYGSHDpz1iAy1GC36AtkSfvq1VpfQxLkzcbdX6vmOv9UzZUjIgZpgSauZxvHZWczvpo5FzOliTqfcefWAsikuIIjoKVj9hpvCSSzogKwGVCZNhRqB2P2YbsY1RRUnknomS5zglaBcCInY/aDaRpBPK2WX+AdiZ1WVNE8q22/2lEQ6wqqD203bsQTX1kS4zqQ4UExvJXOSMWmbx3kvzeyb1UgYAtvMkFUxgTtgrINLxALLsWoc6L20a6iWIJl1qHw51lVaCf9yCgQeSMhTYFRAKQCdFIrf4HdQJ/HgGXBMsjyAN6cRwNYS7gamSXm76CfcEQYwVE1ikphIAhTA0GIylXzfCU+AFZEpzmu+tFvtOEJTeJfBU5kGVhEChsfdl3qPYJ2TaDVxYYToO8jH88OW5qNeZTnMGYHqpEDRGx/7w4cUQFFPcJ6Z1rLCrRS6TMs3LAELZJNhlg0cu30Hw8W8D4L/s5ZSHuOcrQQ9hHju7ufmK3md8mbSJh2JU6oWl3y9fCbWf/LGVttWwYYGP8b6FzBny0QpgxNEubVIHy5cWQ8QzR2K94ePec5iDaHNsjOQkFOyzzVkWS7+ZOmdno/sd0J0xq6wA0ZbcOLFK2sj1AEk1E6bhcspkSrIDeqnJ8MghqV9NqoIc6Y44wYo1hS+jUw7FM7UnVhT6G6rAWvs8A6FwLib6511mRiEjfjttf03EEyylutMQ/aPlPJlr8Rn+DA54l2F8jdAeJf+9y3HT+LZxytqAZAQKsOo1IksXTFeUCGHhwEp/kgQAcqXH4wv1q9oP30FA8Qp3DZ6o3bmKGhrA+KwQpeghetSLhrbRTOCeq1Y5ZieKP13Z2z5r0tn9Xcrfl1Fu4KmuT4p7luTSsI+5Hy48ytZYtDp3FAq9YVgb4zUXdweVEYJJjqt5mB9lS3gXbVjSm+nFWkZRppqpD6UUwHVvlvZvulaz9uK0TV3vvHrKroNHRYlXgzc75E/oXkesf/vfj35PZkY8X/UeV+nznielDzXN3hsjoJlhH5HGt3nEvpxUPhJIzfqsyNPSvzucyceyud907lBZ6p82udOYms7LcqOzJ5/5J5eTnXeb/IPKFiNR62s/2OQ1deHuXaZ8g441sbHmy/i29QeCyj12vfjlZBTir1qQrHGTQ9EoZ46C89Hn7vfd/HxHG6sZ2HbT0stKhDl8GvAQvRDoYvZ9x05eGYK1E73YYWQRwR08NA9FCAjaTusYc+wDNOXcIpCgTK8gTdkoGq8QhGKAclRPsEaKMlmYaOPN9XX03mLeTcD6ryct+A4IMdnFjVsYggV8/jyq0HDlA01EMUIUvK3s04fMQAFfAu+1pdQMMue6uvcCq77F/qOoKLX+QFTF5L3/XrTLyFwsk+gO/Ke7TaJU9jlJFuxBOWcjmcraIVCMkKFq4zaInZs5KKN2K74RLI/2CU4Ax64aAkcBED7QSyMWq1x8esgXGnoiaKlPnX6H1lGk06wj3CDpXgaaP0WBmls5y/9IH/UIAkylsZFS0RhkUcxeLORsAYoeCioy1o9Qm5kssds2kW3EfUh33WFXBeIAtPHp12h1AqdTJodtwfpU6CAqNsjHLq3PIWVKT3PhJbPIBk2tQqmGxTwGSyTZbK5DpJb+B1ZWygbcr0rU00sgnxvey7GbPDuv20q0wxscs0v6My6yiIJweFrXFpFhP7jlmeVpFgInwTRCFUP3p5lfCYskmt7JTs3/cVx+7KpayZ+kKnOSeUroewvWTSU1B55c/HX6F3upoYLyj+NM0GPZc84GlR2wyzFxMULWg7WmRkTMMqN4lB9IbVqOReNSo5Ie3VIWucFINZZzouZC4DSFbRKTLN1RDfEUSWjQ66RZjzOx4Yr+Ggg9orE2RJ0c5cBlMShUZ0nEHOfgynEVZ0zuD78O9ySsEw89yH5Jde9pZPZOqSLzCFYaX5klIi1iJ/U8KFDGXK4xAvoFvXWOQlwknwr2Eadr4OUr7Gm/8SoTf4FV58g0jM/AKT6K7Fz3yRuuYppi6gszyIIPXKQ4c9foZtvYJFwn/GSl+VcfCWX0YyecnfYfJnIAf8N0pF/vVbPitl8pJPRHLBf8XHf6XVxs88SL8hZ6e3vJzpi0se4gWCqPHCl6m3PFDJS56IJA6YJUa5XcEx0wqAh/Hveoj0eCKAbuLtWIKeL9kMNO706FrEsSIlYI6qXfx8MavE1RNVig+IsO01wZA66/wgNMPsNsTYeCH2Z9W//RBkaT8iIE5KehuaGz+QE2JOkFuS7qos4KvRnfACvckw0Dcr+Tf+CIO1ZtffzBfxmIUiQz8pcmdcrOjs7k6e14dvY+d2K7CKDvU7ioZfRw6QJ5njDd9al2O24KiiDocIth67fW14odwhYPf2h0mEIWIwlC2lFmyix+n1IvBhVPBqFeUvV/yNp9Jr/o1Kv+U/quQl/xKTV7ge5r5IXfI1pWCT+ZCLxFt+LlOX/DWl0jgGCgUT1y/ty7f16cJ/wvBm7Lqf8bQUw4ymSyVLlZcj90oZWZWnFUjNmCsPyD4aulRH1a+4TpJHY1ihCyK4pCcjOQY4U3Dfhmnml87tdb+diWdcnHQiS+VsKMpjgDcC6r0M/FrpnCxL8SJz2cpr3QrWGFJFsgr1Ig95DeSR7UG93FqDUCMM7P/2oCbqddfbg7reNajYc1zmcPPhg/pBt/LPDOpqzxwVOk2Eu6OeIRyZ7/tV7GI9dlsB1qs9qIKs5vxEyOh87EppxwgMJQVJhpdB/w8t3IdxfouGQyFN2GmJU3FZbr+5t9UuNQADOPf1443FyZMG1tBYfPakYVUi3rP2gqqCRSkrgMeedBsPabvyzpU3hvoOzdpY22/ygQSi2UffSH296mJY09db/a9/vee1r/e1/Hpr+npr/fUQYjr4+Ndb+/px8fXW9tcTldz79eby662tr/eRth/29dbq64na/tTX85HDWvkytb0Mv2V1XAh4Oq0QoJ0BnCfIB8MuenTkAFkUnMVScRbIEgT1ije6P9vT6T/Ui/X+XohAnHyBzKIIvFHjd2Szh6o2+IrrOWwP/YYo3pA1CfAH+2ET6FcAb5CbtOXqrxEjZA1pXM4T/ntBacEFb2uf8M3elA7UdV46DToKNHCQvGxKHtG5/NwYuGTmRdnut3lZOmUk9MJ24cq0qIRHhAfCHQ9c3vfAzDwwCWKvTLw1MeE7e5SGzrflVvmLIJ/tLf+dXV4cFHbs1VI5ZPHGGO6YvxACN5opcSg/T8bkQ+KLmEDQb3d3ogzJhVr3Qpe/3F9+bZVPJ9NK1dBLOYpoeaM/qTaMED5wnLRhJIlXGq5EAgdqRVeG2AOEiAvv/pU4CWopQ7JHyiCwBBN+PrMw0BSYYMJfV7Ln0WQCsx/yP6h87bqxTxRBL2zBDSYCxp7G5meB2oDjk7AE1zNL7XG6/IfG6YpUlH9zpIp0gW/+Q2VEZM2Q/2LPSL36x0YKRglHa3ukCn7oi8QuVsvEirTIyTWStj8iRxCoFap8VWW7Nvz9dbxUdax1HUIltHs1/BzAEvwyIIN2KppM6kYPf84HC0VB2q+05osFjU5KPyABb5+OxVISgqpqoAnUvPMSBpNCGBE6NroquH1xSajHcNzFLHe8oQ4jWk3xTZ4+x2Brr1OddQHU2yZbvBEk7V9eN2DONnL4oAjwqY7RF8Jc3gJh1IiWIoBrwVv4qtiGg386v/z8lXMSPGYtDGut9K2JbBodzHU/hJ8bPzc9exME1xNv/cC+nf21vnW7Pda9v3skwXmL0pJpkPJpKBJfqd3YSJ/qQb4TmwXM6kG+WUo5Beag9xwL7GpNFHA106tR623NLcG0OinWgZ7HqFilabp+8DPMPLQruDjq/PCtEX3XL22uoybCKHint73mpqFD7/a1er7XxeDOtUclTotoKJq8XPF3nkqv+XOVfssvVfKS/yGSabng7wKVfMuf6/Qlv9Tp3/gfmJ4FK2+aJg/mnGR5yTrBFco7bPIu49iQhQ9wvDoWbVCfA7cfYCS5Nn4LuLGZGJ7AvKM1+xZoDP8uEN4YAgEDg4QlHaXRJbsMcyl4ReVzP66YYiQd8RL0vEhy/T4WXlfSye7usGHWyBC7EfUhPEBMlVcY5B6xonVYJxQai1imPkywEhj7UHRhptjViRo6xLsZ2LpcfxsXbEuCvWq4lWfKBzyzbqClh+wR2XpgZxH6PuThMBRC6P47grxmMz4bajiOiUou+EImtX2I2EfufT8E1QiPjkZjNuUz+l1iXGdCr1/Q741Gx75GoTlqtw4RO3tL8YY2AVERwd7wIajCu2cHwphHSfMrsnf9dO6niwD2IBSVN5gNRk3yVCj1Gwr+566RwsvY05kKPR0jSPUK8ag9MsIJgINIFSr1ISIBiRjTHQxirNJrGOSjo7W4nMMHC4dRPxxlcMBB7PCjo6m5NYNbM3ULxmlpbk3g1kTdgqFbmVsLuLWQt3a9udgs4d1id3MjHkuVXu6CR52VMNFhZ5Bei3TFaiJR+oUby2piZaKiahyJi/FQZt4UzhXDDPhoyyBDfQkZQ11spGmFju10bR4/sx+/ZphRe/xMPY6CqKOjWx0Lar2hPBjNW3u56zCwFLFUlIFhlZRVlVruKIXWHXIWG9uQrVI7UMClHtO5RfAmINpwNlyUyoIPlotdCYsJYifp0C/LhGt2IxOwKoGO2MhkcCwjNXfcDVoACEMTQXVJY7LDpQfpwlUo9+oZbvn7jmBFqA8zEZzBCjyD/YQXpIF5yGnMnOczO4YG8vD2OU0c1C72HNSkPx7/ltJqyWf8VcCkbeYiRdSk7wMvAx6R/1zW8tMk4C+qmWn2pZetSUAQ+fxV/eYrL5mk8zdefM2/LMlvcRpU+Fd6R0Mw8GXQ/Ck2zAsijCJdPpdA15IWTZGDIKpGlL4h5lRDGOALIkMTVouTEu7YloLnGJ2D5NLusOELqEYZSHnDi0HE649vNFSo81XmoHtu5LIydlJGaktksLBONBIcUgFKCow/mE9be4k6w4ghOSDD6YMkPaB5fBBSzDj6bBjAjp/7MvWWv1bJS/5BJb3slY5v93aHvGhF0ngtLpICSJSU0+tXACsz1wLfs+b69zitXgldZsRqMj4jMNJ9tvu0pR+APq3/gT79jH16YfpUkRpv9+maRzhiQEj4S5l4y9/I1CX/XaSy65wnqMIUQJuwRviPM/tyj5xjzyn7Vlg8FVIxDHPlje+QuZmkCbrePfKQB9f7e61eOthoY/O3KDIjtXWK+rFFSguVo4RLXcCLWVeXHGVTncyriuyUDRQJD1C8JsDSKtI12xv7DAW9+kikWb+AIsptZUiufBj0BTNM3/InQcAQSI6/jGXqLf9DJS/5c5Ek82L7kIAyYjVCtxUsRjpXfwN8L5X5gIeuYSF2QWqL1NtfRzJ5yd9ikhZnnXyRdabFHyQCkRio0jVheQBTJegNev5aNob4zts8pje/iqZlWuaSEpDxPYV/GBwoFDRxK1dUYhDwywypUsJEGxubj93RhhIFbLdQJ0D6yIBjImxktoWZu0ygClfDbe8SDVVtGL9FB/MdZow/UcCQj1gGaXMbPIQTEjXL6GvI71AZ8OzeAZc2QNZARwkwGTmOA0czJRzdyuBu16flLHWLooHVX9gzxBoVhV7iaPBvZzrjHEaB/2SuL7yKTtA2NSIBF1ka2aUv95Veb5eOkvvqDrZK31e3KT2LwmIPofx1VhEIU9E9tO/XWUUWnM9KtA6xV3gQTJSDwTbfJBd6xl4G0pypEIhZGTEm/UAmzn2Mmu0aYpC4w8QQA/Ij+BHZpHwxC7JtMYQ4dxcUCmrL/meK2MUwafuN1/Q0ntUrj4lHxAsuoutge4XJ2D4zb4GMzKGn9za+8iTqZBWomfcE5Yx4VtG/ebzzmEmBKRzJJcIxtJ9j6FjZ4XNPMpA5k03uw0EXbVRb0NXLNyo8NARaxzrd+/My6hvCuRIH5FuhoId3R+FUCv0mwx0M2ngdozEZU3JfSywnGAT5pAfPyQ9LHTr5z3Tor/fokk/1cF3+3eESZkvUu/Xu4ZIKha3OySc9eM7u3N8drj0d+ks9Quxt/l0kU2954cnkJQ8oSVZoi1ImL/lcJOeB5oteUcaC/4ZDbgxeXwR0GQQ8n8kU6eXehPIKUXD5j3hVFr6u7Su4plNlGvJ3mBZ2bueeTgMHby6AhxcXGUVPbnQ7Tzu9zxqYlWZpkkY7j4fW6W2X8heOnAEeOW9FzDWjY8ajIJtjzEa7ArFOZXv36hITc5C9kTZ7dvcQaT3YlsJeIDlF2R5Xeo9v0dYDmDo6rpYz9eyScGagzDJ23kTOJMbwHO7Gau/yr7S3gvbWpr1wu71V7PweOYtKe3BaTm/4O1+nt1SQH2PQA8nrv/MNTy6q2tLSPaiq362q0Mfo//wPbbZKlR8xAwA="
-)};
-const _132otk7 = function _plot(plot_part_1,plot_part_2)
+)}
+
+function _plot(plot_part_1,plot_part_2)
 {
   // We push the source into a DOM element so es-module-shims picks it up
   const script = document.createElement("script");
@@ -30048,14 +29670,18 @@ const _132otk7 = function _plot(plot_part_1,plot_part_2)
   script.setAttribute("data-mime", "application/javascript");
   script.textContent = plot_part_1 + plot_part_2;
   document.body.appendChild(script);
-};
-const _1kd2cgd = function _d3_part_1(){return(
+}
+
+
+function _d3_part_1(){return(
 "H4sIAIVV/mgAA9y9e3/bNtIo/P/5FLaerH+kBMmi5CtlWm+apG3a5tIkTdOqfrw0BUlsZFKBSF9q6/ns78zgQlCibKW7e875ne3GIkFgAAwGg5nBYLC7uzXJstnc390ddv+ct1Ix3ro6bB232lvP0tmtiMeTbKvT9trNTrvT3XoVf+Zb36TzLI0+/6/tUZ5EWZwmTsYS966WXvzJo6wWBNntjKejLX4zS0U239mp5cmQj+KED2vb+uNlOsynvJ84Kpfr1zS4AoIstbMjf1vh5bAvH51BTZWrnUHdfuI4WVBVzXiaXoTTD5N43i8e/ez+fs6nI7c17AYZ/Lm/v1u4CyeDb8wpegV9yud8a56JGPrV0x+2VIcFz3IBb/l0Ci2+v5cPSf91+NrPTpJ+0/Oz06SPfyG17UP6wsDgj8NITjKEkZxmffwbZMswBDZxyrMtwVIWFu3LETbjQZvF0L0pT8bZxL2LRw4/iem3vR0EwkmgAa5qQNwbpndRmswBWMAb8enpqddLnWwgEL8n7T4PRMPz40AsrifxlBOohSrM9UMH4OoK+44IEpYGDmfCDU4BZw534ZGFAdTMISlzErfJXR8yZgF0+v4ef3g/82Mol0HGzGXQv1Hm5yziScaFb5Mc9VBYPZTtjwPVfyaantvTHTwFOgqhQ3HTwy6dNukFH/uQ5McLRsS+WsO/C4fBY0hcFCMbO4Y02kVqiuNdohigCaSURraQ9YbYJJflQdii3rAInhCDbARfUrcl0di7CsXWPMh7stQ0GDq3LpvAT4n65dckuIUXhUfACuCVwQDBAN7JV0ecnAQdt9FmTqyfUnpgKn/DYzH8S4uEDiR07IQuJHQhYbFw3YKSh1aPTctoaANOo7DtODxocPc0aLtuNhHp9VbCr7fehcmYvxAiFU4tTq7CaTzcEjc1tyeLiKAhNipyC0Vggt0NwywEqryOh9nET9mEE6mEiyBRENPgVZhNWqNpmiKeNwFOwEyTQhvAVQrfkcDCPlSrqG93M7CybQpuen+/HcI/oP1toek0UcOeB5BMszIKBD7B5BwFcWs+jSPumJmT7+xEfWfm5GyE485Cl+FLDK/mxXwZO1HxBV8qv7h+LiFWA7G/uH60s+NsCJYl1hyaaS7AYMKOAEXIKVOY0DBJ6nEvPQl7bkbElLK0EQjmuUXh8WOFRa/RSK3yIbC2ovitPX2sgc1oWBKcuO4yWVslOvWs4ekZp+Yb9A9mnKK2ZhACLcSa9SCNwnBmdQEcTY0uzPx61tNNz4KYJUHciHqwMvWyBpTPoc8DattlnDgpy9yzUvZRkELmYLQmdyNyzxgfZGdBvpuwvGk+hzdOzLImfF4ssMOyOTzImglM21LXMtkxlhddC5tBDl1LS12LgqQeD1LdtVGQ1xM2D0aN3GpxCh1MGyPdwdyNGkFcNDksdRCysmkQ9pKTYNpLqnInjRF0MBskZ4ETNXjdiYv+QVXNuXvWWCoASa67K1jUDJYyjxAZhjqu5NqP7YAFBilCTnhcBF3Twi0QXzIX+fx2kMAcSIIGLFv42GjwHp/OuVz7g6ZnuhXbhZw4SGAoGg0BXXcBQhw0YiQbglCsO6Zd5xa3bd/rVa/4flF833ay07ZF8JfFJy0HGhkMxJqaBAVMaiuD9f2pEOFtayRSLFYAubHwAqSCSy+sJH8HQ7AoJM0YlpSA72L/YX7DCEISLC4Gc6GNubyEuRwwlwPmQoW5PGggVeYEOV+FnCPkBTRTnHp6Yqe7DgogRfeuZff0fJC91VyW94lg5l8EcmTfGpVXJaxU4EJxjWVsmFwgZWukgEgG8hY/VSgCeewEHzHZxkxsYyYtYSYNcPY3GrHCjFVLCtNW1ZJSLfItxVpSqgVmtZZ3BtCXs0U0DefzrQ8SJyKPMqjTvUM5vHU+C0UWh9N5gCvdt9M0zA72iHCcLkgWMk8StBfhcGjzznLhnp5kujdAVj1xokrv7IiTbqcnGo1CeExQXAPxE3qo1uTwYg4VnJjn2O1nTeDBsevH+As8LkTqG/BG4wxYJQNepGcXJJ6BKKtby0EKwucFrNU5fzNydL1ZVbvVAqQ+JXoqxDDzaE2CVg6aTeD4kELkn4LAKpMgb9IgMQlbCAMNy3/PVRnFCfyVkvBJ+/5enJpXgExj1qkL4qYcAMJMwtFLkUZ0t9KFGrqXKE4mr8IZaHsZT4bzLXguDScQb/CaZLV5PuMwvOwN8YeW1NXeihRSs5jPpfp1dx4TSP+OUOTj4APIBTv/zG9NIkiJTBJkVkyBAeDrjGiVEDbntDq7izE8FIyNWtHCtKeyRqDjxSScr2TBNCsLgrNVNpkJU9/rTPB1MeQwcnwFmEp+UcArIfA9UqlCIDz/H0Kg5iGEPpxWyUaYUROwlAXT3hdZNseKYXtPHdOTTLY9WcBoGgULBCPDPDNqkoB5SQMrSvzz/b8EyMlojAWUQFoyUF/8Dag0tTRklunuCxBcrfa+XtLyUKfe2VmxrsA62jJcxM+K8p+t8lbyMyCkVqtVEPC3kPAZ/kusXr2tylSs1ku5/5ITQrNWHnjAcBIlNvQ4ycjcBdYG0m+YARGileY0a83SmeOCbATvDk1aEP8GUC2J3CBCuQXmisqekEQOufhSD5LSuDyvzmb1oZz/HWIL5pZnmS4sDUspV8N8BkpRmPEtGOla0bxB+6wA9a3WGVZU1q3MQY0Z64FFUuhq9NIPK0pP6+9YqWGqoMiLQQqripKC1aqslgycrHGx8KHVo9EAbQioCbR+pDIQL3ift2b5fALd9EPFE0FoBwwss83Q1d9BAoHWml6CcIvGMWbLe19KvNCS5xIG69Apis2ulf0XQ1eAgsLQV4iIg/e3lxfptBVDz0PgemfWGHyAPGociODnW/F8K0lhscbMF1MOA5IFJZkS8YUrL6nnoOWiYYortN/faxIFWc3M119gMnc7NhDmUB+D08RChSnZh24mkoaxv/SEQhSDNSEFGQ4Lo5HrrhgwgQOWFAP2xhEwEkxAQ6VaaBR0NIKgBBVIuLwEFZv0xkHNC9SvhKYLw+EQZnXOZOaXUNAag5cw+eQAkLVNV/amt2ZIqkcgSi9BRuF6CEJD42ZWKOuewaxchTUGxf09SouiL3wHH5DWoJlN9UL2NGsVeGPTmWPMpKh+wMoFxZTBFJNQynXd+3unZHwFqkVr1zeKQGYizVLsojRzFKam3wq26aBxUlnUfgoKuXy/7bI/rXcP3r+33juW5eqTZAYFgYH2kbm7Rits44IS27YBepymY69NK0IaCJl7ll5DTTitwwC4x099r+3D75/9ffz5vt/xPan/s4iNjLnzpN13RoENAOTVXVC1ZZpI8wRW7foIjT9WSoIp+e7oJEMlEUDujlBZaDYBdgBqrL8ENHbryzB3V2BiSl4vYNY1TMh4AjpVa/8ETVH8pNOXaOvUQQUaUIcs/vqdRqlt92trQ8HgDAkZaLuRuUBKUhnU3zJtOoD16SRjAzI7nAEVfkJ2BzB9PV7SHJdaxpXBmbGXgcwPAnxETFqqIjkVEC78CU/abmGNaPeykxzWv8yN0EZCasJuMyQda+vhbHWV61GYcWMjmJgNYCrKiAqEftQIVZ8+EfYYYo4RdgcdC/2/6tz4qVeQNeL5ROIdCFr0P2qUavCaLwiclJ5bd5A4vd1m7McWe/pdgyctjda5Xq9Qyz5a4xMjA5F8JIaJH8+/jRNYC5xiyCAvaUV9aJdtftsFekVDGKVFPJ4CcWISaHKoE+nc9CWD5F2TWQJIKA3YcRBbTOpHS+IyE9xjBSg9tZ0ryKmYwE+vO27DNg/8DMogcqos+IyVwgj8WLATATR2JzlYPJekJ5DVCXvdA7ZBln1lVDOCxjLFIm5j1CWJTGIgkxiUVAeNhyyGdYSAjECEhQk6DUYg5LAJ/HhnbBhwJ2JTNpHzpNygoVtosxMkoKE2dr4C1A6g1FnwuwM/yPCZMwy+0y9Qw0kwhUwhjLPOMBwMVftRMQ0mOMeA6092dghkUZcu0jOEkKGoncHwTwLHGr3JboYor2d+RqOtv9IYTepN+rrbRD2EptRQSqokKiFKZoFuERsHbXYbzHrDwRib3nMbjbGk2eHgFts76bnN5m3PGd/f357MsD1DKC1N62N267JZcNscS1RfsXNrgGbQCGuIoBIcI+cqOMdhGpy5rZt2gLQ9JJXdn7Kr1o0XxCczTDnzJzRFNCpCl/hleCoZiT3sxqKD4w8tnJ6g/SY9QRSfF5bNGbNQCAxqCsuI655JqRJpxl1hV3YtSAJrKyoG0a5j2kyBYbm9UiOyhjMEdnaCRiS78sXCsL/NOzd3hjBH2mxW7oeaw+dakBJSwwqKrSczz0Mxzi95ks3NdmcWVOxgJ/3E/w235ATqaCDGDdPLME4KiNkDEJMqiGg//c0ZoOrBMpiTZwQ7QdggsPH5JJ0O55vB5+vhl2d25va/aUXhdIpaREYVcqiw4F0/WDbKzS2U/ATktsKACBMbJThlmvxbFm5+EpchxriQE0R7p7XQy7KyybnpMbJ9PtIFNH9u1g1cKdzyAv2wPZWfpGVgaFWVwFIJTNNm0Ysk+3voP/23o//069DP/y3of6AbX4/+069Hv8gsbwRvF4XiO1r4bMEBlfJlYV/rAShPrHwDppeZ9Y+hRrANxIE9Tk4CYZwOMrVUmDbH/Tf+S7QoiFPeo4aIJj89aLc1rwXFool26DBI6FdJ7yiepCi5t/brlMBvZk6nnu92cVdYJ5Kek9ejOiwEkbsLfNoJm+luByQ6Eu56Chmmf9xePZJmWI9208YIemN6KUo5GgA4dE0uIBvdarQp9OS+DUfhRnY8I/8BQG8sHS1SF63ZKhlEmRDWA2miojTca6R9nWYz72GREIuctHEBD+UCjqm5BIRreL4grDpoT4DEvgKdgyqEygy95jQ++YnaZclhBWcwSjlteuS4CbRqz4qzZQ2ROkgbjlQXGTAsMkup4iDRLj9xsE0zxQsK24b8llpWolCSu1lnUSLoOXEfN1+xiz7NMXiR9C+CkHxvAHjbXlpL8w+KcxDyhS7OpdouN5Jk0YppEmaW/pYF9o6OFF91zrpkCl+/6Xcb8+lwy+Zd3OZdojTz0UQrgBS46Tn5hAgDR7i4fy1lVcvLaGcHFI7X4WulYNJMPwlwG+WkYww4md7pPw3MfuAPmIbiHg4dbQ3WcUvHIn5S8X9waAqlbmueX4S0/LZZChRlcBo2HKyg+E5fcdY4cTO1rSe55kzS9viV3WiAII1SRputdIY+CfSkgj+sol/hUr/ygIrAbMMtVeNa0nBkcgMghbg35jZz6kZodyMqd2Ol4aKCmNB8l5DnWepwyRpolXJpZraN7RVN8csjlVGi7tLDlkF0CCnYdG53O6wX27sCLcA5oDJkhQ1Pmf/IhsecPIAZHtujTnwETeaY0SXvn37uNz0LNSN7a6t6Lrl3KxOYCLyeoHuGpYDOSxtcpEMXH6dm9to2Alh4lsVK96SDkiswFFgPPVSsu33Pb/Ce1qLUMt++t9bAQg2TZjJOBrBCJ4LlDKSMk7jnpjCSQdYQda5RmxaNnBgWucwXi+HGGd3THBRakpat6kbESBnZKQr+5kued9IuGF1auBeSkXGYBbNMrt8iTEDUtwyCM3ukbF82EhuSEgOPYYmW9i21JPWsVcJx63GzeY+eEckgbvCznvzBnWv4YfLH2oK2yGWcqe2ObcdyaywMXXqMEsQMIBLRdYsCvzUWHMciOQHhQueOCYk4E3DxWhq1FEctHKS4qqVnuMStLg23Nm5W/U6uSp+3YkBEmESorJjdU1Baip2T97Tha/m1ZGXPi9XdBkd3EYoub7FYFvsLzdflHihMf/iSxUnOiaIAD3K8HLXNGrNhmnA/XQAhJvwGhs6VIlmqUA4ruF6YAXasYMsNVb3NG8/RoOa6F4KHnxdqVLctt9CL7F/cMbws4Zco+SYLPHadBR32Kgu67EMW7LGnkMabBwVJv7fK1TKg+Pk0zLhTa2SNGmu7NWu3tDpnm1FeO+frUmeC0wbuYlmbm+VNeCVjSyaStS5g0pFbpeM2O8B9dzuQKI3QLokKtlUad10JPncbibVPmhnf223peHEe3sRza49UNQHRxIPBGVIOIB3YAf2kwQHMhANYCrogTFf5pF/HwBqud3bkb2vIr+KIv41v+PRdCDWcev2239oHoRv3aW4y6Rb9gXzBPTYP5JtMvc76tZuaX7utsWkp+6us/z7zX2TFYE2ciWzzMJB7JqKftLI4+jzXv61wNpve0m6NnyhDBRCKYDNVIlY5v03FZZiVXuyyl+jAPS5GJgVaAEn5FpicQIdVmGxXQeMWRItGxM7x6bYw9EHSReAkxVD2P2f+a5A5k1aUzm6hbOSyywA0ET7l1LO+9QzNnbCb4FKlPJ1OnZrqSc1toRevM8C+nLnseikX9kXnGcL4tlIxJG+LV8E16EIgrrvsAz4ii3Fc7DAHMqqNoVCYZbg1hg4dNVaTkNhTyCwrcGpToABIem8lZcAPam7vJrhpXXIBWLkxoIHBcRAYajPAIMDTTSvXYnolk+eZSD9zSI9yIQDQs3SaipqL/bxWFXzANj3VL6YDsm0Pg5Ff541ap8ZG9dTFrrxfgSS7pCCN4ul0HRyAMdb5hkC7knL7tTa/rPmKfGvt1qGH7/DQ7cADVDoBznYJExmRRlwkpkGfyF6WU7Cr5RRscjnlVfCqnKLalM7CKM6gYU8znUTZgLlf1sonRPT6b0zPAXpJuv2pgx6yPnGQMc+eApD4IkfuWEByF9CnD19fp1yhCTTuxSbZ63TIFZ/SqytKUqAH62YlqONBsxKfmgdNwy1m9qol+GV6hVPyRo+HHA6Lw4T92qtaY1QPgavXGleN2ve1RtSofaw1zukZvviYI9Lf8YsvS11RGpX9SDm+p1Ifi1Iyh/oCA7mMDm/DEZg62DPZMfZ0mWDZ+xLpIaU6M2AkLSBTnHTPsiW6TVJrVoxglW/O479gYnjtUuIovIyn0MraHBrXhGkbj0wprKQJgsoEKJ9pbg2ii8gkkQNLr8G8AQq/jIdDdGOA9vAwmlinMLQzJI1tcLEoXPCA60XhlG9qSc7YhKzEE8nrA6sGLRvbW0kGBEw6XeipTtvUuqy26/uDs7LHLzaF62MGGvpHcu3YDLQwoPF3FTgo8WIZvlynNoMfS3TFuux7GPrNSqZBiOoRFE7twi+ThItNIVSUfwOcY8Pyuv5Ql38L4mScjDcrnavSOZZOR6M53xBlkSoYQUGSIP/KAiUFozvF3WJRiCJPUMTSygPqkm30WFoCCWLV3aKHegZoG0pnyYpcoEg0ajUXmBToA+hVsjv4Y94624WpjXqsu+rDBfOaj8PpFkph/hYInqC84f744MxoSpD5Oer+ljsZiaNyDgaWyPwuK3zfSBBU/upaeemhsgoqK25/oR8PaK1uKwkvue16w6U4bnmQGSW7UJbXQUWQBcQ7fA3+Qq07U5QPaqULMlMShWQsojRBdiSpSZQUBjwJJHfC7hCmnzA5dnzhsmzxPCv8ZoIn9ovtqeo/z1ialA7QKSnZ8mLGE4EiiBksjzB8sPrGlyDxzGdTELB2//v+j3ljV7kGrq54tRr6N4N4NOQ3oMPUWvKUEz8NpPuz7iVHu4mNCDQnZHgECtW2N9eJ8pm9raSTPPmcpNdJiU4IVXeUAr0iBJGPFsMzBCDqp3qAiEyXSfmkowxs2mhZ4W6VVBCsOtGFG28XYfQZG5Moi0CjQYZt7H0A0yIdhEBfCMqN0WwMhBSTDZkohCXFFq3ylyLdnePUiatLQLbCzRE91peqXamXLN/vSlBcs0vBFwyld99adaSrw92CaZd9Y3ygZgE+yIEP/iwfSFPTFDR8hqhZIjjZtuUhaHZctQNeEKRt0iDf+pSYTeriUSOL06SNDvkWKXXwb9KQdNhHTodmWIKEVj1NOLpuAXVLtmBUqhg6Ss9LZ1MlU/yXGyXZjGmROnQjDEWfpLShjjvkSw3jLnB1LP4lC2p4jNzf3b2+vm5dd/Ec+a53fHy8ezPJLkGe+gWGen419iuyddrt9i58qzHK63/J2A3oJJ+r8kqQ+BVyQ96KLJ9e/YTZjnaRAucgRXLKmszX1k1fd2vWAvUys8TshuQ7ScF3/MIDWPKeGoGAyRxYXIjYDvkU2XzJBVQsD1bi9u+opf4vuP3DpinQtZ8tbBvNm0rzYUkXgLHl4nkaEdkip8REg4Vf3r00jYYl4wvwQ1TyZe4XU44/pdyUCZT8CFaLjKsc6ACwlPT6vYN7KJaV8Zs1bbXYSbmxKwABY9gK4COECxv4b9bY0DgZt1OZt/9N5r9Be4G1iv+EAkfx+ueywQwlyZ8yf01Tv+Rc3L4ntZ2OcFqN+b4KkhF3LfeJtWfePhXmpoHt61gF+NNmTXxKfhpWKz9uMB4gG0cTPENiF/y12mZdNKxUDMfk92zFz3YE86aYWj9mSxWPYjHX9PdsEk+HBOfnKjioqRWQfrAg2chFoBECAs3YQnRmy68F6zdGcMudQq0kq3QKM7k8yVamWFCeQ/rgF2iC0jpoTnkRNPV6jkan8/PAskLypDiAjCcHNKNGt742+vNpKXlUyB75yQg4de6CCpAM8jMXdIECdop72gL+BCEoX/iLOKCu4iclVuQnUQkEHhqVZSx3h1LTWCgnIznrMnlYD08uTIsmTkwT2dBadKeyTugPVDuV1Uam2iFWOwpC6XYUsch0heUwOCA8sjkZ4Udun5oY+fLI14hFrg15QpANJNldgJESDKiR7DMABvBF+LHrkmib65M6kGkt7qr7IYFjZ9ApOdL4jCx8lhSrzFRtbZxbGVaN+rD6bHS4Ni9HLXk0QEmUVDMNIllpNSqMWiWuMfqKkg/z+nm5zcuw5rZdDTNaRaebF11tQxnUZC0ouQWQKIGIDrEVhpOeZNu8vwZjflUfuF3x8D9QcQXCVxtSgZFSw2Zlki3xRFQky4v7kI/CfJp9jPk1qOtG5oCM9Fp8tfYpHyKheXY75apflsBrte/WSMgPgoAuF+XluTBr0/EBGFJkfhj9ov9QY/21zRDlZpwvTVtVZlyUIcMZLMr39zQs+OlZejmDYRy+x7xYHrW5qjLWJuIajEvOR0s1KAdWwy4fnGBoWLE3nm/+RVIuN8PXVXCriusyUVZaFqxT9eXctKvyUzzHEEx44Ckp8U56VVagJB3y4kQ3rvUB1rxk5Je7NDAmtZoF52myZDUKqBna89EcnVS+DlwewkXbkXWc9WthKAv/EpgXa8YbmygP41qofb0m8/uqzJ/XDrWzZpT7TxP/feJWwHpmZiwa05+lSYZyU83aL377EKewC2UW2L/WFFLK1BpaXAGpg3XVar5N609M/TGafb//8OqnUpOfP9Tkoojd4Hd/v8EFwDXN/dbUjWLq+/gC1OsxMOel7SW5yUcSOlVkHwY1EGaCX8VpPl8LRW5tfsOBerka76UcpA9QNfb5UUtdwW5YpxoLW9ISpB4tRZL6K5v9ZqloNE0TjiWdbfTfXIGn6+8nS91gy9greVd8s76a9r+xmt8eJhGpaKSJPGi6YrcmR6ikMDOnZGbmMhpGRha+nR1Ov3RQGh/u7zkpO5SAD/1k0GjEwJV9S/J4cQUdQ87KgQ4dCYLx1lSlwGM6w6bO0VkIPQxkG4LYt3g+Nd0OkPbTY6uzMThDQehaxR6Grc9mSjlAgkzKWhl6gSby2JmxH4aAszzQgbnIx7jRCF3pYhkbm2igMYXbUcpUryyjtgZchSch8SQKPAmDJ6bjMzxSBD3WdaGAuwy9aR19pCVR7GEFjGwxKHZ46jhQNm+ZRoZvZSBWcSSYrsxPmaoKj4bE/Vidq1GSDg5DALRkDeGfZgilOEXSC54gbD3L51l6Sc3qVZxQAeCkgMXS3cTBIsMlSxKWdWr0U3MZ7ztxCzfCZToUa13kFxdTPoenCH3JpniOHGoHcTQL42nA1YPrlwtue/B/l4I3xCAgZ9FEfrFPMn6/dgFUKX/qZbOsZ3z6inLVHB+gJcm63ZkkYRYP9ytmhG2cqOQ9ZMhwYXitb0vm9w1AQadZyWD1aFtWLHBs2eD1dSC0hYx9KGEL5kIJjiXjGeNv5sqDotYnFV5BowgXsXmFMGiLjK0/0zhxals1DIjEJAMoVW1z7eUG9BK54WV/RTE3QgdV719oBzozhjBY65G53BRoiNoC+A6mN3lWFQa6j7Yd7Xws0nw2N5KzHJa5bfP61V7kYX5D+cHATOwlU/XZGfvO1l9+t40kGLE1Gduej6vwlmkKAK6vzPUNAF3zR5t0fl076z4mTHp8lZBaFW+BtgrINO1afrg28mgXwuyOl7av5NFHTjs1urA8BJzgqd4oyAuDIe7kWKUjl82h9JxMf3PXSYN8MCcbXBiodRF4e2F+m7Oc9jVqOgUNTxghyrY2FssnGwG0ICzt3n3EoxclOgDqM8545TlYfUbxofXcpKB1fi2jRCWcrOwbIXuA+2KDs9I2oW2TTQbpEpbbvRFhdITG1HwwIowKxSwkWkNWoIyNEK1MLZuhu4qv2ODoYQauHAz1psGPWVXOVWT9bslAxn5O2piz5pQo7Q645VZBmUcahrxXt+2HDdv2899vm9w12Gzyffz3Tj459XKKwKuO4Qt5hFuRRy7JIw1CSR5Vs23EQvgSSbJIH59FFKl2ZUd8e+WURvXGCUsTefAFOtsXic/xBGWpCiNXS6z01iJzo4HNaB4WKE+NUM1CC8cpHiAqvUblV4nPlPB5J4MbC8Apm4I0PsLoBdNiBwLN6RLRczZHC72FazzGVzrljxPXPpvvslsarVJajwOoKRuzWxaVv01chr7Epn9X7JxdgPJwCe29OMGT/ReoNVwF48HFmdTKLk7JxfUyuMA4ANvOeXA7uETqaDQuoQQMj9pPOpfRwvWJAEci7COGIoVutM7JmzjIkceg+3IQsXDBlqJoL6+3cmgp0/29Pc7kkpMl7gq9IehH4UGeDcGhPLLi5mB5KCgXaUWFeFSRUsk9W82NSo6APhcYH4OO7gjbYdz1MUG5MJNTknW2mA44q9ipcakU05bJ1LjQ+hxJUezsxH2hfKNj40aOzoSUVmJFFquxHNqzkkO72crXjAgtz/o5NkecLJ8NffoOT9fi7mFp8sQ4edq96CQE6osMv8K9Oz6IcMoI/JkE82LK5JBSpuoZgJjR3trMdUbBfDA7u7+fwl+5dzc7C0ZqSzEil7XIJRhYwxILy9cIArHtSlZaSBaMcGp/Nc6EZUypY0xZYRMtnVsiIwE6XBRsh44xUajhZjMF6bbnkkafSnloZ2fvv0VLhcDS+xtvU+U+jow6XGvsEhitOgxE2auKYaSuMkmYbWjHtm8ANfI+rOoFt+KFjOVvJ81tvsgw9lWQW/xmhXIMtdjuT0K7P8mg1qXNZr4i2JB31HrxMTTioxb8RjIcWeIuyiMfL428nirLbl3aelZ4ZLUNEdlpkiWYoyi43W65MUt0o1Y0r6CrpXXQlTk3IrG2TWHaX9VyrEICW+NTdSeNSRS1G8On6FU5tJ0zgUbiv0pN0WGelk8tYsMbjcwQGHDny1l2u9pd6TSGPURso8v5Oq5UFoDaVfEd7VOA6K7HpHUsXbaOAQsld0Ej58Qg7RpqDlm6NDPQib7KmVR5/SC+Vv0s7bVC9s84PSn3IFHaqUHnJbXTyfV2aDkHCHgLW4qVDvralq6hjhI/SqquMCmyDBN/AhKVepsm/jxxHU7x7hht6q2se2ucrU+9fkVLxmuqv0r8W9xbAZB6yarVfA7r3rlanyWeUJxmM7U/WG3U2awhF2sacpP4l7IhrjIKyopxW5GRaYIPK8cbt9dwXV435MVce1Xqkavt2rzg/zjzUOLaRjYurR0Ox9g/xYFMc8ByddQr+/U58ZP+i8R/XQwnbhJVaTYrbvMFbK0SPUv8ap3mr8R/i+grI8/ej1ow8p/8e/U+WVfvu8R/XlGv2VZaMBHGc75mrZaVfIsmv2l6XSl6Ftm+JNLTFSSxCmPYulhFlg9gSQF21lRlb2SttaO6xspZSZIPtYUJs9P2y5qpkPh/UnDWr2h1SZbg1c1mojpdKgqyU8u2xopheInDQLtUj9kYsv43if8mkWpnfrk56Wk+YxmRWFYmMOMHtXymwGgE6H5WpWau2fv/mlMFJe/ex04WrJ4LWChFItzkYIB0Hkv6PyX+b6huY3z6kLbfiiHJnZRuEcL6Sqskud4FZbzJTb7cLMwYurMNQpqW4UBTnpOmjBkEuROimmuqxW0sXKtFsY0VqW2sWG9jRaVtrEgdZGF6U+SBTYEHOOmnxP9erxALtnJI3wCt/31xrJD48SoXs4OXUtdTW9gvgsCQQeTHBAUuLZv/vKTq/mCZsX8oTu0Ftf+v1nAajR8TwGT6nqzSTvfA9kqloOgU2EaqS0RraS4iuYfVc7MgKQS6QjngxrYDGEAgrAiWo0hWHb39AFTHKTi98bUh/6z3H79T5m3gD3SORm2ewYe3oIZnWphaTi9kKtG6wXqmMQD5BNzn1rz9xgakaF+G0OmbD/roJjBcaMt7gMeTZx9e0TpyxcUcV2u3dYMgzvAaDcr2DZ7TB4w9I4jvgOHIFqGTS+Vn07CBaVQzpuuvmolK+AnvwjKNhK9ZOjMfP6SzM21OARCzcMw/Mfn729niB9vG//Nag/8PCYPGPShP97adBM+4wLrlqnNtmaU3mqtv9LADwaJWvLwUmc8SKjpcVW0llTZwqFq8UE9ureuiILIo8ly3MpzDPFDxM6DDM5DWYqhn28MqAQHhDLLCe5tZn4r5EhOZo/NaOnt5ecmHMdATOqOF41BWZvnDqrzoSwIYeS79A1FA3ah4yK39s9a6HR1gErRj1ILCtaEIx3Qut4VPNZZy6JTbq0F3aZ2TZ3bxUBII81jASi4V8Uk/T1L5HchUOuu9Sv/6BVZvudnEKlMDdeDY8tfltsDxQE/EAz2Rx7joihf6DnQefS41GenqQ3zJ03xJ9ljJr2QI1oYlbxU1vC/WoIbK+ahmVXSbW/hiiirtNBm8OwIEBKcUlrugqREi6M7ilX7C5jm5R/ucZcT1fGD4Q/gUj2KQPWMWQlGgzZTd+CG79XM2vPEjNgR9p1i65gv37uEbNmi9V4dbgZISGA6KQ4/kD3NkFI9z/Y4GnqKB+vaNR8uobqj8/LH8qrMqu3gsu4USE6jmkSIKcSp7+lj2G50zfCynuZIkfyzn0ACNHs1qoI4ey3quc85BcLM8z63LSrZhvcjE9Ed+u7MDzxd5lqXWej/lS6yy4OSWD3nVfZ9J/+7Gz2DZu4W/twvfAjq0gCbhVTxGCQijqXxI82hCy/D8/h6mYYbvZhaSTGiAzLiJ2WWtVvbKhVYPa/GyTziPS/xHTQgpCDgWOOsMoTy2yfEgMrqNGSHa8svmdA6LW6d6UisWbslN7hw+WepM69z2bNToRocq+khqhZ9JWe2KB61Dds4Db/eKswtQ1/74Y153Bo3mWf+PP4YNF19r7LL0wen78K3+xx8tlzLB+4C/OCsK9VWxm68t9g9Z7poHu//9X86g3TwOm6Ozuy47WrhPdtkrTtbUd3z84mbm/PO/xfjijz+cJ3cXIE9bf//4w33yT5d9WJP7hvKZvyr309XcYRVw+HtpCr1fV2ipjlKhF0uFJvMplbmsbNfr1dxhVfZSFZ/RRQf1rgucr97+4XGne9RlIfCyLzm/noCi4HsHe3t73cN9Fn7JQ/9gf78rHy9DEG64f9Q9Oto/2GPhXyitIIg9DzJf8HiMZT3vuHPQZhfx/AvWcHB42O7s7bGLKZ6+buNvEk34MJxepsmQvnfae1Ac29PZlw9XcQqrmH/c3t/vtDvsQoCw7Xvto85epwugcjG9vU5TKL23f3zQ6XosCoc8IxAHnYOD/c4RiyYwnQXP57LB3f0OJKVRijGzfK97eHS8d4isTIRTbMTeXuewg6/JiGwsEtb+sXd85FHyPJ5+ptbuAzQWgXI8B53ag3Jdrw2AbsNEoWoYis8Su91jeqFv3f3DTpdex+kU1g6Bze+0jzvHKtdYhLe+B/87bnuHKgUkfMDJAcBX70s5Pk/CzzGA2et2O/sSzCUI2kkW+sde+/hgT9aYTmHdkdD2948Pj49l1pQiSVHvDwHPKi2axNCydnuv3fY6lCb4kMDtt/fofU5jByPfbR/tebLcnIeyAiCGY8CaTERkEyr2Drt73b3DIpV6i5jbO963U3k5FTjUlzxF09h+53hPpmniODg+3kfccT6b4VFn6Id3cIyVQMr8862s+Njb90AuuaQKD46Bhg725Tu33tPhWI15p93uQg/YKBb8QoDkBhgHBHl7BwwoA6hFzxGghGNAGtqS5pkaqs5B92ivw0a4nMQhtcg7BpIYo430IhUpEgzQGsyP8SSdZxpW1zuArAwpAwvBC0C26GSv2zn2MAk7ATV4OBSyzm7n8OBIPt/yKdAutHev3YWZw6iLOvcEROPbIb9WExZaMEkzjbfu0eFem8WgCoYJjrbX3ds/2u/sUdI4JSx2u5DjKhW31HdoYJsp8ts/PIImt9k0BAENNxUB5d0OUoZOAczOJ1Su2wV0T8PrRLb+CGj5+PCAgRieAluIRyMkLMQt8Bg2xVt45VSCuQQkvieT1KzdPzyAZh2oNJxkHiAXKPxYJhkEasQAXzvqYLPoK803mMydLkxMlSQp+PgIJp1JWs6lkbZ/tHeg2qhnBCTCcHRUop4SHW+vc3SsqtWECQnt7p6qpZgSh0dd4LzdUjJfTs44nyq0QCNgasl0000YHu8IEy+Rh3WO2vSo6AVICYcSI5YlhJL9A2CEmm0YkgVmn0KXkHcetI8Y6ov5pbUKANEcdjsd9UFNnX31qrlIp+MhZavUWS5mIDEeHwCPhjVHJhosdY8Pj4AWdLJhHUfto8NDwJ5Kn6GCLUsc7HlAETK9YBR7QJvdts4vmYWk6fbeoXcI9cbDpCAsQABMLUhMMhTMLnEF63hH+wAgBmVLgA6lFjEsmkZROI8TldI5ZiBXhn+mhiccHB0A3UIiEA0sQkCAUwxJAEjY6+7vYwJqADgnu0D19AYK3oV/2N47OgRmVrBkYG0w4eU7NR94wnEXFlKN270uTAAY+lk45Rar2D/YP4SuymRCE7DTDkwnmVTgCWincwxjQckWmva6R8BqupA8C29D6NlMTtz24SGboeFxlo9G1Ff4D7JxkSO/ODgCts/03Djw2kBDs2l+iWt0Z++gC4XT66FislA3rBEwExVJIJUdwkwGlssBwyr14ABIApZf1X0gJegEDMitkgc6sKbuw1Ij0ttQzgeYZwe4TMxDjAUms8Howmw4ZGaOAvOD6QzvyVBDOmh3oeQeK4ixvQ9Jh5gwn8C0IhRAL47YPOZJAvMEMhwcArmCXHCFLA9Yfwe5Rml+g2RSEDL0pt0+UClysndhTGFIrXmuUxI1kfePYSxLRL+/14ZaDQvYOwAhAvCSIfvr4mTBFw78Ebp0fEBb9hkgE3gQ0BiILll6CXoQcf1DWNOZNXM6+0D4B0wtsEBKsBQfHbDrCSgsJNl1sUfFAngIS4t8nV+mn7XwBxPA4kQHx7AyyHdNjkAR7cM9y7L1bFn7A2nZcVsjijb2Pb+xTVNvH8r7Dp+tI2qFGYvxQt8ph03K0p9Q4HsWogEVL9675i1+wyMK9YcB2AbemXbcSALQS+f8JR5jwKt8vAOXHdC9vU/wJKjflTcFg1T+Bd5PT492vP17+N3b6cD6Sg+QAM87CXO8/Z3EPTnZu8cHjPJ8RKWfU8kOFIElHJ68A/10RA8O/NnBsKz7+66/ZxXxOqq2I13bg9WX61fwlJ0pCV5ZSND9wR4ngw7+6Z5hgyHfh9V8AKiOeXdRLpYvHfulK19k+adW+ecrdSSDvTPK9r6cbcMqTPEXVvGfrFpUrlKLXm+UV4L+zFdjBiEpfMabBV1fhluUpoxaQKH2JIpeh6+Z/teWWLeOPtp3vKoCmaGDTNMBkkHG7MuvnvOVyzPFiTzlECQBD6A2l2mAKqN1PNKuthQg+paTTxTNJpeZTpDFnWaf2xIsa40xeDD8U1Enpbv/Fzsy22r7ML74yu4mtcQvNVQfB/d8u8lWP1RgBAygR09jjK1OTxcBXk+AT6phQcOKmv1LwU7++V9P7n6TBypbUEvxMrZfLtzFP62Tk9y6ffqNyqIRoDjOP5/ceTT4NURWzcef0KkBzG+K2thW8Touv15g9QqCW/P/id+yhftPux1v7MGTof2BEj1/OTw8ejN6rBSx/hu7aFV+JDb7bkL3/r5tA/jNAoBEQQDdE++gX2tDb2tuIys27jx74+6naoLtG3L1OV2nwE8DjxIxKdEkbcj5UxU5/0mtwq09m5Q/me1WXbA1wT0RDNFgkW5vuVx5CmxnZSgr2Ytqsp7cRSlNFuS1tMM6pie8UeKCnuLC51T2R99tgUOiUkLsOKN7FFkUOGkjBt6tF7ccY1fi1W4pLF1N4e7mjYO6w0/wsimZKpoJpnaA1TU5Pu2xfDeITlr7fQDld5oIN6wHB8CX8iDCi2CiE4ymHWpchwzj1BTIsg7tbTjB/zQT/NPDE/zT8gSfmAk+NxN8+uAE/86mTlz7kXr/0YXunQChNeDBPgD88bHJAJNnifx/5UuuZrgEOdnJQbufNGAQEree7WItJ95Ru8/hFxZg88mBF7ysATIk7mLGnVvO/uLsjuJ0F01RpmPcFhwDbQDm5DGOwuzMpOOmK/0HpiC6X6wY1aWoVPq+YBN+4z/jzAhbpZejdVuZSxLaEUJSb/NpRaE/JTMzRebTogRIbf5bXuyevsWAmYCKL5x9y9mYcHJ3IVBnw7O1RUNMBNtz7psLVc853SKvVg9qa10vCvrhQj8YGibL0hroVxb0q78HndBV9r+OpuHlzFle6IslgRXLASuWAra8yKwZ8CbeByshqQAC4gQIs7W/s1N80rEFxqufLtSnC/2prT6oetVn9XYSeJKQfrEJ6ZeHCWnj9ZZeaFaplc3uP0ZeKuPjnzZdvbTo6iXHsNZAWJ84+/5fIaxPqm0TxYoUH/o3ENXGkCVBWVs9E+RpyM7qCsIJBUbQssD9vYW7uQv8XFWgvNun6NcOPAnXAVDkYGmo4+UsnTqsIr0yiSLDOw2QiWVN+OtnDTRN4p2njHiheTqBdGCxlKdp8ix1pGIaABK+03hw2UeuG20epxtPA0eT7VwR7BxIdQkXbkHcU5VrCrk2IXmLmW0uBU4gO8hFuF1DUmDRVxL7QLuoF31e/GM5bQpp6+RBoG/lYPK7uinv7ctdWHbYjzyAn12VxH7mQev4YK/TYT/AB5aJoHXU2e94LBHB3m7nmHERHOCvEEG3zgX8n8VAIEI+F5o7nfpdkbJyYctHOcZDQOkqXFIQVsSmmSk3Rri90scvUgQj5UCeryPBIJgieIF+yvQ0RpmJni5QVoqE47Q6nc5+e2+/LhqtQ+/g6PDooB43Wu2D9oF3cFxP3d0frLvV8aK6nZ2YpCUUQ0NUCgnMHsyuw71DBNM92m8f7B0jGG+v2z5q7yGYnzleh0J522Sw7mDe9vGhh7XHWPued9jtYt4Mj8kp9HjeQT1segdsH8YZL/hzWQefQpiGlYJWKDYTtGh4fD0IDwhauVgStKZG0Ao31KSiEp87jUXf8DdQU3e7rp/tCtFIrCKjchEu+lkd/vOFACbWTOwGzu2sSsIKWrhXA9jve53WcQcKeq32vrpkUdfbae25TUy2gE2FLRPuBmj6QGh7MEz9bJegFdzZyRpUfpegMwRo+SRUToBZaQLMhFIzosfUjFwQjdOwuaxNoU5CYET0cLEEk4wHJxkxLeBYwCNk+MHlSqQCQt0JoaKOI2dh6NZ/5L0yyOQEJVOUidXtk3RVJeStwz9Q40CywWlVrsByuNiQLCeGLGcPk+VsmSwL+T/aUP4f6wFSPL9lruqymVMbL+hbRhnkrf9eQpHKLW9aS/HyqjqOqkQVKm3y3cINSBu5YKF4QNrQgKkvDe+obs4TeL6OiBGqGfiogFEC1vw6YLZMYZpzAHQPnMlIEgQAY/FmDfm8C0wLuJ71+YI+N+UzhodeEiBgLndbXhd46IEH7Qt+5vUR3u7qNr0WcOSjg4NDmN7BD5QME6HZ2jsGVr2HmmyQCUzFsOgM4DRbx7j5eLRXTxpe69iDXN5+HSdst7u3v1fnlKvVPvSO9/a7dRCLOx3cqNiDPF5rr73f2escYq4yKpScOBNs+NjIzURJYovYg+P4yMitAbZmHNeoF2OhVC1KJZkAx/RWBE1YrI4OPHYlAq91eNQ5PGTnmNo57nQO2QU+HuOyxi4xwzFuRbAbEVyK+oVg1/RwJdgrEVyJ+rloXoj6rSULfNhw9tt+tcsM8GmJcT4V6+wzj0kGaGx5wMrivBKwMt8IIIhrEGjcXUiAV3hB6UGgBSRwoLego8du81zggg0oUDdTElMM62EjxXTMF9cdD3LiqeC8b3FaPJAHXBaFX+TMvXLfIuC2EXHbiOUgHFtsQ/PHpw/zx6fr+eOm9pH3BgRTZynTANZgPHZR16cgHehdF2YMCC54Q2rScPaaB/UU3uENtAavob9SimiE9djdPbACJQrbn1ifEtboMARhjqmj2a/Pg7ZPlj8HZdSk6bm+dTEoryd0gp3uK8Yfuv40EKegctCtqn6nHjdTvOT4BMpiYqODiWkz1hVD39FKtpvQbasUiTkvhWysaPb6RluNA7D/CDy0MDUa3EddSrbVAfkH+vGPRLUZH0KZLlNz+dLBl8pWUrRoaiXwp6eCfXiIPz2mxz4V/yk9dmPI9ppjLSET1FDVI6qXLizEeF+q0lVLy42lzdYTnIiJuQsc12iKh2ZW6MxdWoxIlkwavO7cIk8AzobzuEg9x9SL5VSY8yi/r6waxH0+iwpP62eiOjBZYTfMALAdU/KtsJ1Hk6Y5k8z7BIyfgkp3f89PmmRYbKLub9np+S4aOYH4/M/CMVsCiW/HZP3LHlNg1g7eS+v2n1hHDG3LJm8mFvcuGT2zwJK6OVoezDtma+JhAW+XM1O8WCSKgg1gyBS5l2zdmdXyxO1zvxTo7clj2KnoN+Z9XlwBtYXnBxWAv1AAKUbLAg7cCHc1vqXVpSVwh/hb3Ox1pdKJWwhjlki9k5NsnUjVE1uoiQPSluwBVVcBwKIV0DX3ADKI5cNFkMoHzbxDem3UavqUzZZojcPLS+AjTCwcz+rFO3t47fqs+1uKyBel8BZh+bUc/ILclYE99zjFpeCuIJQM+BkggW5cb4Ei02ahfB7jcy6fL+BZYwBYIAb7gIY7IVaROblL0RZlRz1mSwqmrwIQggdEAUWhfLgIcnognNAgfysC6PsLGKAv9PRaWFj5RQ1uAlJDEgzOVLAeFBD6xfaLxou528BvE7qW7tExTVQhHyRW5KF+uhMIb+BBppS6DURQPdUlY4uYX9oDRVj+Jh+NuGjFc4zpDR93drbLktJzkDDwmx2L1Z4SeILWBAKltlu9E6VuPTD0YnWsaYC/g6oGdE8y19ce6F6H+sqhFRRlNoriIjNCtBhzaN+CUp7leGlRmFmuHPoW7Qq2QoH78FSOkyH+BeAfeDazo13/VubJFeAsBodA8Jbbug3hpyWU3y0A0XeLnrkZ6qGrhElqvVvoWDl0qdVyJkmklMklgFlfrAyAHz+Kc7rgTVKkKKM7llPmTxHsDpoN6Yw/bPzR6v8xrN/TT8PVDvn4nfzxd8fse2G7n/8p1IlLhpe5FpPtUxlBdNwY8k7DefYSDwsH39svbX0X2ADjpai7tOXlQQn+7QHxQGntn0GBiL5X7wneC01xTOkUsnuaythDasamDNnYIDzr459GEPv5oNEIzwJIBqh80KbbJfDAJT72raxCZxW+o54oMIoKKHYX+yG78YGYaAeabl23e2XY3YmejuWGrW1Wbk449yNo04Px+iwqduhmD1hEsVDrxt0sPFxGIXrJ1mnC1FQcv+TqcHVCp5zzAaAuokPOGLK4dWPRVa7iYuINrdZ27NKE0WRupDJ5qOf+vnaRplMe4tlmUHs+C2pcLckvL7iQab8JvwhSCe/QlL9oYcarOjl7Llz/k/ATm2n+xfvPl5KQn/S/Ef5LrKH/i1i6dgjS3gi/6q45fQ149U10xuNBbzYAoJ8EEIk8mm3tOH8FD7K9MAp2pG4N+lWw30XJyv8jhh7W94R/AkZvXn7z0ZEyw6MQbTb/zK/xK12F+gmvx8aH33z77OnPlpaIV+moyEYs0hpiaKnGoD5CuxJ5cdduELIE/rh4TUwG2iJyYbznrglvERPNIKlH8NHWrTlkIwEb8+0GORP4J4I/IPnUgfjqnDxAmoiqZgKsohkh5wgxjkDR4djucKo7bKnnGP6w/rtQGDAfnEimSnyEGh+5xfd/sBTv4oBuKX6CDtUAou3MgRm5hb4wixWxwdz9Y3hepXRkid3CKIFkPoGFI76/F/CjxiUKQsmY7OvkaY1R4WtANu7lhndFzT3JvTKKjkkpHZkiYKhh8uK1hw7UkcrYXMugG3EjaaSwmC+ctFWgn1kvv7HQ/hLaX3K8jLysVSCFYb+SPm4DoJrTB/ZPZulmhq84+pQAvNZ0hMunGO+ir8nB1v0Wru4STT7X9TEUWFV+6IqgjsgEaKp6eLCZaxpBdLWuDStNULlNC+gdGiB/q+oX8uooRQX8/j6BH6HpKdXA8ZYmomHdlBrTDy6s1aFpfF6QApekkOs2J7S0ESmQVQ8mIP6AmF9VTYPThdQgkUMF1BeaS0w9IDmolFCnUP/w5l9qWOXJf1AhQTgQZoFCCRKETlyFYNVCQQhXoWTdKiTZZBYHMHlLIUxU+C8UZ6piajx/8+oVRWDomyf/V37xY5w9e/9evrsquJJexGD5eEnng7Pb/o/CB+6ZtELUC+FfBP+G8I/DvxGeBa/NbthWDX9cvJKej10Mn7jazNIKmSFc51fcL/pVBMuR280dgA9eFYmSmst+FUsRrq07wkGrAjYLOUxa6yKc84/hlFyP0mk8xFkDSy50kVzcZKwK1+z14mbIEP7hJUgj1/9RUI+pv25N0p/hn9xioAiNGDIH4RIvW/d2M3e3Q0Mo4pIKv8qFjSWTgjdnIAYBZ83QkXcEP50zNg9iTMTIph6GaYwxcRjMmzmbBVNYTMbBsD5szOoz3KIbn3hownXVGjdNx85kd+TuVt+JMMgbWX3IIvg7Y6O66URSz+qhe7agW2SpebfWkjd22VXgTOqT5qg+gsVv7O46nfqozuu3Ljs3X5r6y0R+uSiaVMC6ql81PLd55bLLqs/n9XP8fA4zP3AumxerHVHx3+oh2jdi5wIn5mjXwRrrTlxf7XNptDp13LPxoJkZ1ANSJRrQ3OYjpaiMHGOo0AQhyRspITMlZMa70BwJzwQZ2Upbw1xQCIvA4916WE+kBPT+53cfOizV2eKWmFjdNEql8fJrtdsea5DxEAQQo2OiVM9QGgHVbuFYkDtszyLeOK4Uy63Qqw5wqe+l5WiCKsf3GBbPRReXGG1FCTrjoJdLKt+mGExP2ZGM9Yhu+lhjR7JYRGsSoEUBw2QEsXyYSrNJYtmR8LWwmaRxAH14ix6m9PTEtpnkG/VuKIreDcVS7yI8Jv9v7l20ce+iOMhl70b0VOrdvKp3WyR5WxZBXAJV7Bzq7QfTW4HPQvY21WMpcCxD3VuBvc3LvRWb9jbWY5nq3oZOydxq9zwveq4tIbgBpI2EiTQSElKmcTCXSJnQUwkpw1hpakshkVgWfCfs6Kh2QEt5fRbyVtuoJE7QNQEK0XJNBqQMI1cGeNcNGpAqum95LSy54AqoxNpryeog8hQRvdJBcoZSo9KKZjEbx+wWY4de4Z9z/HMRI6dgl/h8g3+u8c+rOFgxv8y4IB8v0BV3dqyXVpJe9613H9VI9qECwnWcDNPrnR352xL8S87n2dMkviSW9a3AO38e+ti6gI+OzFHW5a2oMxnzDl1LX3saF5r9DYjuzofYeR+72NtXMTYeNJJr+76V91gAcWFt2sUmBheGGlVBIjKoUd+poW9ktXbM4nK8abo52+y3iRaelQ5RRaRMzNqH/Iy1YbNZo3EbG/JCDW8W95IeiFjBTdxMZAtcCiqXyJbJSKiSTmkDCmM7Y+N6zeZtbF2EpvroXBZYQDQgeSBx9DJxe4ftWIziBEDe3hHdLIfWwKZDm4Dqvd22sn3iHXHUlr4jTrlsI1mn1DMGvONQjKvrX9DOop4Zt++2BdyCyqgS/FmMdwyNgeGwv2IH1QIawra9SxSb/TPdJ7wPq3kJSDu9iKER1zHo2EjspZ0fYnm3SBpXmAn6H015KDRBXeF+V9a8iU87e3105dxty1wW0T0DBbupK21eY4lzhHWuYL3EOONX4RQSYIL68AO1WbjHyQjgTLa3McxMAAJY92AuAXzXdrR/8iBtJSZgZNtvAJMzpAZr0emdoLBXGP/K4Q3UvjT9vYitSC6v43UByV7AcEt4VffHV8Xvt66O/wBJ6vp4JJGLMPq8Fc+3kjTbCg3PA0GYB46OLosTwQeVuuHYvTLX0gB13N+PYxW5BbA6jvvjWJENJiHl0IGAsfzVJeVEZtZU5khZFD03ndk+2kV+c0sOFbZuYKbyQBgEQcf4ew7LfebUZDQdVuPJEP7K66HgIcaxFvkML5R6R5eBfItT7AuO+C9x0GEv46DL3sTBHvsmDvbZb3FwUHC1n+IKK1SA1/2SfkIRxGUMaBwVsnnrcNBScy1nRUP99vJwmgiHZaiFxyvOG4zDBQw/+BLD7EU0FOQWMrz2ahreqi+ufj/BTQAQS5rq3XbndFRnRgzvQJjIQIJUBSj0X2ITItKR6+4IexZTjMkJXc7g6pCS8jI56v5EtTEIXhoAMIVCt1d8eRP3Tb7fYjZRfVFzZYLRg4i3WuPGMPSfiTg9kcZ2+KXYka4OP0aN8hujExQaNqpBk8jm4DHGIXTIDrjGrT6j7VC9vlkdpnxlmHIYBLLe61K/YCnTPkXQpeZx1Tyum1fU/0usNl5Uysu4dOEJXo6WXXOu5SZXhRdter0R3X89cmFoVR7orDQ269u3H2gC7YmAVDU/CyYgE+mLAOcNz1ozcvv2QlhiTrhRofq8xUHDlzVJm+Fu8ZVC0JURGRW9/ibGm7PSgOL/i8JIg4FBXTFIz3T7Y+B1BlPfyJEyiCaO8TCaI8deFyIrkinFz+IFvfEyvRnywXDyOkKkjuNYmvALzEOhvQgALA1OytqaWBYodbM7GayWUet8wah1foyxdp/D0ohD57+DBwzDkVJBRiQHL5L0NFr9QoVliH14xx8qKeh0MKMe+d/G9l7Kn7G9OfpJvlm84/Tb2FqF1AqUpekWGl57W+FU8HB4uzXHcEz5lA+tmL3Wmb7HKnm5USUiTxLcqamq4lOpilV2vs3v77dpjy45cysqM5lpSR3h/khlPd/Fq3uR5dqAbrfbWKXazY9pC9dIFvjro2oFiw+0J8WY55rzJn2S9iROfonRtkvPJ9/EbD1BFnQv+haT9avZ4cpEUKRLDfGh7V4vLOKSlunZ2nEqo2FF+dJKLo68PFNId3sQPRNu0Na8dI0n9j1I3YrLPMUgPDM4cu/kzTHSh8LVN+6FwDd6F0AonxeqnkBYDf41Xlqce9UyF1+mjTVdS+2uYXhp07VQ2s9j7E/oGl8P3dc80FNexZRc4DUweJ2H7nh0MqKLWtDffBDZHcfXIFe9jCBthJGgyXSeuwvVhsB2Cvl9Sd6FAY2HxiylYkAvKyema6BtO5lcNtDPQN1YegcLHDG26iDnuPxV2CBoggpXwsBAukUjf7SJSW8GFtu0Jiz1b5U7sZVbtss7pD9X2p70iX+K1VtYr0s3X//wFSVfvwckyUssMnWJhQUpS1ejpnNgBGsoLFTnK227uuXgIs8WITMJaec69vGOJCC58rX1yb9caUWnvrYRfLUR6+rHPZxAnfOlK5LJrSVyzRZxFVLI6SIPItw/sZqzs5PjQax+ilfT5mhNoqZFrrpy98FxF//JNlfg9N/Th4cpME7LXNva7ygieldfYa4N4NvUJphzGKEdBEVb9al0TJVOtQ/2nSXWrc9c3gnJUInnhd39XN2WzCxbTPp/Q3cw599rfpiuu2b4T7O0SCEvaKzphy2Pl6GV3T8qQNqrebS2Jd9bxfQGyQaNGT3cmCqoibS1ztPSHa52dIJifKfpAzxZRreW88IKqSPBT1L79oBZunT0Ye3luNZdvYE6CAELaWCfEbPbhDfotgrBybGtZrepMas2GpOUmnVV7nVvllpGpHG6zqI0S6vutLUj3NMV4drWCiv/pvfdivJtDnFxpd2Ko2cbJLWYJDUj4rCIbrcNcZN0pAtO6dYpq/QcdHcoPaFLMCYuML/RYEJXPkT6vtuc5ZYiz0ar993mmL247za37rudArQgYj/FDj7ROEMrGAgiOU7TkhM/UEJaHnPi/esuw/1bKP5ucxQP8EjHAI9ytHs5Ybd8i4gY5Eu4bfemhMcpio0RYHJ6Vmi0eHWgwmjECmwBMkZ4gyBgJEJL5hjk0Ftz6WZvfHILAMdoRBgOxjgwgMoJ4XHMhmzm9pTbxhDIQD5FpavlCKlhCZHyxtyrtGW9Ll9bW/6KF8z+P3x3LOBo6e5Yi9UYRuNW3VmJLjv4cTswxLeivKxFQ1a6xdLcRWhdYmk5eq84dCvCTFcIM5GEyfFnWtDnBLCT23N/CnongBiSnWroEsUOz+7v5/AX5/gEfkGCkjsjOXmF566EAX+WEBhuhMCHbrNEQPPUKeGoBBPvEjPs/KHbCKnWxAwIYBr5PXtosuOFj/HKRdbigYusUcuUV1mrO3ZhBodoUvkJf9GsNAKZ9I6MRnMyFjTmctnHX20lknakdmFBmi9ZkOZkQVosz+kVeqX5TVdFwtTFX3W7I7zRg7zCUb3JSxRxjsOvuhcR3uhB3oCIb/C7fN2Use1oRquVkJW7nPqf4tKFehzv5GjRpJFnvEjtXWO0r/THKUd7XLrOil9xcVt1oVX1XVbJqYo9VlxelVA8sPt7ZSDGLRm6vCpx+3/G/vfxWmUtNSYI5FBp0suVQEvWh9xtUQgol+4koc0qzIQGAgemhrzd6eHbHYFwLV8uGZky9n80LZLHtwHEBzQ9QPHK+6Qcc+dj6nM0ezHBflcyYA1Lt2oNeR2htpKZEj/E/s8xlCCrsUxKUj9TQEwPqPrqG+I0/DW3FqoBVnRFFhR0OkHbmxTatUaHFhi71yqrutql2pqUrDBkufK/XLkrT0NzhOplnPop3oP10L2UElhpgORJB7ef2aOksVrIx3q4KjCGRs21Ri91VaU0ejkPydusyFr4VeBRbqncptL/0zYb8CBlaDIj/UlIokVLvqoBSYQEf7f6Lr+HO7eRIm93L9caPTJhy2AicZnrDc11vYdCFjTEVhBEJb0+KvT6yOj1uVIfrflR9D7Bu7lWeFfJFg31mAIJ9IHwV2uEa3oc2VbMURABymH1ll1Ud8nhsZL0/h4EnCkeInR96SPRG8kBxP1j3DwWAYzfqMRwcljmEH3IcgT2Sq+J5grLzUbrYXtVgeQNrVKE3UStCssEJu9WYkXD1s05XUTNt4eZi7CZCx1JEBsxF/GVzKUKwhq02pvRenI/YixBm31MDil4K+GSscQ6xmuSRUkjn/OsmCAlmwmeqJMDk5Ifmii8Mo3dJF1U3Jy7/oJXCwU1zFOrWpiyB09DmVVcGfYkyOKWV7OjA21JoPVmwsr6kMgfBr8CkI5PKc9sAEoyh+rjMi2aOzOpskrq8zT1JTb10YmaZIX6sgrqSx6kvmwD6kvYSosZtw9IF9sSD1IeHkzh5DkITEaUKK/yFNsqZi1qQ68+hwJnFWefFZnR4efs8dtZNd+QuWpV2x2rZIQFixupCt/HrVjf7GdttaGI30DHDT0weHdcoiqUV+YSVVpslUhlrRhkpGbUGukw5IM3OAPrXhWiCfq6GzvRkURd2ql3rAxRCbmU2EvoA1d5f4z9X1Hk0xKq1FPWmV/WKwL2ndiVsz9M/RxErITm6lJ3E2UnXRTq0X+gBVHqjx5qgap6IfWxf6kBZaL4yhWl2naLjUK77dr2k/pIbf8YitvSpZbZJk5vq3yloivVE46vXc023fdd7ihfEmGgY/b12LZjp1zV0DkTsqJRBXVdp2T3gaXwMp5zS220TvHpO/twa1jfn1fU0w6CZhMW4hQDM/V49SYutzZxqQnoBiEPkaPfOaifcSGsnbekq4DeSobV+bxlPAlKqcj2lKlPeh4AAagwc6pJ1VcGX6UraZar8bllPHfQG7vjnmC47nrmN5tZ3ek0M7fh4bkOU+RibREo5GRNeMfHRkef+LksFHsZtKPYnrT4tuUSnxSGD9y/wJD+szSh5YTxhdN12c1GIL2mAeo1NwF7vQlYq8+lNvudoroOVYcIeKTGV6mO9Mk+wGO627HcwG1Eq75gTJxXKZ7RsYfkvb0F4rXa7fbx4eG+d+i1D/b3jvfqxXmDDmt6bSjelJkO9g86dmzFF9VjC/ABgdhDrKnplWt/XV1ItZhOLUFpqNS3EzSlKPKi0DtpsLfreexZGhzg79s0OMLfv9Kgu7vHnqTBMb4+TwOvjQ/v4GF/1ztg36ZBx9vtdNgXKNndPdhjv8Cn3c8p/L/A50u7nRQr5+Rz2v8lJcLNTt7SMzbrWQrtavyVQuJzk/iEEt+lvnr/lt6/yG2kNynGZGt7+0fsm41oiKqHip2kTgiFtyVSSfFW6EmaKlp5k7rst01A47QFuHR8q540EL+PQ/7pawhfznVgZlgDHtYoZr1ObCSunP+P1vwnDF1dT4Hvy81g5ehceHeT4+061sESj1TzOp4z/zO1z3PZZ3DqQLTNLcCLWzeRpByBcdu5W2wUh5doXMyHvHTKzJwjg8bUoYoFi1ugScXpsMjGy9nkUTOPtWB6f/pPdMhrUpckCRU9yhrif0OPvvsP9AiPEnbqOA0wgikNV9VYAfuRHS99a9A3i9b+Qx3/mAbSrk8enSsm/M5+W8qKF6m1vP6qtuONztFDV8iyc59r+UeuuQ192Wvyn5bX5JO7ZFG4Tv7Tcp0sbecboaLCyG7rApY0852Rw0i0KIGz/PCrNM1yPN0UHcQyKb7hL3m54yEa2qGBvn9MXdosCegIURGejkxJ8nD2Jpu3X7+fo3dzaIcVN3AS2sDh9/e/prSx8+iWIUoVZFv+PQ0G2N4zevsxrYgi93O6el+3uriaW7tkgl3itk1cXMid/p+/kLt8wfaj93EXvbnb8Epu6vPdhpdxmzur09Kd1T/QCo93M3Ps3HM+CvNphiRFLrsvL/FawTAj9IXjUNK5DCwQKu9QukC+tmCJSSCPqRpqUzplEibDKSYJkxRxnF+1hQzgfhdezP04ZMD//DTE6wn9MFwQT7RO5YbWsfMGnXNv4DH3M8s9yM6C+TG4EaMH78w9o5aPTBtuaky2bO4Patd4fKd2Bix4BjMBNJFklmdLBoqSYV3NtoFqCh4DxcawATWK4U1a+H62YGmelWEVfGRnZ4ClEQCWgt+zBRCDaeKt3cQEmjj/W01MVB3UVGhiIutS+NusiZ5qokdNnBZYXGmjRCW2ldUSfEnoDZ/mD6G4uvU0pg+2EJozgeagsISLTC0S6Xw+CWNRs6ZVTRrA4CGZNwVHPbfGoPn82rzNS9+uS98SeE2u57xIgLIJn1ul+VKO+XU5BwYWDe4g17UEroBqWNcSBKIJS86xwAyx7CMisW2yAGbAAnNdp67qGgqMLTx4Vu9BqJDrMMdk+XjtNz2EiH8pmf7g+4LdPgAH8qtFfQ7v1/LRwGkWgOyQSlfWzJTMN7O88M6tr9tZK8rE9Ed+u7MDzxd5lqXWNfcXYfkmkPQ64eL9x+9UFJD7e0wt/MYn4dwK9nEV8+tv0pua2x8MSGhQCTrOh9u6AdZ3CzMka900stZ1PKSgiLfwPOEYcfbsDKZTm7UpC302MUKIwTKdsZxsM6nL0HLnCK/iMdoYUPT7kObR5G0Kksf8/r6WJhm+y412ZXktgNyEOlhMbxvFowuRzydrpCFllzU4UbkLYNehJYsEFyETwTlGw7gMQUjYRiOqfciRCqvDjrj7aB1ZjIpAEyT8yD2UmqqwxsZuy7ipObWWorCa20L3I2cARFIzaWd4bIpWCcdFAxlU59QEnjZ3aR/fqUXTcI48pgAj02cpCW9NWtMwQzidFoVyMU8FsixdvdsijyWQZdedMkBkow27xW/QSN/7PVHvEiSsI4qJ65RbleKZFCKVmmbyzaX8kmRqmsE2deEFxTqwUWamYglpVirA3AhpNqAVzJiP+tsonuKB1v86PDys2WlNFYehhiK/Sp9nIv2MHP+/RqORyQ0MeYa8ES/IxqNRDNg0iGsvhmM+r7nK26DcVyU2qI5m6n3OquIEZS1kKhiTGAMkxiDDqC0IdGnaCCMVUJXgsiV/ms1aw1SzhLOqJk3Cgcx+JodRWoSXMJqkCX+McHET5zLN53wIzK6lptLEbUlnQyeWOQpuYWUxHxAVOn1opaOVlJK36FVZV1XGmSt3RFXeZigJxrRafWxe84vPcdbMwllzAoRM13M3o3SKmJH3P7bpzok2xscyzGJk5peeTywpppohwR7GRVs7B1QT1G1IMtCXNS+TlXmZVM5LJRA1k+p5qYS5pi7MsmpCfaQ1VSTGyYmK6ESRiwkuctbXzcp3O75qGj4X9HdbDXRuAW0rMJ4FxlsCo7BQBSopQKHbV/HWX8JZI/fzAqLG3CNdBpDXyyALPCuQrr9m/Nl6zJcn1k15KJZGRtOAlWQGnrwsDMnOV86oyZWtxS/jDOaiWmO3xf09R9cJDAyR0A2yU1XStxzxdZraBZ6EmXbnB93RuPLLw5SmKpUBIFxhMBp6o2oC6+znxJGn4p3tBFrSkjN9Tt4clVtN6hAKk5ddTtkEvabZmN2yK3YuN4ku8Hw26bTGW5jGjF0G1lqCR4NS9Ei75FkIIlz/IjDLs483pYQ+fQ6nGX4Voc9DdgOqfxDMlb/VOBxcnLFrShuptFtKe4Xc4dxlH4JXaiVmT+GxIIf3wQel6LyQT6CzvIYnqex8lk+Q9gwQ9xb+/RXc7Oxc7+xQk+aTeISNYk8CGRR1JNJLxyDv/h4DEINsdWoi6GWtmMLejWIz8nj3MB60OYeJQNy8bZwnkWkU+XF0cbX6LoYeyVASwdw5L8aEbbfd1gUHCU8dPZf7gRqZgJwL9+7pzo4zBglN34OWBIMn2NUn0Mv7e3w861kICp4Gg0Gssf0edGxHa4ZqMlNgcon4F+Zzoc26IPZOdfnXoKqvlh/q8p/NZ7s8tE3xt1NvZ+cl0KmMVREHTxWkXD556Jb9VA3dUD55Z70wwHtgczYJpmwWDAlz73ABOV+7iEpOwL4N3q0RPpfFH6A1deZbT5znLVw/h8Ev7DnuK8LTmyKw3ResnpMqYa3V9oL7Cw2m+ZTP9Ic3+KEH5PeFvn7mt/YSX+Kd8+s4A/kha0GmZyjW30UhRqc88CUVy7O2PZl45F+i01sI5AHfnGkwaT6r34BEHzbg12VA884wmDXf1q8ZnuSDXwyfJ0L2ks4kWLC6Hf9yW8LCXxHe3zs3J+0+wfRv8MZcB+A2nwFUSCao/jUlA+TmW4SbhOzbh4TMUq1DaYTy5YRakIlq4RoMQvcL/G2KIWjMbXAV/BVse6s9VNgShC3Zs6JfpldFn7BHfA2m8PQzwsk0h/tK/Lv+VzTBrcAq0u6G6GQh12S7GEm3I2Cuz1uS3QBjl9FVrNvDtcqpmM0WOkG0IliDx3z4wbDJ7MwtMmWY6YlbYn2AI+uVsAUdQMaZIOPEqQcjto36/5UMvKp5RnHvJPK2XhzKolqjck9NCilRwHD6V8Ae/Vv4s6hoFOTE6qFooAGRDhZoIG4P2SsjrBFarVsM7GCqxHVJ6SWmL9WZnqLIZxQjromiGCw7yArhGfjbpaLQJPTpFxZHpJZnATDO93grU+i8bk7ZM3LKjRvPkOk1nknqeYuZXjRzzPS5OWRv5XVMjbfIFRtvS4TJQx8XBEmLIUEn2OyJknbxeJud6qnUm8CTtUVUG9UlC3n4eVZK9VTqNRRSZLzUlbjcFVeRuMo0Xeqv6S0CKnc3L3fXVRNDZRou4URhpIQSIVFtIyPGKbqEiilNV3cVCTlO3SUUDGkau+5ickKspC7j92LkvymsZQJdxqFjeMZIsAt0phtCvqopHAxxHhOKTyKMaaZA5cAshrAYIqgIujaD+hWo2TpQMw3KkgMAZElwctktIUMvwRO98LrsijquV+SZXoddpvKin/zOjvqOnuP44qkvE/VCX2awcNiyyGAQsgjkiQmbgVRgMyBi7iBEKQZk3/mhvLFstv/gVgVO28ws4/IgmnrTLKXwWiyFhEtQG7XCv9lWIRkjBbjofrut5JccL8NBXsrGLqtYzbesdWtrSUDYWpIKpDPruweNAlULqrZnPTzUVcYTM5bKPnV/n5kRVTaphfMUj7vZIyhjV+uBc6VsVIybZd8d0vq8rHVIoarEVGfVGUnmKmUcl91VlXJ0f39X2KppjMx2pNIYgih01oQDQRvNML4EHcz420bURGtXXJ7ATqSDaZ+OatVKNpeyRLLSkZJAr1Za2i4mSIUjm6QLY5x5FC4hnuAoV/KVYja66CSl1idj0DsSCxZeCWjpVCEdDpvBDKjwC+X9Nbj0MQSrxDiqFN8Jchq0DcVIfRYt0Q3POzty50cfvaHgrorA8E45xRkKzx95k0wqy21juciPMN4rHtCqtuYqDMTFTY14pMVgY8PuJizGPqZWH+eUuKSyfUf3WqVLk6boYWh1L1f0IFzVTyHHVUh3gojUfGG5D+B+n6RQJ1M3HkC+qX0G32pNhYs4IL3RsOwJxVEhYKTapiHxpdNFFiekcVIKnj9ZjhJZdpLQRfrOEgRPgsRKrHBziT5wI9MVFWe6Nnp/oLZyKZbociX/V7sUeaiWMaADSq0gwm6wCtuWuKYGSPaX+YSM7KGsm2TgIVt2fungPQRy3Jn5RlcJ/pxCUsnlgWtXgsjah8tacj/UHi+Lx5NvgCj8IUJYq2JgyEBEig1WrAIrLtkODyp9wTP/x9ShbVmQr1yKC6Vs0ZuBFQ+A3d7OCKhAoLRSow/DZnDjDeDGCFdaDd/Hf20IOMdraqBwjoVhIX+VDkl1mW9WPA2gdiyfLuQZs5UNJjzsqjhLWHGqJAska8ugPPkwvFLB+cOLOfsQmtsf2dPQ3P3I3ofGU/ZFGLwPdzvsdRh06u9D9jk07mbsWRhQvP+CN78NS1PEMobdqfvVkia0xCGHr+A0a5REtL9C+zAHRctGzhTLn5R+irpCR7uSs6iIXDCyzt+DrjsP3uIOAjxN7Q94kc6knBNP6ofBt9M0zA72KhoOZRYM9xOghcFpOEj+EZ0Nkt3ovn3mF4n0Tt+kGxXwA1g22r2EnKCgb5iA97rpj/KSqIguieKNAEDUo4Y4a2T1cCDgMTnrDRvBiEKRLfIAVP/P2KHXYZNDJ3aHeN3j63A36t3pqkAthWmdYkBf1S7hjECzZiOKCijbJZVPjsrsXKuigG46OFNoyoA7r/E/oC6YDSM0YmagVYWD/8mgdfzMDwfQkAYo7qB8Y2CIUs2xg5mbq7lZotITO325fYLMBBQc76Tt3jnTwf8Iyg/6gHkOFMuTzgSK4Ukh21Vm5+BORp7kcs15moyn0g1rqB4R8Qpcfahi1pmUBYnpWDunsaHK5eODdctPG9UtoVlVy4TFYoIh4KsgCAuCKjUamLZaA9heGj09Avf34UAOypqRM0P14NgQ2dGxc34iYHYEX4cl3A3719GEXtFQsUUbj5IGqnab08a6ihmXx5wd0w0N1i26hriViRLLmCZdO070B/nqWtsDMltvBW7R7uTvUAf0JtfXHTjTQDk6Uo65MwWiVbGhJiztTyVFpK5vDrKFrVko4W4qBRC3woP0tNiHBPI7WceGC36GZYUu+z6/GH9F8VgWj3XxZ5NUDDcsq13J5MLj05UOdtwM6zRw4pQHtlEeWIxran/l5WFfuK1z2U5QR9LWOZkAE2jyQtLDk2I5fo7L8JOQvaOl94B9GwbPw+a7sFgWv5BDjtRsG3Slj7UQeRQURx1qTCgQEB6Hk3kNBmCdaGQYvRIL/RIG5OVgx+QqarhpKyX6Vj/ceDrFs0Og42FM+SQdKYzf8Zew5Jgn22nfWkFG3W0HI4pUeGfHCeDw/6fuXdfbNpZ2wVuxtB0tgGhIJCU7NqkWH8dxznKc2DnyYxQIBETEFMDgIIm2tH/v33MvcwNzKXMlU291N9DgwVbW+vYzz14rpoBGd/Wpurq6ug7J9ME0uUjKYvDg4fvy7k/loPCk98jYZv4d6FuuSPa6nU6t0NQSBm0bstwesrw1ZFacQXv0OpF7EKkhhBjpDuesN1o93R6EP08fro4jDZ9HHJJJr4eVRtNL7/68C+dZEb2iaiFL0iFTdcHa/Xw9BTf6khelDbzWLPz5+5/u3TxJN7fuu7p1K43Sbfm7CqZQyQ+fV7npoO1nToP54eF7VZoKCRtk1AaZE8jz6B0xxyvwlA/7FsznbZgKFEFowU/a8DOCH+ShDVeJ9epIkir+C7VEEOHwEpeYjjWESyNICK8gB54mFWNcAowDtmT1XIignjc42fBLuNTyU2JPM3ouZEDPc4kIVkWnaCzU6/LuFjSheWx1iqZhqC5BY2d+8iM7EjbsvVN0Kj/sxC6l7+0lam3NqDEZ5MB+IBay6lQeMbbiQs46M29KG5wdamuBUFvN6xzxtRJlD4Lgj87DQJmdBbCUcxbe3Fcht5adKxdWIoi6dXZwJS7pdzmsm3Xu91ST1pDNO+/E6F5KD8Xdn21UfYaBFvwDhSCaburg7CTuwO+VPUDeZadqDxKlhDT5KrLBNgzfPLBDoEwbEVsogwNaBrsKOsrcE10igy6BjDq1pSH7G4saa5scFxClF+BE41WEMr0/MrgXHOV+Mkj8fLiCMaNVjAnRn/juz0GDECavH2ICbm9XPix7PiOLuz41BpiAmGN+3OWbyfknnwfe5wGdrU6+CEark8VLMsJk9eih4NH1A55ev7rbksFMRtiaDPRivo4yLRjAh/mJfBgwNhQrKGENdOKuIIc16PTtT4gIw3ILLfunBHtGrQOhu2LqRG9+dPf7n3cm5u2Ky4WzO0vt+eug7brtp+Du68AS0P1kvTDH8H2gtU8a0yFWH2lAfmbpSm+ObFxn/c3OapgbK5x3+7NiZyyH++3PCvctV/krwGvG1XJ1385i2FnLR701PFYspp+t5J6V/kujpyx/C4jSfwdV5b+gqvwXVJW/wv3ar7Bh+jKghdcWNRh1wxh+gzZLrcV8m6twMZPV5i8HfSLE32tpnlVgQTuQXcKZ4oalEFMX7isz+9PU9V8ERLSD9cQr2sHWocwZytkmKOcboGBrCulEFcpYAiGpNyfPcUV5GjhLIvcnfdo3ngej5cnFyLnw6Nyw9OWMzmMXPp49PF/IpaRvS/SXip37Z3Wx85OzkXOGYueq2BmKnXOxM3ku6ds5byRKVk1b96LzJkAMyEXnGf7iCwg0dgTWOqMRIpbo7PZ2uQM1JyXPYMt4eeV7W1ywiBtT0zDcX+NqAPsS1Z659PdZwBdW4b5mm67w5YZ2Sny5sb9wmXNd5tzVt31bKrjSFVw1FZh+XYkzcc4s7ZayG8bEYhNFXEfF0ddu3u7u7W3LPwlNaLw/i4Lpj7xSN9lyrp+Pyk0y03SUDojMIART7A7KO1zC5CtAP3ze2yqKBdiSwRKfF2uStNrgf0t4vAJZUbN/AvkebU64zTWlu6/496NwM8A15PF+UIOPQw0A9Z+d9auPQ62aebvnEZyOxVQubWblvnIHLhehXAj3SDf3LBiu2MMCCvEiMYvOf//oBvttW/5d+ikX/CHYYKH6TbBir0z7kYoK2QQEyo8TNsyh/lTIPc4nxianDiJh734qlwVThZjMWXOIQBN85dnInGjhUtPvsX+jSmaeZzzmlTDkjWWI0gX9YZXKEg5vZ3Ku1Crn0Knkk4sDvd+0blh3WJzkO3J6ku/tRcfOjJjKjpP7tN85U/r1YtZN85PGfN6K5FCtecYT6379Wq7YWFFU6XB1nKjW3pLSiawPaf3hThfnVpRjOu4pLS7JY+UiIGdE48xekelPcoxL4uxYEr8cmGc7IGRUEXegwi1XcjyeiPF43BO9/Uf0tP9IwEiSk/hZ6E/tNDub4IK9VpINTGzJo5Js4GK1CXULrDw9Xa5OamUSH273hmIb2t3b1AQDbDKx3BRU9a1WTyhh1bdQXVpxZKCYuEhLhtSKTAp1kUNYiKCWWm1aCTC/DdyhJRWP5Cmc8FVKmJ3KL539/f3fGVkE69ZBfccdpuMmVOvkROLL0IWS3kLHuRkCpY5RDOmsAm6pF7ClKkE/UYIV+5orcyJIHlRrMk1wktHL4OXA44g9SUHPCLK2VdqlRLpG9KD8KY1heT+erC0WLehQrr7Za72Knddcf9Firp+HmaxAJmIZVGpM6CCaV+P4+Lg32ad+v4BmxEIPAUKWlUQ/XOIPTZHM65lC4e1aMYC67W6CVB2ngMS0K7OaUHVK3ELkuMwzCXarbovj434L4KZWMRTPtG1O3HQDzVtrMsO8nR8fH643vlhJvePGsjtwatgJNOyq8Vqb2sO1vf7NFbeVnLS1JS0NYwHuZcZo0KsYDbQyFqf3TDoNhaOG0QndIcJQwx8DdsvZuMCD1l+YEuoTRzExUbNm40hxLrQ22Duyk+7j9Gp8ZIlEJ7juYEZlVV6CHjEY+V5peugPrFHBXwTKDDQsWg5hUDqRAoQrndXWrFSq02UxkSl7uNCdiEy36tabFokaYqQhfrw3UdObtNWbyOpN2vQmavUmXeuN1RpdbZUq2oHg0uajjLlTM+oIVVzUlcZcXaGqGuciRHB3Rpo2StKiz1bspzgQX9bW4Wsc53etiwEIvMeRz2jT0Qjm65SuTiFi6Hm4QHBzSMzTOneqc6d17pRzGyeJkIefdEeVGm0ofA90yADWQYM6iO6Gs7GlQikGGA8jHCjb8yIwSX6PjnzEVREqVONo4rJGds2VsEff1K5K2ZLvnlbzMnmVzZcXsE80TjHCLMunSRqUUUFsqx2BtGHv+h1wDB72gY7yAXVkh47UhDfa0KPIeKNlChvw7oJwA7cZ4qTdQuhXVU4+Dok4VBN3mEFJmWiHCpSUIZgPWJawcoik1xl9KNfGHJUnQIEAQUVDpWbLnBEKBKqAE/rsPKoyRaAoVnv1CdmCPJeZSNitX8trD65jVjlnPcpj2usmQ8tJkbrDiVgfOGsn9Sb6ZidnX/HZxvudXbPjsRsES6slp8VLrYNjISoTFbNsft97va2qSW1WonRHPwTO71o8A9+PP0CGxNp7qLa4zLJydu9bzFE1iCoUhhFDddcK8VRZhZPiiyRNOFAXNYkYAQv3qjVHHTvQfPTKE2m5OahscPo4c3urmAp2ZDXyewfdgSWuC6tG3KnYkoRvKwg/fahx1m1KXADSL5k7Sg4y7WguuYD09KB5aSKAqJoDdKf0An//kWXHazcVhMWyl2x/6lmf5pUl49N3pLNK9g6P+r1PP+0/FdNKHh4edh8/ftr99PDJp4+OPu0+jvxDS1FpUdmXQHx3oy0YY3VkKiRbdMyJ2iB+T3ESS1mc+DHO5DFn8rw5ES96LTiz580mSqwPTSJcx2C5zo5VAEirfCBj2pbptOU7AR2NbFiBLJpPhdvApZkIRHdHuWRPxlPPm0hiYE0VQ7cFP/NiqET5NajQ9ZyYftt1ZV6xnq3ww4/Xy8wMVT5071PZh4Bw4+/TlC1AGl1MUEV8n97emu+0200tte/WsiAKY+t6YUtQiLSsZL/f7x4dPe4ePe0/6h72jhh3xBVhWK/79PDw0eOjT58+/rR79OTTyD/6VJxVkmAfueKcH5644pIfen1X3Kinx6641rkaHDyt2vdKqv5AOqmf4ShLJ2QEDC3pL87PmctDVNG41vc2gdeMQZ0Yuier6N/jLnTiUTjw26do41FfLQLreGCb8YpzcSluxLU4FW/0RfozSe0Sr4lAJOKFpBaLl0QysuGlfNZ5SUtmVnWe0bli5tP5/xlE2s/8qUp+idtGJL90xVK+9C/EjVx0lr5z6U87F/6C/k07SxgDvei8VkVeGEgvAOmFgfTaQHoNSK8J0qmCdN2GdCVv/FNayjc+9aXCxnnjO1fenHBs7p9CGn7pXdH3M/9SnMtL3znz8e2KfqnsuX9N385VWdpDz5uy1zAoPuOyb/wzfO9PCIrzpilPaYcT+YYJw9sVBWylC5ja+ga57A1zWli550EdEBKIxsmcc0TgXPFcLqsOS+bfnsjnt7c+/hg25y2THpqcZzDH9Z1nuqkJ31D4rwl7It95baem/gvcePjOC52aITX3X2Lx+c7LJhXLjNZfVxnrdFVsVvwpWtU/l1fUQG9adWqcfOuKtx6hRuG97FRUUyf2XkMJc2MPLmVlcKgyM19h5qt/jkOhwaHQQAoBKfxPcOj6P8Ch64/g0PUGHLrWOKRW3itJmxcwQRzRFyI6Li+64oOLrjDdLNDN4oOLLv7goosNpBiQ4v8DBuwdBuwVDZQasEsesMoM2BYMu/+AhWbAtmDY/3kD9hAD9o4GSg3YTbPH3FTjhz4Muuy9IzZb55tK2s6PH9H+96xi0dJPSVoe9tVO+4j2xSGrlD14XeFcWybhA1a1hkrFu4pOeA+rRie5PpUmcm3T7nfyRs1a+aTMhyzFrkuPs8kwGfc72USyTgU/ezRAEYxjLG7gdYXb/xUlt0YfUzseOOkp1TI6sJjYzY1Td5xy1g4wL24WUVhG0wd8oiwelNkDnK4CxEtnAAXCZilfHJxDlrWuWu3YlU6a/iPR1fnOyjwJcDFTrA3uYSdytdrMLJjHEVwkcaavt+QpZmzLoLQjomTuNPo+xkKFstEh4lUeXa1Vl9o5XuKW5YM53uTJhzN8Re1ZbW67pW4d7W698zWoaVKUxTq6mO/VYkrnese9Mw9qnt+r8R+Uou7wIBV11waRMJ0Y5KJu7iC5U2ZOWQtLlH4PnbNoG8ZvKHHoot0Xf1ZMA7Jh2uBsRDhL0z1hKQw9EK4OI7YKDiT1Pj+u2I4f4WROQrawReoJLlVipNbDA5OBVK/MQhKrGOICfi6dyotx083aYODy7NbQ4kP7VtqUyxeVA65QN800jOjCMRSCaM4EYpbo2i645cSzL9UDuvCBOrCgYPHrYl0kaRUNrVrBgW6uNWfD7ampGsCvuL7pBI5n8ACx6rncOuCm4ttb/Jmu1h/Jt6p+cMBrbYiOz6n6BVV/TjPA1V9yrYsJvNLgwVMXZOcEnNqghFirjbAQFhOmquFLKxjSqsr43mr4vKojMxQ2nouuyPxe48ZldVVk6lRqG52ULENjTCypHWUz04ls8KfEoctuXzIZZrjUc9JxhPNVQkAytxXkBKsC9y/VecCVd4VZsdtpVpf2ryxRsV7221Srnc29g3ZjMyd0JoHOXW3tMKX944qw4Ww4lQvaEy8JD25oKy7hR4QmJdL4eS03nYGaAxjUNSsWgIQyoWcobSJkWEBMLRiGOe35oRfzvr//6MAJOrFfddiGqKSzb6egt7nbmVHVqUdf537YKehd76LvbwZTsRws7u5aPdG0PbyR13AlqV6W9LLciL0riENLZQVFBcBQafdjmGPR39csfJ4xwpzKw2GE6MLpeDGhsY0QrTRFwoKeF3imhJnIkUT4hLce/aEvfZHA5GTuAHoybij4t9ESfXZRbjWdxsFFPavpGBvU2cai76JU1rrM0+kbne6oc6vfU/9Z3AHEOxzPtR4KI0KuGvQPLfTnCxMMZghpED/oBV2B8tRHm5hORsfyTWUlFX7ASQ1FoVKQGwUScg4mOfgzVX8WTT40db6yUo2duhkQOqATshy390VWyEzGDqIQfNL+NKGBoFrmt7fQF40QNJmX/JBWKr1wnTQpcq5EMheUZTkRtM4gCUC/lwqpll5PPVzoP6CDJ9RYCN+XEiCoFvf9kiiLcphxx1J5Sl22e3gl1yduKULBFau5y+mRCP04nOi88+gimCPCzJVHfCU+01o/9TwGeMZtbtp/1mr/mWrv2ab2H1PzNzXnjJpzIVC/as3ZxBVbW4MK5Zk49X2iOBdDHg4MhW5PujKeVv2r47u1PRfUnqUZGPq5mJh1uzowFxgYDIdccotoZoarKzxFT5YqV4rGY+xD9GF19QHZ8Hk1fbXdBO7O2gFWaPepuxmjTYMInU8ZJ2sQtPsQzU7ZVf9wZQNZYYLt3WaNSOhRaraVFeb4w4Xvmv5agnfrGmPFot5wcAeWzrXr1c+Nj3scIUaHfjToeZF7cEQHKt+Qf5Gax6XbWWF+V1b2XTP55rDyvhkXZl5NP4l71extrvhVXjcJTUamyc1waO2A2PwhPyo/OVS0q0IQyL77yaEiJgFzTxwQyVW+cUr5rBr7PvEIZqnfGZoa+AGVixWMHmAUMqSNUcEDFcqgV5SiUuLnxjG8xaTjgontS9xW9TtzID394ZtyxV3mmrfkh6n+Y94X+g9w030P0LSFpONgQmTOsJeRroJ7lBvbo1XUnGas8W8fYrDhQuj1fi211ITPBoODBEyBrmcJLeS0ttipq3Dv9EpO0rccFVZY7wGtzGzSSsqwAahOVGogMajD5PiZuRaF65ZqnCghuTIJ3TZdd3UcyjvTgNoOqMYetRr5gjWtzYyar+g4rRWbXm1krNYWWCvsWYO5mCbtztJOxLE93ZDcp9N8e8hWhtDrIbp7K6WPu/C19njyUATWbe+LDRdjpR/BFt2vY7YlncTLOpkVpKlqy9ZFZfEXPlt0+LDoiOgZgla4JEzoeUp8JlxOFZ3Cm3fmjVWOqSnsOHMWGU1dP+44BT/PXM/R/KiLtKk/p7RjSyvw7ZaLhv+Az21zues87gNqtbfoLJpGPLeGEgbdfnQs+13XbAuJjLweobDMh0lbgJPgGMKCcHWmToi7YHoVnCBeJi1tQpfJSTZ0S4Ui9Mf3adNQb7lC/7oO+KgZvkJjIi+nkzowAzAigoG/+WSyt6e+A42QlKx9SswnUyqxSiVmcQaq9ZUE3alpLOiJ5xlqoMoeVy7oTOb7VnpGsCu+I8+OzbLVtdOpi+pWnc2wC2cTSVjvJ17vhCYxGjl6uLmh9dCD23cHTutdWDltv0uvak3MZiqwFatTaoRKI4xu471h+13uw7W7XAXz84qtWLU08MeqZWP675iYbrC09OT/j1aWntz9fXeThSW16mPWlbXdWTMD6vreU9ZmEIhSTmV6v255trtiebbrbrEYUwOUK9O6jdZiuXvyebXJWizBB7ceEertd7te7u2KXY9WVWR9WDUI67E1GKekq7ZgPdt0K28NTLLNPOvfmOUZm42uGGax+s+qVZY2lrhTaPrFZjSV48kG7DNqTiKduC2ssj+rZ1oxRm91E8a0IG1sZisc6tnAbvPf7TaXYqy3g4lERArx9HEXDukmSrkHMW49mnTpAMGUojRN6IlUiPcBLZ1zmEIXRp6NwF1VGizrvTxM8rC6VPF7Nshn+51SOcGstYpUuasIrf4HBW4ugxuZm+ckNVzDEumJeaZ0wzZAocWWB9vjanpRi41bZZQPJ/2iWXBTYvBeNW5QCvB6iEBV8+aE67pbbYZcZMMWt9Qesg3D2JK16WE4OOz0mxNXDr0WCdlzF0yHEXuEx8UwBMMTe7JvaEwh+x2cBGnv5wew0zP92Ad3XhLPDJHauMAnSHrnSs7LnDkEsDMlfp0p4euFPxWXcukvxI28oudreUbPpwTSOe9c+5edG97hatpy6h7TlvCUEZFV9hTT+j6R5pxiua5J3cRjyQxtR5l+YhnNQW1EIbLm+a72ARA97TSaSk7iT11qi5P5CxftIUI79a7cg74fsZNdZ+Gd0ZsXdW7a7lV6B6d0RD3vnHuXnUsRyZvOjXfduSYAU8+57qTUvYjOcARi4VF3I/+mk9L7XQC9zlzQH2zh1Z2leiFbeuc0DUd8UYmuFWr86QF9zJWErdvMMyS80bFlPRK5ABeBA5kTBsA50nQ7RDovVWClc5pRGdNU4f2Q39HKmR/eqRAc9sWYsZZRFz8/VgM1Z8JaA/YRlKgaP+VqQcCjlo3Lg6xeFIFeFFCHN7G7pYn2/kCZZ1pXCnmD18ZHw/vmmJfyMS8/TldF/IkJiKlO8+nBIfzHttJypFUyAycX4g+GijhlYulotjJmMrV8RQ3P6+gCyn+O0aUpXTO/MhknzdyuSHWTZt6o7RU7acWRsr6MaLeK1igahoZEqiHAfJ5dHCdUgxZ5Bv8uLHgKaBr7E/5zOHGHM2NL3W40cs7YjysH7WpuSBGYXe86Gg0+Y1p/D2RoogepndtQ5YYON1TbX/tq0pCPeO71djyP5vO2+MXEWE9XkNLEMwznyUJbj2iWKL+93cnbqqzD1JicsiKg8uisThEmp2Lpc2U8lI8Tv0+HgFy5PsVrj16Tk97QTXzZtwRg/WF5nAxLkN0cJ2vkLnXh0uuZBPjhT40xKTIK9bmJk9gy84wQicAMTSekUdFKzcUHNqY7vcza13PmIvOgXzuJqWme2pUa6E5Kuz17QGI/RLTVLpNoPn1AuHNnZ7PxBPt41Tr7r0ylaCZ5BUFXtTbbuyVlvqADR4jg7AynWk8H1zjsKq1oVmgaEYWxODeRmDFHTtbwbNBmtRk42zODZCBkQJaM3RzXcLJxH2m07PiGFHf/dTQQIw4Eo6WEK8xjSRxt2+zHWVFGC10MXPxdJ0WkkXOili1VhTUUd1d2zTZYG8jKLCsokau8wpUDy2edbaYII8UcyGxpYlgmhmxcmOE7GkOHaHYMnE1wdM897ScYKhlIcHIIBROV6GRe4NNrYD4dtj/18Ml9r/AtUpI3ODG4OwsZkep7/dYek4pmGZj9KBLNLpVbXFpyV1/uQyRaCwuz1kZkUHCsRBS0WeAw31LiUFS7IpINGIFi5lPFuaSabQG2Vp8cStkfVX5/UEFqNa4mOHvq0z8CrFZGkFgp97UslGs0dII7M/dG4lcqP/jtWcf2u6q6b2jwJrrcUGOxgUKvpyX1xlVjpJoSi+im64P43mz/0Z3xNnzUKdtSwiJByOF46cBK8/Y2YiQaNQj7dRprBXosFZhwqiz8p6/+0FIcNCW+qPPTAl1NaXYVg8+Kp9aSPSWACMFnEQVnnWcYyohinfAQOwDFyuZyD4rlUICe6cUBz+yJjBnaTMFiLlqpmG+GZzSfWR4dsLf4rqiMfU3IVtdyTH8nw1oOBtKlND80iiinNnpanHQDvUN/wc5A9Ow2XNRYA4KmiZEyfwgMQAAULagWGNzZEiiId1UfVFEsSE2z6WhH9HpuuBZ8oekJxJwON1V9+qs7jgLoOIDebQRJVf4zkCgAkOguLjYrdyPcigPR8Abwcei17ya1qzZ7Q8MlefUahPqOU68vr159cJDxv20R66VX3W3c/lri5OQ4Y9SGrtLYyjHBNOQc8DkTCbEvw+bySGFuTU6Dkck6GRgQTHWTvTbJrU9MMrm9zYZP9mI4ICg9J0I4c6fulJ+6B05Ov0Jf7fOADY4250/SDfmJ7Rz0kT+ENge+dZx6SBEtnWEYToMnarAhL8FezwuWNoEnjYrOkVj8G7kYghdRDpCHbDM/497dbaB9ZoJYbo7gSI1X25QJsROsHBRq5GXZGjE2VW2eGLClGuP1hmIGo0EDrTc4HcBSByBeRBaUyqIPNb0lbqpmRVdM/erRsZZarurLfaWRlQ8jkNKUA2esZcZBeKw2WuKzEma1WosTQvAKCktNpXqF/qfLk1X2xhsW2PrivP+CbQ4CtDrrLmjmWFmoI/rSUBsaiMwElUl18JhHg1QeDZsjMdKOKO2xiBpkNiiHltlhUB5Txv5K4T6l9bqbSwc3rcBJXcr6ZKX4E0p72pRO0m2ln6KelcI9Snu0uXCS3tFxDIwj1Ab5BA+iQ2e+1XmFheztrZPvFwuWxCaiq6xmE+BV46+ixvxaDK2Fd8wSQK/O+CzGhnhskRKbiDmJbFOe3GXtzqDJj054hDuJ26nDnRHkEw35xCJqWyArGrgKWc1MAxmXCBpoeWJRso1ADeGLFNDMmu4AdI+B5k1zIz0Q5bFF97ZAVmRyFXKStiHr3Y6Ge3LXLHFLR8MpDcuLwqPewHoPbkb9Qde9ZeXPeqRHwHzZjM/oCeW5WyXFNfjjFvCTNdDHLcAnq2BrJlbx6ewZWCsPH60qijbeRy1BbUQMFo5KltE2JRw1CUOnVGoKuKcj8Litw0vOiqWpOXhFfPDSl4n8HQRSeTRWayASfSKYPvDfwKYlUkoV37JxHafa9VNlBFWvvhZfNwYBjdnb99vvCT/bbvP5W9U+MY9Lr/baV9LZuROJ1Kt9/JXYeaOJvv34bt3M4HuYGXxWYeVaNgDfVc6u6iFHzR6tqolaSgC1eHnTrUTSCGUDuJWnA7LnBVZp3AdndOwLiONV9sXYqgM4SuZkNlBof2jUNOrWDNa91ZsWd1YoU0t2ninX3ercXNdPvBnq16fplVTPS5p63TU7CbWN6tMlpUltUaGjb+zrc/aaan8tZ7KVUL9WcqSPZFUSLLlaszaiuMe9jl3ovlc7tWSkKWuU2VR7WFTCp2usaOuUfdLf27NNxdVx19bV0upZOPnaynLDshHpl548bOTacD9QwqsTP6iDonrsM88MXywIF5crx0jY9nx1FHZ9vFvfMuvbCWI6dDV93ulpvNvp3rGASO+Yc4i2glw2M7QS5qGeLkR7UC7lU9dtfMwj/AMEHyUi9kIMcnvLr15PJ7Di1rAtdTTVqoh5K2ntV4sDzeVY1SRMDWJF8oJBpF4/UYRrtlxkdOIdH058CHOhR4an7qStxNhIBA4g0IWYtGyoM9Gr1UoTOBVCkvL6YNLZ+cPdthWU6m3UDi1Td7K+G+DkVR1HC7/rT0YGzlqa69lUuA1OX1W3tLLVnwyLpZd3o/NtDgj1cq4/reiB1rc2hOX2ABILPy6VLKz0+wOM05AlXRDDaaFXRvsb7USZVj9rA85XAQdjiNChoWc+Hcs+ohrr9dk12gptQwXbbsptOrgy4B/L2WirdSfKsUA2xh9ozPch7m/09vCBMFKuqqPiWoHRcSW5r5KJJl9leZZmyYqV+99K+R87yAaBcS0BTdWNnLZx4jnDLV0tFU0sqWgmagy07+mCZvICdRnwPeTG9W0FD7HaXgL2D6PtPtLjoF6tdg6mAHdGzzG15a+VuaTBhCNOI+yqtKamKo+LsRA3dqHCopCwKIT2F6WyRFUDgFdNwrVQK8mHTR+iMV+6QLfSYGktDlHt3mH7Z10hZIdaMhuyRPaOjuJTtWdKxf8q9Z0deONQAv+dWgbq9xqtVHXLpC6XHHOOZeF/pOJGsb+UZIePM/iTD91IJsPmdGLdFKxMs7l4tac5s6Y5sKa5EvqWKGzmWKnKjhE+ZCdsC5CVbq9jUk9Oeuq+LJZweP41kTI/VBSx73r0GqlXUMa+IfRzhq1M0+QcE6ruG6rxbFJnqUHlbVC5BsW+NwqamELOBdvEzeRMYcGMsGBGWAB4llydSsxkAJkr92/GszWDOUWmMcDczk7EbIcjftSNmLUbMVONOK4t4mdaI1jjBorP6zUR/5MrdT0b2+8q1q/ysoYOwm7IusijL/paPFu/FscVOO6eRcUP2WRYmvutCPfeEd96I8KJuSmDtQz9ILVlD6a691XFsv9Nt7evuFM67hN3FDrGdETZ29vkpUc3gxdQKfQhRKT1lW9/4KX1rvixkcxXRizie616xCJi2yPryEWfIEPCyLGWST0mCfzAYzSgsgchQCq64qeqHonWzWxrRD4+6Zoqt1vMPB8zEZm1gzb31QmYloSviq1AFqsooIBAp7O5ZG5K1tPYumRuzSArt+vr3YZB3nq7a7CgXBkLW2f845f49eStoz7zv8Q3dOThRCgcZvJS6cf+pLk5r8cqQ48zJRVsxiFAarCaWiklGZW6/e7dNGzt/r1pcfnhe/fD+t5dX6bbe35z8X63mnSfS/bWcFsX7ezC9K9Kvr8TX/Hvr5U8PBJfVhDp/Qz3Ss0Z/pc1XzrmaLM73RW7+sP7Xa9UfjA3BlD85vX3L/cL9oOvJCHe7uDBdLzrpd6/Jg9ubx/s7v4LcbT+ogl3CCp9v9u1/Gj+XjXeQHUgo5BILZ3jFFWILG+Y5YfdyuWIg0w8Af4Q8YnM/Ww+kRxCU1iO57+t7Ch1pbe7a2sfGT93x4S5dXi51Ke9SXek63rRwAL3Q9MLxoCLqPzpzfOvsoq4NJdjz6iUU6LPZYS0pE57HdFsT5GWWfmINSvMh7YPrtId7X6tVTU/p4HaHcBZnin5BY3ab8TTOa573B3t+rseddVPxWN3kJ48pf+Ndj1O4yT+e+TSpKiMdf20ldCSoE22v/btc3XIpg9ONtp9w98izjfg59x6Tvh5n58zcUjPv+8OkvuVopw5zeL2zJRh10albyxUYnITXby4WTj/Gu/+y6MZ/q/0v/LJrsvzE86C/Hk2jZ6VrHtnIOQNUuQ0Q+OJ5Q+AaBHcAMAJQHbMipg7vaYkyAO4UMMwfFVhV66dtiOz+KtSMaEg25eBEjJYDUmgEPJrpaX+gecdZxA/WDkC4jUpB+2rdiqEUlxy2NilyYD4y2wUyp3uAH7rWlA8z0WBL6tRjO9wZfdzxZ4Hdui80q6Q8+3toQ6EQlPydEIL4nVdIkWLeUAJB7u7BxfiX7v/Uue3YUBblOKVV6qmdtWVu6iuvjpVjXA/3IQmN9jmht9pYlBoeX9ab3yhAmg+ZKqFrRpgP6Hr8P1MbPr2s/o2pGbSRGMWaH4bwjNnGkWpf1G+XH+dK/IDh7AohPjiajd05jJ15gIGy3DEp7LNN/nRTpzUDk+2QoUbGhyt0ufGiSFsUCZuTYDZZ6btxDhdAR80GS1vmWueCEe7uwPiPWiTCtIQPB2Iwoip4CDdJwpX0kFC0uoc/QuLz8IURhTCFI8+0AaqjekXQV5EKxF6lTv1BKwaLuusj8r4KKp9qCMJUgnEiSOeY7QBjuTNbs2tMt+yma45EfuWwSGbxaTugAvd1faeDzJIbarLtMCFNajDneCW/5hdg5chfLgM2lGAVwYu4vvK3yt2yzKOVoZ8YjzOqok3m+Z/pUTlNPDPsulycyRjzWrBsYPkTRU+cJFhAxRu7wZ0URt9tqUInTHV888qfqJiNspQEuHFzi7SUJbhPo+IiJpn1CZyflflRWK9oEcisxI4e9BOEJX1ztWLUNX7XyVVHIcyNBUXzTNDmvO7rnhmvXDFUyuBsy/aCeLCeueK9cFkGfIew5vhbr/be+p3e/Tfm2530O3uutgr9fZ/e7ua8dPNGZvd5CrUV0o75X72ds1Sg4PtlFXh7T4Ac6Ze3kQ3DYKX++fz7NyxFvHZfw6SDRQ+q+KYjroW5PP/HDJCO9ggL8MWascRLrwZl8tZlDrnoZX3JtwUDklfmxgfv1AUXfHnuvFoivVJfCBREXVQcQU1BWtRVbyJ+NKuJlSEdl4O16GkFqWhK075KQ6teX3zbw8Vlel3jyDt0Ml7e/3uI+vdrQfzrwInuWaAnlkDpEM2tzuVyhOHUfT701dYNrmrls8XeXapI1yl8MHscgdfh5Ig7iIET0K0imo4uLmc0yJ8oT5gLg9mJSe9VEnJZXARHRRXFx7nbMbjbdjccNUu81PX+LmNar/PJXNO+mredm9J/T/Ls6wUC/l+GpQBYr9cIPGmC4MWtuK74vceDFpgNsb+iqfNeHF5uCZRwrqpOQRAmY94ovREOhlCH12xitboQmaDK5kJp5ARfQqks2TDEvq0lMHgTCIa1VTsOFM5Hc9lAUf0cRPwI4FhBiqD8pn00DIdCB5i+ynCwwfQW8KX5YYvqfLeGLGYU8Nc7Kfw2jUVyUiBH9i9gkBV6i/NaebIrTPZieLf6rEWizmmu4jbMZNOeEJ8KBIqYkabXTSBrxm4iFEjYVkXh7byC592U+LDjOXZTbc2Aesaoy8YF+o0GBY2hq82VWjfT79rf7Lvpx/WxprK+zWvitAxUoxX4SAVeiMfvQsHkSAstf81YnLNJuWDfD+YTp+xzKSp5/OVYIRKOnxTm9gtawv5m7qnsHzMTWrPGMDBDDLTjzyZim41Vf0Ytn3Eq1VSMjYh8nE6LGlZAH8gf44UJrUy1X3i5f9FKB+GVgC7z60XK37tRqK8MUbdT3ZWGBJ3HNoL/P1H1nh93Zqy/RtaHFc3zefv25+X+Ly0FBLan/lSw9JJCFuSAOzHWrFuJ9pgj0v4+CDNygcxDGcGRKfTetKjuy9C4uAWS2n1mFkkvj7QyKRn0ExfPc/1LNdzXM+wWxu9YIq5aXkTQIhf21J8OhEobKDZh485pmylHJtI2rkJox1tIAF3dJaRpY6R4hrMgfJBcnw09LzEdXAzp0CNE9YzMZeoo1IdZ+qQ3aaiXEd+ggZXqzK39Yna27hXoQEVNKK0flr+2Y1szNPjZBHJEqd7nb5spRuQb0OjpXtFXAyWOq9DWpy6KlqqrdrqMB18ErGEAU0vMqhBtl5DqdwE4rdQPgPnjc9AZeKXqYgHvNHlmzqTstKPW++GyaaepfiOKO8wRYR2JPy5HSuXgjh6nqgrFJxrjpV3wYQeT+bK05SrAtKdFLe38cm83hKNTNMaKeig60faeTHMTR/0mCLEPCtnKq8CDXsHBQzBS4OKr3hPrnd9vlUzXeV7tVZz9Oo0a8Wsh2W31hG96dV6tWqPr3mIBCbPrWDULnuQcFrhDVKkKvV6g/PMa8jEj25vEcjGWoLRSXl7W57gGJifpMTh0wY3dLVmZiWd9Djnja88jqBoa2O8O64mKqKNCDuyz25FoPrYHcCzBZSDcy9saVkOImrDhg99XSKXmd/6cKhL8Ie7ptm1tSA9N3fV1uYRt+99/sHuwxOM7WKN9tnyW5S5SoqkbHPSoGCGgrjErmgikiqWxzjTkClvTizJLbk+eiOG/l7BGyxU9nQ0FOHpIChu86FnPnAkFHegcVMPhjtSu+tgPF6j2hMxXqPbkwk3E1fIK84KW5HRDEfboPe8Qe9Zg97TJhr1ArLJCxsjgbMXe3sLPXSEcMRNXRg2mYbM8C3st3NANAEucOA3PEIdXgSnTfQbdWTkDkO5MBsA+xLYcS5kyMwYyE1CzzQaJ1AhzOh5Sc/w2B8gveceEzmhRUDp9Dx3AeHCzC73eymdxAugan1FnKZXwZHpSsPHhxP2qgjTPFEn9qGJfkUf7MQecmIYr6zELuusA4TLPC20bK/UkjyRS5fp42K8sBSMWm+tb37c/krvxHsrUxl0h84V/gb6faE59nMa4w2U23y+lGedM++8cw6adXmsUePGCtkdyUt3iPm64fm64fm64fm6oTWuANUeoHLGuTzC3VhraTQxyTZvnTX1DTZvoesEueUdqX0qqxETbgYMWl80aL1s0PqqRbWtk5nWVjAHMtf43lHnsoyOImzVv1RHkYWsBktZ4ZQS0KewdYAJ6QAT0o66/Vxmatupq1ME1UlhOb93yKptc69fPx3Sk8vivBThFLXoWx3TcC4fKmMwXaMiXa3K9Ik8MR/39kxkK34X+chJRrliyJOB/qbemcK4gxQ54P2x+Y43AX+67HsWQY1YJY9/ub1TtuoaH1rpKk8XX+veo2Mjdhw6HVgbxNTVVdu7htoMXAvvVpmozSGq6utRfa+JkqzvvM46qN1p/RxRN4JztYMcmf2n+0+3H88rt+85XH47h8imAxzEb4U2h7X1jKZR4b04f3eYysomxSWskpgSIyAokWE24l1CS4TeemBMQXf39sIWySUKmHsZSG5hiO+QUDdUSNFuWcQLGeFEiHQiT39TnpzyxE2e3mY4iTI2VHm6m+EkqM9tsR7NUD+LyxbT2NyyjlkpdNJwqprHiVoVWJTovuMdmfF+rw4+arhtJxYmEGOgZqBSMxCqGYh5BsQmb91EehM1Cu1GKgIKxppGCnl6m/IUTGTrPP3NcOaYF5PncDOcOYg1Rlx/0cQLxzrddUS9YyTjDnL3uHOMXGvL8+Z+AbTaYg5jvHvDIJb/BMRyBcTyTkvlv6OT1+PHR4/6j8Rf9NjtHT7tHvX7h+KrUB71nx49ffxp/+njRk7x64pgwYpMvyJTYOHHz6HUVhEd59BvduhHriXU/CWsjzaE9bCxoFNxmb24WWQp9SUJaEf1exC/tRNdt9a33I12cX3fMq8x0YXNZSaccuuJGNf6r70RFFK9XOfp0+laeKZE5PVcS9j1uy0XLiU123J3SrsmmGAOXYaavw3FD6E8+MMZDZx9d+SMj0/kH7R70pP3X77zAKEaxw//B/4Qm+z819SjX4GnffX8P5Eh8N99QlkeHiRWBOVaJk7k9gcw9VHIDdjqn0pfs0FGrsKm1h4okbmMnffQ2x1wtGQqcJEOsNOJQj0RY1ksL88zZDiaiHdRntHTo4m4TqbQeR8/JuqdXV4G9PgpMX55FBIdylD0CbsweGI8fEEvOE8u6cNTOvIiDCFV2Z3cWYKrMq4NK9AmWTtDKvl9tPtgd6AeoYHC+bjFdkZOGO2eICc/11mLlZwFZ/SRsWjl4/62cnIK3+Lq5zozBkTu7JT8oJJ4ZOzinGAOQ55+F/qMRUPH5flJm3mYQbSB1IkWoDqtVpC+ZFh40EkQOlpQ8K76gSfqhRWGOm5dAKtlqQV7ZmFTAR3pkDXxEhUi2AiqoUHT3d/1mvO7n5jL0e6u60G8q1de4tHaq5cmvSm9l7zRmaC1aAFKfFPU61sg776xhatl3LwI+4VIh7qZ2cYUMUo1+OTV+OJZGOE59YxTP1mbxmv8dTVTj/Gto5j0RPe2+eS6ntPM+2hXbITSTDVBwrDU0LoGWp2lhog5H+3+TwWwnvs7RQhj+X73k92BNkpxet1up3RpVL5IbqIpYoScD0p5wtXkkNQ6/FXfZvVdEeIzq31NN12EN5RQtmC4J7IX9XtM0L/L6HQUaZC7UbprKcSIgwtBzWYar3P0usQhR6bFazuCK2L7W92PCzv1lRkkfMk+0MMnrliYgrQMeHigKJgPUuK1Nila/JP1Qbxm4jvfhvKwU0+k/0SoZ0Jk/ajkasnBIRFzSNyCRivX6FPgXnaUD7IT+rUWR+YHtaodVgVl6FqrK2uvrcwdrKzSnp/Zy5S7ZqFc6rEPVdwKiV8/MIq9x3j5abGI8udBAaW3mw/nvrNUyWKbf+A9NCN2Odb2+81KvgwWoorleHdJi+cd/QvoX0z/FvQvpX//z/9NP5f0j/57S/9O6d+X9O8N/XtF/17Qv9/p32+7VhT2MG7HmLYo5gU1fUENvr21yegsq4ognRajPEYY5iDWEVPr7OIlBzpS+nN1dqygtmZOc2FgmVeOJ1p9jsNyhrhLgCEJx2BwQq/yehySpJIWmcn9kNjYTHvXhIdEpWZKpJOO+YlX0dcdh0pLKu6e5MSDueylVypf2uZIV5PzjNbnVZRjIhVyRHSuI5S2hiGs8jxKw6XaUcwbWCrqZ3aPnD3OGdg5p7RmLwPabPeRU78hV2XnSonRzYM5j/8GgrRB8SBtyM246z+dEMnZqJ8w9tIJqyc4zaSa2oTCXYRsbm3NUQ5HSyOQ2PqNp9rORUu9Kka7/+//+r+Qi9+Qp2h1KyCaT0wkctAzyEkTAbZR1yQ6y3ygMrliFON9C5JQ3rYg89K7Fl/6M3OyMKwIX/krfmNpcxZ89c+8w5lmFYa70PaQZyPnApqBZ3L3gshLFI/PYIVWN3wJiyCJ2J9XTTbhTG9viaBIVrPalXiIXA5ftANrNfpELad0xZWey92HyDIbJYPd/8FPe3sH4/Ps5tfJgdKRO3Ox73pnvJtcGypDG564rAtng4PxJwurRIjvN5LbLK7lwXgaxReLvPikyWOFJzVjjIN4SKN4Lk7lJYj8bsgD4Z7KGw5vIEpJk1MLNd9oP8XH3dvb3kF5zM4QSlmrIBeDG/u8IBD7DpcJrWOc8jbWqEXXVu49WnY+gmRCAJSbixPYtavbEKwVeEbOrWsNcCja3YyT4Ear+UwjEFTzcoC9y2Mo2o2YIjOUvdvoV9JW0pyhErc+HqVg0Uo2kBVv2KWNB/sVbxfGPgTkjdzpwQrJeTPadTB289F8EA+I31ZxWUwiEYS5681onJ3dQiFbFY+feN+GB4cTZmZOPYcqqPO7zOKIaxZwYlysi0bct0Kblnp29OTECeWKyrB7exuePPrUfU+1HT2GUsgo8Eqb6axfXDXJdt+NVdMFJH88e1C1RJgrhcLP5MwwqaZB3qmZxdfy2fHC0o9f+M/qTTsFEhtPJQTdAH/tleK1OcwvfANrgCoJIIYh0hhwTCRDUr00Wq9tLJAq/TW+2Ol/IP113bln0tQDGzZPA9Kfn7kriEMlVRaDJaz4qZ+XDUFbjh7TcsRqsxaktWfVLFC/RyvCHVhMR/Opi0/i9IM8PA4ywrTmvT7xzrX+JbGBcXKzkYubwy7b0FI+Q4CXAErn9+LWfscFPHNstELrOJC9rvBz2CcwIueEx2uatM1WRahGvLiX3d1ZWh5xbG1JWSzDmAP5acVKmcVGQ9MkqT42H9S7yGIruHi8yrGrkfZ/XxFlWEHH4/UYMKrQPxucD1Qxa1dRSptKps1b6votppSB+yyUIWb5rh4abTG1Mi46lYb1fc2LDYgJFIZdG0DQYdiSwZh2E2IgiQ/gdT2N2WW/WPDfXl9cxEawJZaxvIhxNcd/j8RZLPudi1icU94n3QN6uuQv9CJumijW4to8l0EqTq2Xvnij38KsEM/iJkyleK1fopuFeKGf2XBfvNRv8+xCvI1rTBTP9XORpOJV/XyR3t5uUmcmUt8b0N418nuD7p14Fze3auKhfqEWNtvl5y2u/aQ36lJxvze6iNVSDtgviTXbP64WWMaqhL80RYoVdfovrCK0Vp/TK26pOpYi3N8xkQJLRUqjFG1H38f7s6D4/jp9lWfEl5XwqYFl7uLTWD1PODcfOb6mc/IXUUBVrWrXA+b+RZRdRmW+RHah8z3P5vOIM66UMFs5NvJY5S04ACFOhc12BUeiLkGHW4pWBXfie2rN68UsWmtMul9wskPNYFvSle8ls3dZPk3SgKiuSJWjDgcX+KIcqwhcEyp8SsQ82QTBbrwNaUv7S8k+J7fW812S6pP/Sj2fsVGP3VTRNe3aWugfNu4zNbgatLYaXAH521o7mtHZlP8fNuE30wSC+qWe43shjkaI5KOowxjTLMzP4hXFiTab5CsVN2XlyeGYHNewTjr8jJnL2hE0uwRxh6rMCzrMW2v0t5boEAHbGo5MVbRQw9jUBcd1mBoOq5KKHiDrTCvAv2uW89fblvPo6/ZqHmgaoOw7Y/FVLH6NxZex+DkWv8Ti91h8G4sfYvFNLEqa7EJggAsBc9pCBMq3xRtRmYewkMoEd/B3LOoxMy/UXjzaXRxYPErQQGnGW8aFeafisijuRNN7u7S6lPWCYlgVULhzQJ/PYo+YMO1no4FZvwKkEhOi0fLv+E4UK4TEfa/hncUtzInZcteUnBcW/4Avs8Lh4bSZBG3JXheaFeIvOED4KpYpDbssO/ISgy/fIPask+IVoQWuYpfmAxQ9tRmCwsYlhwu7Ps1eDnVq7FC8DvIOIlJtgBgogKKSP8edgA7qX8adzKs6lDWB7/iqk3ee43kYqAE4jZ1YQHaCpqKZGVoVNC1SDt/13dEpUJYpW3fiCuxnWBbWPdGiaM7ppXbaw8sHjbXuoNAgiBg7qrnP8dECc1G0+SKC1IE0iJWtOris8VBzB3c1Tallq9RY5+0jmm5flRL6qasC7vJXoZ901F3+agG90kCRy1MiKWTDo4aHR7sZZ6vNAHihYOsGWLnPrRF7F/Pu0SnrrpZ1V3mkh/hyIBU09bePv7zSLwtxQ6xVIU4L8YaYp0K8LsSLQrwsxNtCPC/Eq0K8K8TDQnxeiB8L8UWzrgtrXX9d1Ov6+2Lruv7C4PtnAGQtw9/qd6zD70BZGgrQJoTbVn2TkYmhqOv6e6Wur1t1fQ/iRfTB+SWWvvMts6AuUTt6+SGWT+mcOsiLk2k84jd6PvanUHNFDvpKxA++eohAZux659uNdGMbbJuK/K0RACQI8siskONfsLyoXAlPAse/63phjn/yA15+wIvFxbXoAK2qcdkhMpLSz4TF7lFh7A4I64l+c3QoemRfQoKdVwnsXXR4LbD0EznF36HRRSh9ov6VDE40TQlZ2aBzHnfgWucGvn1OqI/D+A+n6nwTQ0s4PK7orDbSOgeU1a2bnrkDkxHKVKF3+LjrfkI/PsbJLuqbsvUYUFln64gQzRqVx9/Eo78KmlY6m56oh29jyNIwnu7gL4wVJbQ+/cKfvo1PaEJHtG38EptEUZ58G5vC7qA8+Xeha2+Xmyd5uLVLtNvKiPZeafHwXxf2kvrJ2ne+x5c1zGwtCXijQuSnhv8x+NegScQTPswV0b8BucX0jiIPXkBHNFMDH3M2MD5H4WiPWAOZDs3OprxHaMS0uB+9ZVrMlMW94COaAzbDtfZ8XI/ETl64J1M9MfWq2rAQ17v4V4vGOqkvIX0cpUC8Qdrk+2p9I/HTloXPr+s5jnnPGqlHmGKrhEF6bKK09ybHiuZ+STRUEwlmgkBNf7ap6e8NNf1mOzX9ssXIzMWXDVVL59vIZKsQ1WMV+qaw6dHPZgsDp6C147H/MuMw/IXoB7Zj2ENgOy55O05tMcUvdfAKz7vEFuMRa+JfF+7BJXYbekv9U/X2Bm+R/4bfLP2RQjVYIe231pdvP9i4h7RWdOM+x6Nq34+FZnNqiD8Ughpptjar6T98CDy4Kg09qYFnGnYgidt5xy6zPy86mf9j0UncTuDROz3m/kNK1O/0mPiUKad3lzbYTu7RW+L9iCzDGxqSgLZj+u1QEz36J3NC89cq5XNKob4llPJCpfxIKdTFjFI2d+qb1mj+bI1mObe/RNaKSfElnzvMBFgjZ5eOdFidV1j87wrwF8y9poqHNUXyuTWQH52jzV3I5//+vNTTQRtYPRW0g9XTQDvYC9rBoALnikL+COcaYg7XbX5xEA9fKio4x2S9Nc8Vob15plKYtIInrVibtGJt0op7TFoyv7eZW6YHp5kYx7ZQJmLuqFClDl+045rd8t6UpFd0OoTbJvPkRPqxkR5b8KCVrL872gl8Wb838FsucYJ5i2reYIZOLkDKS7+lBXFAJ6wO/RMcx7ABUM1X4uGUn0jKNoIvnhH1P2bHUcVcOTcY8OuAP+q0QWAhd7hxbG2XCtTC1JOmkWmrkWnTSCoysSXR1rUj19G4k9IDSqnw729tOcXcZt0UFufyucZmde7RuNyQ6KApE+g8lSrLp7jn+kmfFwmn405ExzoTkRgHs5CQH+ug6kR+TKQIxzMQoZBo0MRgR7CGCP+43sQniO16vVjV6xV1vZFPraN6hXWUVA7QGorkWBs4oTT2ZWZywSESFYDORUee6wR+qJFcAn90/lLlF7U/7f6IT0yX8aALd1erPW7VahD9PpXbszybt61y2cfIyjiqMQtxWteRWJORk8jUywnZOKJ0eNAn7pd48zlRqwR4wU+ZK+DxfZQcZ4PkJONwU55EKVf5d2MtbZqNZIhsxUk2KI6zYeHL0I3B6I8D4fOhnyg9PTzHA3vvU5xcjFUd86q2Dvoab2lUFhy4HrwS7QN8/aAp9Oex46fjJiCZg9f+BELziFhH7yymI5X7yZl18bKYN4atjXmXPnjaS5VDu+qYpyoMCB0QG0bKopipVvMgcDqLFkLlES4U21mNsivoobYUY7Vl4z4l3VfRLnAvQwAK3PCtSKBg+GzWPbRTlBNCIofW6F2sE0TDa7rH4HFvlOhEDR+lWGKLGpW09mdt2/3OmHZnxrQuMoZ1V3ASpazetbBrhUO+shC0VkE39gbjifIotdFFmgoImzby0p57LIkvtzSEWLQTqPjQsNiC3/DAVUUhKd3b2wkgr2BxbmKfDQSCembsoTdzE42PcP2EkPdN2D09jHxzlVhC14ClMP0OjZ+J+8PShSVaULLdmtjBGSLUX/ez5ruaNbHTo++rpYO6dG9j6aAu3YV6DEMw+v1ssqEcXdN6P5s7Ff+G3FkBQzcrLhr6HVJnaSojuRPZy5lYFIRjGVreomYSKiw73eFs/0o5mZjJ2T4Cx0ljgjuMKeWdaI2ydoxLhehbts96KbP9iCdoyqoDqmXxasvqGSFKb2ak4BnhU2FOIG8IUkq/iKM+5NbUgaAUaLRnQS3KavB+b5id0Lz7/r1rWNCvX1exuIsl9zxzCTANyFQb3exQF92hjSHWmjyba3RucNkyL2JEZpNgjDkuFFIaYVpOEcdMEBEtKUSViYYmsasTrSrObcZDL3paLRcxnx4Hr3RKx3HMR++CCaR/YUuRL1s8wzmreOZKwphgG+H79DFLSYXPklTRnVhO5ljANoQn22SUy2XsTeMBO7ZN2EeNv2S63OAaxwVuLimOC+p/7LILXGdOPY0nrm1Ix37L2FZvPlb2j2jj1BUXcgpBJGTPYomGXkAJ6g3/PaMJPzvGVc0Z5b+k79f07ZSAnKuOnhO0s4m4BKxz4rjleQ3rGrBuXHEKWPT3mbz0F1AiqWXgL+TrzjPxUr4ghk68lcvONVunG5n2285r7HovqDmdU+8ttsIX0FMIPPly9Mx7TVvpgIr/sTiR0R+X9KOa9BwiNNr9qGv0e+6y9Oy52v1e4VsmnnPaK5X2Tjov/+BG+b1Bz+0Q6/OK5bS0fb+7vYWjunc0A89ZbPCcnXZDc5Ea8UfdFddYYzoBBJK3twHvF+Gxv4jdP3p7leW+yNopVpldm8gDI5S8H7svQgyrAxBtGTMj851ae+tFvYkut4ooZvrwd0WLsxE7nOk3CB3ORaC8II4n20QWBsi0BeTCArIEVYInv6G6+6GVkUGKaRyGj5w5jIpXJMnoG/F6V6DTp3OBsD4JZHvwXLA9e3tjirSTBPyA8AiLqlAJDvnZEkvPWccrkJnaeTcIi9fqvX+Nol2ZLc6ZqoNNyX/29gxBxZvFdulrKUt2ZzEr1lQsaLPbKLtbtuYr3HTzeaUqqexI9aLYWOUZQWsJCZkVsQgpeC2ORqYCkilje2EJDIe1dxRiaUJZ7IfzKKBRJpSO9xXjRi/TWguNnSYpXs8oBleuCd84BbHr7YXK8iqF0wcEQXYblgexkdhX733xR0fu4NADFmOD8AUWY9PaqlScB/Cm/b1wb2+mWjlrM6izhkEVgckRJ/Myyp3reWMKObO2pWt7W6rPRb0mw2mLXYUaWLl/g2YSK89sKu8YA/rFm+s7bN5qcqStHMzR3gVzc9AKlHjozVwSvXKs5aAq2+neuaLFcBqdTzhGyvk3wa85Kmw8A5StsU9l706sHClgk8qgKwmLgAvaES8QaZM24syP3CH9DbELE7UdOeZkBJ7Aydnklcosqcwybs5NCYQupbVI260w2SqVTb1kLKgh/nkAx/0VEfYTyTIICOH9RB0O6EkmxNSyVDzzK52a+bLi1LYnFLUB1E7O+JTu15erD9TlDfXqmlCbz6Adhy+Lc9ftMA/hM0vRcbQ4wlUSNvfASTpZJ0D0QTqj0hDcscktBvLfGgL0uk6JJI2EDCADqZpD29qMKqB0zAEG3Ale44M1HHrQ91Pi9Fp41BqXJugsLUYZdZZ0ONQNARYQrTWvXful/Yneuq03v1XOfvNXvvrtsqrO2iVt63RIM6W3bmYxj5GosXWIpmcH/QZOtrXp+KIIiklJVcwZJbsbcwuXuD2sicAzS7qlLwDoaHUJZYP0BJwxhGZoX1Mk40A+ZhaUoIj50RNLNhJwXD0zFXLcE13BnusVc1UycxWBnMkLsFTsEylTxh6BX3XYHfKO8Vi3k+/tKZd+sUw7wUEIL0lpp6KHOSBC/EJ7wBmeiMe9KpyZOAPYQismE9dKDOgF0pllpacpnpZy0Vn4Fx2HP81c9gqLs+/y2Jx2r3AlvwQve4ZCjr/wr9yDC85HFZ0hSO0ZBC5nrmjcbJ0plX7ibPnMcKPMoa6VJsSpshq8Ob6kBX5OfPGlvAHvq9r6Rt74l8Tu0si/0cSJ2/Rsb+/0+JpLXBOkUwJDLPOz29s3IF/PRtfe6Un3jzNcTAG7zoBdl0zargen7uD6WOLb3h7nkKeDN8Q2/+FcIrnLybjqutG9fl331lO9NafxwnmNHo/PBHX5tTuxD1uVU2tcJTIfEVNJewef9o3o5NhPRtmt7A3SExxL6LFPGKdTjwaRSX1C+7XZ1G7A/m3aLJQHkQ9uEbEMwfEWG/YGOswoSFN4x6E3OMjJOJnQIh9djLqDil8HFyN68Jz5sdlCXKSyhcNOyk6yQnnBInObDl4QrYdjLfjzCGhkFlC+v4DkeqoeFvCzQxkWCOfT0wXcgg5mF9iNbFiAsBBpQ0qnQKcpnyYGNfz1r4jiV9o8bCqnNQmisabW539caEQfLvei29sd50pVxmIO4nzQoHy1QaamK82tXRlurfnQ0x965kPTjIFzn2xb9pWVKgX0q+92Lm5vqTM8vAsXHs9V5gVyLhhyCj6XDhqRXG7cfEIzgaryVLP027af4tbBEQ0+gla2odQIhGfAXD6ICOXzlcZxTJtGORkwLS7pZ6K9pM7Fi7l4ORdv5+L5XPaip+LVXPrP5w3dfWed/JobJaZ9NZt3jNN+cgy/0ekxQoRnxzK3/XeDW6iE3m0wswhNXm+UCU93QLkq9lruzOklw8vtLQc5cY+7f1TEFk+z97HZgRCE/Pb2EH9oyUeigFeBQWr8cBFAp/AqRKk8clUcHEZAUz5TgbGwRVm7h+1oG1oCrK7FxAz2ON3B4cCkRnVqf9BTqRCx1qm9QXeAv4eDvk2pbEltSOh4A38VVhNaXh6xm7FXRayzxp9FhKhAo8jP2c4oGtUKZIMev9cb/KCv37Xwd1Crn92tnuE1w2o5RxILccG+rc7EuQxor+AD/Y05xF9vFpDf6GPbqSAsjdWZoYC0fMiSwCXIIu2IisXavBqcU0UNp3t7y729y30lWndq0ehlfeSiXdbUdy0o77l1wtkqTcDGBzG0iPFzRq36kApoalu9tP0DgU2ppZgRh92MapmVknjHULINJXaCOrK0krTCFxNTS/pDe3LIcrDQzSR8Nk4FC8OqcajObyqTCGhRjaZsgTrzM2Kic5+4bWdKvx1iw3FZ43npYHos21mOW1l8v7lSuGOG94xWLfXFCSH+CF1zEh06RJYT7BTB6iE04sSWbL0lUAhwXrTIP1GHq7kTEglIFU9fQ1QZhsAwql5qZRtL5HCtFYr4D6Z40xH/1D5yJfzCcS329rSKFEfvdcWVO6ezwIwqm8pK8EUGIkqct7pyXrO1dB6pdy3Kt3TtT40NImHTorEIfjVvzHKez7H90ga/7euF60IMOc625siYWd32lVo4Ge6snkTUNqBdQypOMFQsoBK/9uCgDaSgorFg6hFyTD0ZUcoce3Fw0lV3KsEBsbBzHVM5ODaRQoaBDnoWNJGX5zqmc3BS1LlOlDPPgIM+BzKp4R9vhL+x5Br8ja1g+Lkfitlq+4nBvlf7Zx9vf1bDP94I/4Ptn32w/YYgq9iQ0EKrvLgz5ytmGdIjUcTiGDELU/WxoI+p+ljgI9Ex/I9W2aUwG/bow9gN6tcjrmhJ++/mXCHjDvN7ddol0i6Zt6luby2aq8DdLWiJXUiYOFc1L62czj+cr6ustRT7LVr7cK4p+49zQc9GSPv5vHXt2iLyzbv6alGRz+c2SAve39Zt6I9aMvVirlXnX875Il0pBr2d69v1GswX1p3nFxuUip5bSkWqKJ9rS//F3FU69AnWtlaLp5X6dt6J/JfzTs46RfQQeW/5bfh6bq4X6FQYdAKvgtYQlOfRWDQ0QgMtnutvWw73eq4Vodmm4yFV772e85T8NJfjmnJPxNc0Q+wiaLexAtoVlqXN4Ke5Nazft6+ef8KWRs35CduVTAW14eu5YjQ/m2+z8NJlv5v/7zT0omVHFazaepljvjko7hBLLX6br1t/WQLEjYZfug9/zbdbM/3Htl7Uhb/mxuZoQ8u3G3vp1n21tXX/XRZf1MSvPtjEzUZdun2/fmD0/htswahxv36wcf/NBmINym3BtGYZfddaRjvOTkl7zG/zLTZXxAX9Nm/bUDbKye0FifOBXqOWYvJ8pTvaaThu5Uv7Vj7zPN6wAMXJGRAiGKau1R3E9NS+C8x3+kG8XRfJEZ8Mc/51Ii/3E+JDe35tse3QKcY9QCA193gRd5IGcETErB6rRmW6PVI7uL3mYEBfEk37ed7WHf7SIoF8zYCMP8+JwVVXM5YW/M9W1vGKdpd1VfRLrTqoDCDmzIj60xhRSoxWz3r4poYQ59uCYykdRdfWivr9f19lqShXKvvW0pXa7C4XkRmnxOws5FO4yD18jNNcf/+RFQ6oppN6D1khLu2N5Myx6z9rJBzUz2d0nD5YuJ0FNWXhcjeKus/qe3Vw4XYuqIkX6jumtZUhPZi5nRmxQjPX3FltCj2GDfmTBUTNiD4GSOEqpOxg6namNCLTj0O6sCHFzRXZFXMcxQYfCtTzbXHRPrIVl1AGuhNX+1lVAvo6cA1A08926XHh5E1HEd6rdhcIEbnlhKhOh3rRhnRIY6kV/8DNucl8GvzFju7Na5Ly6+CqleA20LnA/VxwIliBFtkh2IIW+FXSuFMXgTQO1EV+EinPH0JFVSqJGzsJOKmCqRIoI50eG489DrxmjMe5qCZiHNHZcmK1EY221J0/0MZUepFuY4lH1cZMp7IKjkqlx/Sk1G6cVTTiiHhIllvjeitT+kKb2kgnbjh9F4lqI8J133OOkLWeIX5p5qd5dQ3UfzA3CzULREZ4CuhcPhgvxEXdwJUh/BComQY1tUDNxJRBNf4ca1CzD4BaSm9GfPcvEJ8mAnZ5sfwdkt0SboMKfKiI4ODDHB9yok7wJ+QOlisY6ozHMD8T/tOuN41p+PHytEu0ezJpI7vJ+IQ/qoxPuJCW0P4wF9/QKXAm0pmIZhLuAEU+0+x8Yh6y2X9gKJ3ZGjHBTGSNTkw82yYcaxWySmRGcQNKsTNj85XMIAXSrd2m7Errb3bQNxta3cnSZpWCmapb1VHNLNmqCr3WfAxn4gdEKKDV8g2dfwicJWbVmRPVwnTWKf1y1sFNB/K3M8eok0rwVKhZKWbUUTGfceiU2UzOCeVm0qc/i5mczsRFPR9tFrI8nsNnORUs3WF5MsXLlF/S4xleCBbt6enJAi8LvNzdbz5XD79bx3g8plbOZoRrU7R2UvvIoXZQhb7D3ZHs6ghDz5EQZuJqJs5m4nwmLmfyYiZuZsQvXu"
-)};
-const _1uqcalu = function _d3_part_2(){return(
+)}
+
+function _d3_part_2(){return(
 "PnFD9v8PMMP6/x8wI/L/HzFj/P69F4NbN6825W9+bH2VbsfG4j2hcz8bzBtb+3YudzgwSv6gIKwLsWgB9n23Hx7Ww0fjE7eDujjtDvZPCaEt7MDl7PqKP0OxmcUsLN7OB0RgNBv5PBWMfXqoeURonGiEaIxodGh8aGRobGhUelhdevNELezDzCv2v6TYXnnVr4/W5m9+uh9eWhLlt//HwmCN4ZMPl81jLu/XzWiiLln8HLWerTtCa4b446xKN3cnf4hhqQdAiEV8I1+DP1ej7zUry+xuu2Kn6ctcffkpG0vvxkffkbX76eOYxnti3yas++5p4tZ5JrvprJlcq//m/s3wv6pWPNOWjDGWiDzk/40OQmBPfkYWd1NFD/9zP5fGa5BpnVPpbPEBIY8RLKu89mlh/d92d5ME2qYnC0/0iJx35U7xt2Qu0wnr9rpf3tdx4qM/OIW287rDz15cwWQGouuhsvcGpnugzKhPLRHW7FsbdhcY2bCKZxudfkreMQtSEjKsObTFkK25B77RhF7UJooi606mltI3DPHvWmJpMtyFXAvFaurmBPH4bOQCwJ7PhtJr6bib9m4quZ+HUmvjS73c+bd3JrhH82i+GX2cYZ+I22jt9nDkOnQ3GzH2/Hj99mH7gGo4/qSnobpfS+rD3lfrlx0/5Fr8q6Lb+j8/IrrJe/ZvLX1m77u8781QwmQL/Sb0qjw9s0reCvZp2vZt6vs86v4CgYAhdn5+8z+fNsOI/KBz/MxDd09JuKdDoM50FRPIimKiBbXoUl87AalYPFIoKpswmE2HazbGK4taJyKU2d9ASGKY3z9x+D9CJSHuD/NB7gp8lFUhaDBw/fl3d/crn0pPfI6OrkU07ZkfKHmamK8LXb6aTDH6hP1IWW5Rg6FhE+q4YrhyAqZgcXRZiN+jIy58tIk9MyOKy53nE06RDtK710DLtD3aZvZnAs2UJgCWKkEuTu7p1FlrZRI0+To/alYZsI2dd/q6THuohYITj1VcMamXFMX3d/310nLc2d4ccJisKIP08xaeLh+/Tuz4/TE13mu6bMusfPj0BXY4eIPNPbWzsvJX1j4UebAunXYT0/olXNZVegokDXVt496D7oid4DJPv9zpYv+PCO2jUF52wCeymIwjg4OjMokd7V+DgFGqmb+ZXmtkLbqGbWEc8G6sa3Xv853FUzsqcWspdtZN8WnYdyNhiewn+NbfmbTLe4KtamdrSMs2ltqpI/SKjFLiS4bJZTq1/QEZUm95JWaGRbTk9bzvCCaVt6h70vWbzgox80fpo3x4owXcBXu9N71HX3yzxIiznCcY+hw6gio+3gar9VGKku7nUiUeqGOZegjSn9aTQltpTOW1LQqm6zOSMjoRFMNQFnlaSClUyUv/VUSSlUCrter6+p8wNHSzZ8Leygo6BO6+k0vmAMpKcBek7uZx1TzMhIXPBmlc7Uo0xJnak38Wo4dIS0BrKTtYYyEJUyKLd1bla7zeMw5mEX6aSVN77vEHlQqdjUdQR09JPNnQskfdEdaXUiaXWClRlWOlH8Ww2zxl9kdeVs4GW18gOju7Vh2dRmbK29d5BNN3J6KuADI7Ct47HBtsXO2Thk3M6v6qy2qclGLfCVvB/RI2q39z7OpTaUMBY2bOY2lb3HYjbFxfBhF5bgluHN1L738NLRys2UyRc5GwPdKV0uo1gc+7k4k4WfiHN51bnyzjpn4ETOT4460GX0fZXxUgYeHfRl5U3FtQy9hTjFGeqyc+nddG686861K97Aw8X1gTx1leYw/XcNbeZjWJOxQcFcWTlk3pxQZ3BKWcQlfCiXzjPxxoUxHdDtJf0hqvFWvqC2PZcvqW2v5FnnrX/VeT50XnVeHZwjfilBdK46b6nFz92DcwRfPtk/vL0NOjOv6ky9sLM4nk052l1rHF6Il+KZuKRmihv8XPNoiKXGM/oMiyidS9zQ99WRqy3l1raNreNt2PilhZlXNd6db8WrVZ+N4sISX1xuw622E8dWmSubFV8q9xuNHw9jI9F422jd5xRsFHOh+fYz0XJdaV/fNLbe7DOMXieg6CV/GEYIx0vjo8amkDCmFnP6wzpJuZgpJfyphEamWNCfPn2f4ohlWoiwY22jLdOqpdjoHPOS7brcuvE3elQg+Lm2LBvVEjqDJbhgHY2CSOGc2j6jzWYqQrlo+m/ZORH0dq+AB7nGBNX0pr5zQQ02KHRxd6ecZW441hOLssFBAc2vVGZ2Yp1MWsYWdy7Ydz4MLaZyA6xtlNZ4eAOIBlkupmueJnYyd3UhWLb+DTOkFPLMdaNXdpysA2f4kU+PQUcmjWOQbM1Nhl2WSEhKx5ROLpzID/CUTO5EdmdVO6x9X2Ta9wXHtg46JbudLIFvByUUL+l3Jh24KQk6gEoIR2+pF3Qiems6DhPGWr15HHbgDTN3/Zh7kbi0hcLRSQl3JHU3Fpv9m2gYeccpqMCcKqNDOW2sU3ou/YKaAZNVy/bR5lGvphus2B6Ud67bsoWcbozvaAiSpH2aun30BPe3fXpeQNVf4vq2K64kwkZ0aSfoikvZI3LfI2LPGkGn8s2cCDw/P5MRPOnbt70vrHaGqx5RrNa9bF3Ch8brSe2rGPoM6sr9XBc/t6/c39ZiBsLGOcx5mESfu/t0Ipkvtdqps4AqJaLMItPMV1dCrBSts9fcO/y3sFozm/7geicHttBThHi9gaS9thKvXfHcHuPnzfAbLVXxwkz9C3Mi2LCgoYOKs+ooHsRyMd10cbxtzeuDA7+0TlCttVs7ClbLP3KdUydwniFyMgIaETfygi/CiOm/343aKQTQxnP7c5hNnDKMrCjvD+QZAXkjc5loG2UF6BkAAciz9GIe3bc5Xjl6NneuJaiUO3A0er6ZuwroNSGMgfvi/nfQ1EQj9XFaLY1m7uDdnNLq++O8uTROmqvkrL4/1g1R4N6M8HcwHr8R+USMaTHi4vWF4pnv17I5RChvAXKOkjWD/e/diDIgfSdKo0R5o3tf0wIQnGliaV+wCrF5U1AXWLQXvGIJNvH7927lsgX7qgX7TK44VNIfBl1d7RLVXuHnzNQd3B+jzmXZ6sW5RqA8iqH49ev9oFwS4sD1goJxedy1QPx2PxA3LRA3CsSGS+sPwTD0ilZHqfGQmPTXvOzjpFxbEJZ2GB1zXwh1yOK8r1txiVuWKis5f+FIixuzxitZv4qSi9mWBhRN3vVdDp5TFIkHzRN1z+nMYHbaxs3cSwyhrU7UbIlsq3ERHxwivNhUuULLWzQ12V8EeTCfR/PiXmOeO8rDNBBIOZlmwjROgZCRQsjEYlWn9p3Uc+2VzYk85euSDtTKLjfHSWmdu2qZyTbbb2Sbw47LTqo8WR+kNUOy7nmvVeIghbu0SDEgEfjGobKg7HlRx+l3ch8aJjjxJe5BvtFfXMRf/X5HO9NGPg1euU5kli/ztUfF+7iCiyTxe8oBZinYWazbeWX5734QdfJj6BsGPk0qPpU6gyvGwUGOPlGTqOqSuhG5HVz3HaA77opLuMuppYM1dc6nbi3WeLR/1D9yNamE+O3wcP/x0VHfPhzdWMUBqsEhZ9x/uv9IHD3afzSpYXY/bYv0wI0RL0YZFNF0xk8fQ8pXV+rvPxaHT/Y/teu83iy/bHgFo2Wu/PRkOH11knroEMawd9AdjftU02CcdRLtAz3raC/olkXNx6p6B+X2lMcYjoyUn6DnWqWdVdstR31ph45G8HlJs5Pv7cGyHB76+KDyhk5j040KdVRF/8DpecTHEMc7fDM1aHO6OX8fTnAQpOTOxIXaBpoYUQ6hAuPZA16Rd3Zo5NctacsYYV6ch4RXy5jvh13bX/yLVeZbMgcPjSw9lzQeiUIDYjiTBgng+NpiWhCQGwGUG4meYw7UhOgBuy1JnPncSQzKcCRmZqaVhLie6FDbVcaj8RjGZn4mKoj6oAiGd0+9e8SZDEpCitdTylibGOkSsQvZ57gW4+qCNN05FRuPY2GVAHAaMVaGs0qgDmKvJ42P0OSf8EEBO+LElhZAqpb8U06oqstXqvw/YX6yunCmC/9D/tJwlzSvEl4lmC104oatTBu20tJQzC22smjYytiwlTFPC5wUEj0r7DPKS3vNanyFeoOV5W1rLzIeQoED6YjXwYBQPTpQvjkO6PklorseMGTlEfctp6EYqD173TN71utp21sD9KtOuqP02Ge3YDBdkuqROnXCTlw4TbsIU21KDt7qWuF7yd5NcjA4idpM8PwBAYLVx4S2k0y+Yq8jCHKg94X/ZIvpd65jh1qZHGSiR4TMhXMLyCSa0+IqAbFvoV59dA7gxVrNgJP6yhPxQe6Vm/iE5+tjbvebxqk1hlk9gtk/Gr+PjlW2YayIyFNta0PPQ/XsY8QcQg7xevpBoUqppuI1j5WahOd1CRoZ9pM2lb39w6Nu//GReDiV/n73Sa/XfSw+n8onTw8RXezHqdzvdg8/pQ34iyn2tUPwZI1uUmu6aIf5Yqq5HfYVHXFMlLzxh1sqryQHyOe8m3qHnYfTTu4lHefTzudT72nnxymYEbg8x2fzkT6pDxam/LSKKak2JaNBjtqcFi1G5Tv9ILcAfN0CQPu1anLTVGf/yafdT/393mHv6adPWTuK1paD8Xj6aa8T0XB1e4/6T6lh9NijQYKPyrTj9OjDp/3+Y/CK9OFR98kjjwv2nzz59IgLHh0dffoIAB497T3mLlst+769Qrhvtgt4K+tnG0eh5/2DcfitXdvqdg7XCE3m71qZH5Tg7ED0aX3qx1HPNur/ayW/l+7fWNY27a/1nkmJ+0uLMv+6cmJBAM1kPqXqMGfEM1m+xXI2Mx/6fg7Xlm7qcRiw/atgXkXKYJmvzlWCrVvzpW5M+SBJizJIwyiLqUmLETzamgh+E1HHkUyZPv8ypV1oJe3naePT0ZI58h36D7w/hHJcTYaRDJW1jXIhmsjUifanQRmwC5IACnYq0nScZ5cI/mmcP3IXo3oQJCyUAtubp/YGkMtknE1MvXh22TORmjNq2v40WtBhNVJ/vZ6hXNV+FISzzyKqJ3K+nVpT8bO9jzbzYJkB2RlU85NCRRct3ZEK2NDyiPu7mlwewh0OtkwjoKYHqit6ouxk+B3Bm0nEj2WtYyMLPK6W+zN1zk6N+wvYO6lBYA8x6vMxFCUaMDxR6jpA1aVuF9SA8aOG2lUf9KC2+/aNPRiG52FepVw4dkBBfsUdwq5J2t2RuB4mHCwtTSpWoqrlnU35dNGcuLpNcrT4mHP7v7fsIhb+ylSRcbDtdCxK4OB0GBz3+tjagKRO7hMTB9qoaHbiZYZmE9LiiqKm9fypofX02UV4BkDdUfFPjhfwpu15Qc3g0F5Rdj4A4YB9qOH4xP7TDr6YYhv9yd5Er4lh/3pLT+1e9h8BYdTBAj0OZAan6qZ7NWHPGsIeNIQ9WyPsgav73y559Kj/SJXsP3r65PFjlDzs9Q77TclejwtrjFWRYcAS+j6xjfXQlAdqk/Icbi88yuE//N/sU/UulTW7lNnTQA1oqL63h+pHGqrPPn6avNYHQ/Hbh9kQ4pAMH1IaPuQHW/3hy626ED9MRZhVaesC2Jb0g0Q9iyEQ+JUolMDrymWe0gokwmhpAj7AiqLibqkCqcMzkOcpP96tmwQFkSvYZuuqjUOVDE7CvlM78gYtloFF3LUvzgwuRbKaajIdV96O6y0sZ2cpuat9SmLzUrsJQawMxLrtGbU93NZ2Rb8/1HjV9EwiuGKAVifUuqbVdTUJVROoaqgDyWoHTOMRDlxtQbmb2e1vNS1O7Ov5j0+U3RBrrmpVUTrpVZdb1cAbLGkZezb2yv8fe1/CHjfRrPtXiC/JM5rR2NpnsRU/ARIIkARIWILx8dXSskU8SzQaewbi+9vvW9VaWrPZDvB93znPwaRGS3d1qbq7ll6qOxRsnrXuhw8GyYHauEhpTVhW1gx1PTIpRMfPwLDCpBgXCkrwfkOKNr6TlEKnNmipS6Ro+OW1jFzOnexGn8I0auCtw+1wFa6OTfNB77BHSiblh+XmbDJsZuhe8I75Y9X7VI6ywDQodgGP/axoDtwCGSVahtxjt5amHMa4oW1hhJ3i0NMaXgE7rDIQyQDhgP+1kQQ+l0zOZfJsfzaVR57rBuGqNfZhXe0V6Y3wcgVOubySDjfITw+V7Fp5TEF9aMiNHotZJMZxMM5nG6SNYoRxy7vRL0VwJWbrq72rgxTuWuEcFU1yg4Rpzouv3m3AXH5MXQBjbzUWsVHwq7w6UeHP2WSeRWIoSsbnQXYu8iFaKpWFz44m0+WG7yVLmL5Tpf9XErEnr5ejcHK5n6I7BWD8aZW5vbpDWpEspFKpVnLIlmqDLMejhrjJFXGzTMVl/EmKz1yRMBRPasMS7kLE0CLtUlFOShP55uawkCNT3/Q80rh6iktowIHhWJatT6a+Yw2cgdezBp4yhE+WFMkjWs5cjIhq/mNQ38qm8NLTqfZwMtUOJsq6hPl0k2w1aDnjqlpkSScZpB5Ge5jSIbcoqZ12ux/YxyGZTECGvSfgi9rya6mNUqO4A2UMrYAZS6fmFkggw2ZT2pCpHXc66RDy+mIK7yICoEN8iFKt7lXVR0XThn1EvtXllHu2Vi5dkauOUTuokupzqGYovhSnpap59Aj54mlxqq6mIJBPNmGBKigjhkG9kGOiFpAVBZRIiTkah8BKmiXR8/phVjwsaZoq2TcQJh9DeDStb2W9q8oh1GfWHe9n3FAXXYpeB3G6v8TVshoQOjI+fBBttF8e11DmwWabUHVM0R3UZ9rjqU4FmNrOMji0RFs8XivjcrWVMsfHK/X2QJJCTCoDTpT94IHiWVywZ1FuGKiOcShW/m+YqJOP/lwMieol4FLPADNa70VLfOWmAavMyhVWroKR7+zy3XS6dpp3TVi8wskFn/u85A5HLgydkREQ08gh36eQ5ZOu0BP4zxlFouum+mV9wnwralN4qaTsHyC/JTqTTnRw2Z7RouTlkMJSd5LyPhu2LjtpZ05RmmuaptPV9e4LpmfJx19nTM+C6VnSGQH7dFKawJMZ4BL0iH1aBZh1KTRb1k30KQcLOwec6Us/6k70K/8S8MwvKr0LD0AP/bNu0ObIvR18hz7CPb6lO2vPOpftS33hx+1p96J9rl/7rWl71D1vhzwduNDAixd+67y97E7bV9rBQn/jt+J2iMSjMkWqP/FbF+2rbtxeUorX/ov2i86T9hM+BcKCG9K5xoM37Sea/tK/bl/j8g3T9c7vtpjDQUjhah+jlXvHraedmutP20+7Tvt1+6XGpb3Whi8Pnip1kHWuOy/a78D9tPMGZb4D39+pp/40+V0NwIDvXeJ0RLzvErdpDRxz5zDhM6DQ6YjZadtPOeJLcfuYluUFGgVOaCWdoJsyXYlWLuVnqquOaujBQdIlfwzWMh0bhGKz9hwfH+F+yYVnaFiT9lwbSpQpLd/biTJtoMRXdFSU+JZOiZLGyIskRHzxWj1CYFXYdPDdXaqGjxMsV9N6xCXfP+MBujHt+TtjfAUPfZjZi7bg20Ubj2k4ckJPl8XTZfG0MiTZ2VemDs6m9ea0ckCGCpJrk+QwDCyMdDJfPZg0nFZ28YPWilouZdPeJPxdRPmeXw28PHq0JwXbHu12Oc6HDaVLywLqIbly8OVwZdSvXvpMGrQlD6zRUD8G14yhg57HZpUfnOBRTBmSkOqxm5FSwYXg3zKLpWbpIM3hOSt5PjkHIlGXe3bAMsH6Ql5nbOTL65SaErMvrdlGRfAzUT9L9VQ+y+pn4hB+Djlrvn0YwdigAJ1/ggJBlY5/REV02iwt8SVulmslJog3pGcBJ+i3OCPp8si/4OpCY00I3/6Zhoryk5JmIrSmRu92IzL48nQ8FzCPLjt+wlgT/FL66jAk4JtV+FAdMHPvgO+i488Y38yv29hNYXQmMLtlQ5QuTaoiKllX0a3wmoXMFdXQIYSPTEnxeLNDrTWnF6mmHQUcxoRSziECfYnmRppMJ2AdrbvL1vILaRvTZ0qafBipQueD74yqxrg5RtQcu8i+oBZJF1WfT/cVc2ekDibWMqoYoVWXf2wcdVzxe9DvM1+Rb+SGkwfeiLx0XQnyVWwZNw5yHCtPoT56gdcSFOZwxOsv2iiRA3JF5TFbh5OjuTxbi079yjp+EeYTkiKlifxtCbtIiN7mB51IjbP+Yts3F9NLpfuJr25DdNHQ9pj79KKTt8cc6nhJ2p7vlioP3kiht78wGid44p7GwZcrT5f8dGGupDU57crTpalU2pNpY7F6HapXnW2Z+3wmeXnqD3pXXo3UZ7wWvRgV6XTmRxFa8cQPTuZoXyBT6BOiABVEnzKmH9Mfd+AUcpZ2IoNuT/0/eYx92DVv9Ke4u9FfEqw9tHfTxhREGitzy81XkufPlQTfTesNlLkyazQ+sgpxurd3WEwgjekEmAd/SM1xqG5E5JEJoxE47o9awewd7NGiZrhH5cCWIVGOSYPu/fabfI0CTg81WN1yz7T5SNSh4zZEd/t0er+Zty8aSrmswWrM45hjYOf7yhzCD7fmGFfe2UrWZysGrjhA605hPaQaWnzU9clzmXXouMT9qMN3f9DdeH+EHyXWxWp/z/eDDR+Kp0Ml149TZe9GZRgoEzLyQTVdVj96olwHcsiiOOGxmNUZlRdReTErL1TUqTqR+Pyv9qS0K7b3pLrvZNShqn4l1J7041QZVH/FZs1+lAlaGKUOvst1Ja+mfstUrG9Xa8zxf6Z8Dm38KD9o4zY6OCIcOFwZRJW7Jwy4G2flx177xajpYXi0OITXCE+GfLBJl9X/zD87GXU6xQhreaTg7NGj0dFCarNL/8In1weuTLulRJBODiI9OkhgSl+3aVGOEnr64mCpLw8utUMgAVNH3FXRJOdUWFGUPj+iA8UufTqR6jGHHKJLWc653orX0WmPp3CDu/5cbmq/mfrxzZXUvYH/J2MdzvQYAmMYHSV6yZXhWSFFQn1Em0KDfUpy/ITHZJjT18fQSUl7dnA9nGjD5+WL62NUdMSP+YSV6y4YEfqjKpYeS9G39U6ET/JWcxNkXlflZzxGU93Xi2OzAIkbARbK/kgnTnXGcNqOx0NT48Wxr6ayHX17t0JTPrsdzsHs/TzI0mSpPXoUFCXSiPWG9kV95aLuK7Ffd47Lo4viXM7Ih80UnFzSOtGy7cG9K4bnKbR3deBnebJi8RIMPUnK8fx5VRPzguaYaqKFtqm1iwwHcVEnMklMdcK9VknAtRN3SwJkpGvlq/3AX2G/XnJh/Bcqol55sSJKW9X5BprcuVweIVadkMDPyzTKIo0VxVPubf/woTo7QVmpMVVDg5QaFr7IiaGbpxx/hFxB61CO7FmHGR/NlskqPExJ5f7Ow3Inadc6peEdujJPi0G+I5qA6XbTQzyFhKjioFLggUIrp3KP35dF38+CcTwZ6T/tbpz151UbX4xhJycnim8FlGtH6HSGxPpiRsHzIYY2FBSVZX08nYZ1RSe/UWjlkXmyA29aX041/ec7Urda9pHFzoEsHqARiwXEK/dC626iTUlRkKntoPPX2+gsxlsO78TNlUmOSXnoyQM/0yYcb5Kno+RxfBM4f1YbaSELJtUVL0zgQYJCS6QfPqAR1cZaR7Qn7Vq3dS15czk5p6X76a6P/Wb1Y6Up/+u0SNk4KT6rZmrE5p0Zh6u+QbMKBDlNLWUvdVbTk0l6vt/FfGX1NqoQ3eSYZi2MTTNjcjYlP8wemzxTC+E1rmfvaJnbuLWLL19v5sv3W/iSl3GSJWnlqMX4sDAVlZm4dd6ArQf5Dp7k53fgyTrebtkIzGmri8dqIesfPN5dCCk0yXVjc8yjvTLmUXA5vQj26sbpmwfbOyWFgDaJOH1nlxR3Jg4CGz1jN4XTvdsaaiUrdkuK7J8ii4MbceM2Dww+1Ke4G7YK+VdUKwTg+icUdq78iPVGAFNs+yelq5+0Lg9azZavZ/dpHe/2OAwWf6BWzzwacjxQSs6MJGfGekhNs9ae21mxYamVH5nHeccc5hCXBzZEp3nQshWJmHJwGUpFiKqWR+3OPKD11sTbDW0CArlYKgWRxxswTMjhvJDDczqa/nDepuH1Q3kODLfl4nX02KeFSbZttnP59+hRJZcj7bG/79JDWvtrdued6tVcqzdypO057fxoZzvEw2RzlaXnW0RVOSouxRIty9kURbyKyNpaaZXGMD9ogerdcjzYTFSmEAX5PNlIY9q0xWgvbGEH+rIC8+F4p/CX09I5TTkdTtrBY9N79GhCXA5gSnqH5TlBSi9pTTqmRvuTInzwXJ+gPkxq6NGRHxy3UnhQOh2ISlFxgm5Ea90A0W4m/hwKOjjwI+2mPuE8ONp3afy3lRwHQyoV1v2MTws2Di+PfBqWvNAuO/SsqugOEl8MJ92LmqtpzdVUcnW+S+CoR5DWNSb75XFKgYOrHsR7DEgy5zR2rfYImh9WTBiDTJiVfrkucEidpq21/rlLdEa7v+SOpuqGRXOwhZiOPBhL2ffdc1L1u2hJ/m5aihhZrYaFVvE+o9aT7aRodnuXpkPhtvWeTTbBSt84nNQ9IVB7wn6/57Y5jIZoBdQFaGHf4yroR9rJ0ANgnR7M+WXHD7hnVK0/8tfaAR06RT1pwv5o1PVXE9SdINne+IulLpfnaLab1rRcnDfi+616EVWQv/XofRnpKbLQNkQAle/G2j78qyClibSSQF7nV8/If0zp9TroejruWI610Ta16eQykLEqb6ezIk/fgHS8AelYa35g47Mkq6fnvlwLBfU9opVqab6nBoc5r5QEafvnhH38IpjyCi7yhmkr2/RcbZmpHCye8PkppJb5MNtyY4EcN8ke+MhVLXykYGOUlFc1yOkeii9V9Z2TycNyZeZp3XYkO+oxBSFnRdeqpbTTC8daO2TaVz5odcGm0HI6maWV8XmfRB2N9crNCHySb7VGUE8lf++2X1D4zfVOKZztkjBCNR+/G0+u7xgWgIIZAUHGGxcn06W/LitRgTR2UuIF8Tf6xXnh2aXqhntlHnx5rq6C86kRVAhkTfK2qKIGeNEvs6A4X8aEYHlAg8JGcRSdGlGmPIJEkNVRH5cYHNGRfZfQpRM6CfF4MgwOc78VQ1ceVGOVpi66UYcXF8z53IbGMAF0b4dzUPQhQbq7zcEz26zIOceFOm90QUs+lftxsaF4SoewiNXzOmpj5YKmtm4Uida6PJ7WCwKH06rhxgI9QUD2F8zTxVqj3Vm91EAuaXcoH8Ag7tPOOEqfTwckd2jAvhNIRPy4QvUDffcGfOuZ53Su56WkIgzG8XUzNkQ9QkQJmqdPKJs0qNwtRW7a2Os/eJBLsueUdRrEcaq4sDszR3VoSlOn7bgFJyMF0/Px+K77hBvoNuF6Nb/znmOiRiJICAFcpvM7NoiZOs/cIKigiNbLb5ME6NRoRroM31g0+bnW4AU8lsb3tBJNkteaqWKDjoitBYeyfOa8Me8GMuqpxrLy8kYBetFD8gYZa09l2nzbl6Fctv7UKKdn5zUnOzkPpIbnxeBtvRBASaRuQlqcq95Ja9z1pYGtqprinYB7fjC+2bRUflMPuGmls5fBS0iTY/wM91018MP5yuI6GXQ1l5FWxzJgJ41SV4LnKCMdAGpTnSMzwJqjo0SH8iHN2vFDPuNU30DhhEWMOkf/YoWGqpFVI+Dl1KkctCQdKvfEMQGN26DcB0ED3kc5HwTPO9YKdaesoaZF9WtPefPUUXaopSeQRlQn+NUBOhzIlB7CqKFnY/lszb+tjOoZf5Wpk+ouU01OxGkrJTBusOBNo/JhNpRmV3mhaaWVVvxyiIbS7KLH6h2dM3UZ0JKT4lerdWleXaknmj1paN9yAZYfnkMKA0T+l7QaaHS+HkQir+urmmMqjySuuQPba3TO55bWTaJaRVf12MfjakSeDiMSSgMSzYE0udG1KplaD/jZ4uiPwUnOx8TROO1j6/jF+fD6XK+CcCnr2i4VBStdrvGHD0VfoWGBYzFs0QniFNYnYNVMxzfR4ZhaK2/xTu1K7V6ubeRS1t1AVLQmQDThQYAK1Vvaukw72mlTxL20dNCw6PSz8zKaRW3WXd5Hc89XLEQZ2mIN2Tbd/clq/sj/KeMQEsjJLfCuWuoBnVA4OpcEyFZDOJTGfVfdmUscEWW/l4FL7e8SFrISOooHQCpnXdCuHf66uim9Pld2vOC6hW8YnSsd7CnbxHodzBS962f5SDssnDs0tK/LCCvp8Z6e7A1p3zIvNmA/b2+2N1SGmKgTVGuB4blX16I2FOWUUFoH/ypb+MS/TCC655pGLVwJDjah1U4QoaMg/y4TSbqApJ/LVeR7e0P+EcXvefE7LX6zveGO8i6ovFsJX6en20KBcOPS4pRKJU7+XlKU/HBnyTOUvAGv1W4ho4K58lWL74dLqARBaVgasrfWtkaeRu+aQb6KtWv1YM2XZSzcesffqV6O/JjGMCdrghE949JVUSk2DP6gSRUhGrMtCClcNlCO0YsbcqkYX2JhaxrSA5G7MWnkOoD/NPcnFU5a5U8aL8HP/JRO+ZZLspKjiI/njOiAdbylg+LoQDs62A4e+Kzb/eSxcSgH8VP/pxatRwCTwe8qsAsr1EgnvEAxbk3YcadNupHqZ0UHqdZOUQQ/i0R62Ur40WG5MPVBK6WDs4uWoaSL2jRTWWaV6BJ+dpP5aVXhDTvu3XlzczNtMVWNCK1mzURuMAp4s1BZMfArmbU0Ccun5+nyJD1ijpAba2B7SFqot9E+pbEkN2iEzf9ctRWVMVZlSd5aCp4LVdfWKSnqcdqumuTTtSSEpJHkC7WcdPYsHadkdWjHndaeKfY6NJR0ZNAYvrIkTsnDGtp/3M1b3XEjuvyzc1LC5dkL49bn5/p356qnz8sepDVC7a7MN6/lbbpJrtOSN/6Up8flRw9NnmioJ0tM48MHq/nIgpCoZ8J4c1gxik23Y57lokqabCpT4j/+4ny4Wjr4OVSHwzk0IeGBd4QuDM6hh/xAs+rAjN8JnbLwx7n+6TmFaSqZIuqB3RBC766mAjy/ORsHNx8zFjBXxgKkkMv9x9UiFZrFkcs0x/IQzMY6x2JoNfLnR+KQhMWJ0NHTT+a6OJX55AqllJbZX+BnXo7G1gfnmDQmzmmnvDeP+nrw0NQePbroXh7FLF4u1d59SahqAXABvkGeyCUytDCe1j3xOqnEh6twFPDgMS1n8y9RD8nBpNWF+k/aE8L0oDU7gszi5W6P54V8mcoxObihcmHSJtQUUSR57NMigRL74/tit9rTcqlKTIf2+V9SJGE9hqLicukBLR+szGBwhN6yfTmpg7Y1R4rKiiyUDIcpRo0Wy0fKMCxQC4UqyWh5ss9tOzgmC2RP31NHg6tQG5QQNfPhg9TEyARrJqNDkWuN3Mr28ywd+Q94NK/Ss7QzZyyDCNYDtLIlKLaOqQft8UHRDKuBPGVFwONycTLYrAyy0cyFYhG1g6Ogu+/SZ9K+JH185M+PeTR8b++GuMP6kiYBs9Y7OYDxJzctdOvHBWLZ1CRindqZ8o6bnXxFW4XVFbqqFN0wyicnlmnsY6xV8zrmVLGVDpqu84/3RghJNDJV40tr5wrC54qRY9JepNZ7Env6j+c8VFnJH66bYLzR3VkTJBKJ3xElnuH4Roc5peqBV7d8yRh9sz7du0vzicPG7KLyEZ81hliqjHINU5lPbr9QKHi7litv50P8q5N8q5qAhYmvi2qrM/x2sHcybgTyG2/nCy1EgJlAnmaJbbjv+jTzl7c+O9ff4j5vvSJG6YDmAWQF+SUviYk1Vb/X8yUgkLwPZbn9luErHnCgjFpFciuvLzV16C1XR+wVbny1ZntwS8s1Wn1QTPX8cs7jM19QVMov6+taj/90Xi6QVqZH08ZazbFvbFo5WOIalhetzph35leTNdxJaRq6RUhWkmkctTG99AW/F/V70eVQZJC1tPGDmE+RSItRZFX5pXKdoMSjrMTKu+Mj0c2Px1RZ6f4kSWYCgjZnE6hFq8xqWvJSzNJsb2PFIS1dquZ5yAXVJ1pVeFDowqp0jsoqMU2amCakZ8QRpPMEerAUrwGr1DmtGC+CpcwVqkTBgIlkQLUuhcKFHVXREz8J6PPkweXERtQl+CxVyeNiMfIhTTPrD3gqWRvTpNabdIQ7mmrT9BYv85FZ8sd+TpoygyHPOTudjFesyu0fSIk8hCmn/SS14i2DlVXJlFQsf8lJ2edgOKWya/1yXlFCR21+qdzSwVV4T/DL88I1LaoEj5GUJH66T/p0Sa1hdUZIV6zjR49yKP38sXlcsqmVHY9Jr4y1h7ARDTIKC9p4Sww/1IYpO7NUTtGNfj73ibmkk/4s2Dam67ymO6cAXPUrCu+oHf58fl9Cyzqsq0pduHZAnVsWIw16JV2HYvY2XqInscWsDX8+l19U6PRfz31QJqfvvjn3TWHr35/7nnD0r8992xOuni/9vufgYrz0PcPp40osfcsdWMLT8T226SKdp6dLZkze4EXe5WngF+nlZToTKDKmoaDtfGt/c66+5dCYB3imE15G9eObz19XiNDTln66LOgP7kyBfFbhWSl1labvN9D0vUrTi3Q8z4UkaL70g5KgaIUghXZDN/5SkUCllpos/agsdfYX2NBtfs8KHatUfr2Byq9VKr+azDNJ4OXSn5UEXqyzpSyRjv7YyZhbiwSyutR46V+UpU6rUhmlTMTlocQaJb/8Qg7knxdXGusptdBua0xvia4/oKdfsV4pGbr6lNl4kC8VKiVa1m7nS39a0rhc50yTzjXOIEVNbHmjNQWQ5FKj/Colk3C19JclCWf/AhJU4UcPQUK49M8KEpQJuqVi1jTEIZcxVjhZ3ixRcg9lPezRqVJr9bxG/FpN99prhH9EZY/pODEpYRdLH98BJ+uaL6ASX/CFpelv+MLW9Cd84Wj6a75wNf0pX3ia/nLpL8q6ebf0r8vrz5f+i/L6u6X/prz+Y+k/Ka8/Xfqvy+svlv7TNQb/sJXBZT2Om61FuV/j9Ee3lA0sb3Dw2dL/gTn4ni/AwR/5Ahx8zhfg4Cu+AAc/4wtw8C1fgIPfLv1nJRd+X/rvy+uvlv6P5fUvS/95ef3l0n9VXv+09D8rr39e+m/L619Xegl/CW9Ovr3JvZiM8wvJA3m50lfGyptuI5lptWUFPIMGfyuCrExQ32uqWpLZ8Oibpf9rSfr36x28Qf2dqlH5hupu02fUL7uriauPwbPV72k80lbUXvVVXy/978uvyq+aXyVTGfod66QqbYWdGz5pB+9rOlXqD/Or2vSrLb2V1UvS7mv0wQqJavc1sUsrUPY/5ZO3ST7VUqyQrKAsTEcZk76wEsdXPj5CclpcrWvvFWbfqQk1Wd6o8c0NaXcjabSRBvvFR7JfxbNaA40y1EpocmOHXFSrQsW2jn5ThWRXvrhalebpVeHA8xh9OZQ/909O0qVuwryno6qWuqu7wpaXpov/yxvb0G3h4DpA4u/P+cLFI1c+cvVBcYmEZp+vJ0j59Tlf2LpplA893TK9MoGlO7bFNylS50u+sHSzZ8nk8O3hWuCCVmgIeWHrvV4PTgVuclq3sTxVlu1EPFeblt9XxBniOUtycijCSAYH7UTX81My6GjBBkU4pkX/mgyO4fvzleWhuWwjrZ/hWWVLXRBItWojS1CmK924OqTRzwU5qO/CqTqJ9OTUn59MDuYnQdc8PbFOj3BFvweTYzwZBtUEVVSgS8oZzxN1VQZNNlYnvx/lhzSuyycN+GBSflo6cSlNIG5YFFys8zsWw6jARrGPj9NyAYsOR9HUhnUwxuxYCW04nNzo0anUwSeTKz24OvXRxMQVVIj+bAlLEZY8fBxNP5lf6ZF8m19BN+qLJcxtOCJwyZTVxMlVuYnuiGJHUcjq5ZFpGOU4XjXo0UU72R9RdGz8+wr/XuDfa/z7th46XpHaS2W4qcJDkcm2IVJi1t2VLAL76Jq76GsS2BRzG2mskO4iVqH28qq5H/rP5TDXR8OxHg9h0gwN/QX+vca/b4eGMhB7cdWYMkehZLjqRUBywTMAOT3hUJYiSyfxjKO6xcFyxiEfZheTjAzsGQcgG5GQm3EEMn7xQt4n/uiKps5m/oJ/L+l+QtNAC/6N6T6ggAYL/j2new5NsODfK7qPNP2M7vEb+n8GmxbXBSd5Ze+f3uhPNqWZNNOEm9JEJ6qlhFSfbUo1X00VsSwGy99e6YJAMvzySj8fpmf6l8PgDPXw7ZX+fPj7lf778KsrVMUvV6ijn65QOT9f6dONh8KedFqqz/zYNy0q6v2mxGbn//2/hgV5YGs3+vfDd2f6bPj5Ger/1yt9PvzmSv9x+P2V/tMwP9Ovh+Mz/eehONMXkvpf5M9ymJ3pb4eTM/3X4fxMp/UbL89u9NFuzpcuwC3MV5Lt4n9t1t1SBY2EVS1EZ6gFgGQYn6EW3lAtvKZaSM5QC7Mz1MLlGWrh4gy1MD1DLZyf3VIL9TDCHSuipmytLpZnqIurM9TF2RnqYkR1saC6uF6vixdUF0+oLp7WdbFo1oW6QjPeFwsBjVgsiFCWG2XHIOzan/I2DFqdsp9Pvp1ci+zzgJdX6qLDTws9yHGKnmwp5fK2Ui7uU0q4pZSr3aWM/LP7lPLZllLObytleZ9SIrUUdXHam2oy5QYt9A+SE3+QnPiR5MTLK7TQp1dooV+QnPiC5MSnJCfek5z4juTED005oX5BsvsLpv7sPl/wfvg5NPrw1RWa62dXaK7PSHS8INHxhkTHkys01+srNNfXV2iuDZKanyv4yQ0a8yrdSqKMn9ygqYMJb4kJvw7fXXFTf36lRMe6bizDVec2lViYtJOniEBkcOghJRSxUM8/IS374YM6tUQTKxyUKDnU7B6tFtmPLoLs80ksnsBU5JNLigjbBZ8jWqGnFzPqqT+9OsmKTMgATNqpdrzyZJj6csFcdrz3yd5wz9jTW7SWm8P5tjJ/0iLLkSKmFFuL8CG0LbWa1dlEQbD/+yQdt/b2Giu3b2eXD9PBHBhGcfQL7FWybt+0JhS7pePv7cE1eVDFwK/2TZHTQdHAvqfgkdUmwYqPk/3vGc/ebPN7U9jtyf6s09r7lhPAwoRlIi3r8aNHD1p7v8qMdArH/q8U/2Nvyk/4wVc+/j00LRoumOxPtfrcmsn+iFOM/L33Jeb3Q8r+k0RIJt1k/6cj88MH/Dx27cYn7V1zKloKDPkFX62g45gPAvFhFIJdE9hkxCi4EIoyo7Vkj50PH4iK9Pj9Uk77ZdrwPS98z2gwVc40tjK91yYieJgV2Pxszb3T6ROypgrBs7h6VoySEZ0dj4bbhpLEZAOJG+i7rum7Luib3kLfJuLWKFsji1fCtPZ+Lvi692NVr01e783L6po/7A2L9McmVR26S1ELK/xX2T9M1t/J755wnDOisMRaUdfpofn83G2lHRd3Q3pMT36kJ0x90eWqVoBmR5HIfj2AJ/CBkL7g24e41WdkyzIdk8bWAWX+vNyKy1LK4JjIVSDH6oyM4GguF2Vmj/2oaJ10eEXSYonEgXwVoRR0OppWxIscl2KGHlIgVX9xkkLifTK9Om68G6antNyWZI1UUBTAoSxKLl4ihNTxlaIyKqpKVWqX8iLcX/jXEF0hDPT9X3CZycvIpwUguBwVCUZ0KRPwpUwwolU8vNqoYVJJ5wRyn2VRqHhS+eR1njX2fqm7ysZ0rAQ81g3IXhTIHpj3wTbPo2e3kTe6J8LvbqPQuAdCeahqDAvhyv9zrwvFsqefDaFhdIN0zI1+fuUf/Ndvs/ZvcedAX9LNwwP9Cr8nv/32X5+2O8cfTn47bWn7f96cHigbSc6umoYGLb0p0JPEOe7mw1zr4G5SxSWtLA8IgiNxXO8AEl2KtyBV1VjrpEN1AXd41YhvmYnpZQD9dgU74LffPn20pyQdqUk55Ig4f7qYtvb+q3U83OvkvMIuvCpK2vuwBwK1PX0vVZEsVpG8oG0fcotnMcoI/6JhK+njU031u69XeHO+aq1Ch5prdjGbWxusrlpvfwTa+e1o39wBrbWC9sfb0T75CLQ/3Y729Ueg/fl2tE/vgNZZQbu8He3Lj6C2QNtp8c9jr39MltjQEvYmm7xe/r5S1MF/tX7VPrROOt3T3+LfYg1dYHjc4kvt+GCdDG+FjF/97MQ8PTaGXXgHFsjJTuxTqGrD2NvoHNTL3z+imb737TYh7Nq7MH/3EdyESUJ4zV14//gIvPHtlf/pHdDaa+Qa+p2Qf/ERNH91O9ofPgLti9vRPvsItK9vR/v+Izj87e1of7wD2tXu8q06SUSYD8xbOuzzlVKWt/WTBq4Gqle3EbxC7Pe38+Cze6Kc3Y7y7VXD8SQLonYOUJZ6MPW3m9MW42wriX/fmRge4YcPprWS56u1PGYHvo5c1JeTDUALOce6rZ7Jurmc5kKplTxfNvMUKDoQozC+6vW0WzCX898rxP+8jZBiLdZK8l83J3+tkKwm/6Yx/l96TGVt85mvx72hEv35+zX8iwYnu6bkpVrI1zsLGT/2C6d0fPyEFp4MnyzL9bo1jvxsJTQYI9VR/pPVmuy0HBq3obuqsFWSxmcNS7NMVicQZ6vfeX3rd2ZreVYm/dlLbOZJ1/K0im/Tbs07ub084SCPo+QJzpSdcxtqQxIgqjoRa3WyRtdaGfOzlfpeXQx1WG45eywdCdrmAYbuwUTXOqBgfOCRc03jYpZ88NArb+tios2fXw2NrHAr2Zp8s6SZ3ZZ+s7C5XMtmdpZl0xGbhc3F1qJ2ypu4ma3AsipvptuRbxE55zvI2Sx1lltzbBM8V6ttpBzG2SF7ztZKedZg7KY+Gd5Wjip+XnFTf7VB/IxWxQ/jJfHzarVupfgRpfgpy1slbLEmgcqUinO59sHvb/3gF1urYqcsebNJDvFHanfJ/uROpa5Jitfr0mi1ftYF0motbSJwraSnZ9VgyV7HaPaQl8q7h8rzd0oVddRNv2rVKaZgJ2dDUHFizpRtMvGVf3FFWy3kjHqxuS++KnbYFY95QIie8tgVHlajTvSwupEvqsTltR5f3TTQlwe7K7irRzVm9VEjET7gz3JRwHDv4UL/5OEvezo9wV13dPCwGx88fLun5/J99/nw4Yvhw9efPJzu6cVqgeHJ3pMXe/redy/2TnVaNYAHr+djXOEhJJC8eDMXM3n1s4jH5fWbCwhaefksS+XF6wDcpMtTvVp6IFFKfBKZRCRRyNwyK3LJJQrI8nUwngcZIxdhVly+CLLoAr9Ppll6yff09Ov5WPDPJd09mZ/PZzkhFNNcjEKR4fpVlE/k1cvJVfnwCxHJy4LYF0rZslxZpCxQLU6WJguTJckyJH6Jeu/0RkYG+OPM33v4tvtw1H0Yv3n4layE/Yff/rrHrz8983k5SXUwxn4+ef76lRxMrMMXqeJISQCBNFQaS+uPM03/4sz/9Ixx/3Dmd6pJnT0LHatrmPj/jWEM+f99PPp1T2sUs7KApt6XVYVB4kPkx0XB3CS53Gdn/g9n9cDke7UjKugU964hZVen/o47+bCj7vRSPLazctRePelMkj7zKZgIRXYtQsroF34Zh1GP/aS1B97v0WoWXKIm9mhBCy4fUvfYo1UtfEO9hJa20E3wycN4j9a30E0ob0K++QxXI756q4ZgXCg79yNcH+XH8XAuL6bDQF6cDyfyYjnM5EUqf66GZ0MhL8PhSGvVsS1n68edr3OYpe6NPrvPXvWLxpGu+o9nmjaE8cGDre/PGNtKhI5KL1wo4VS3R+gY00b0cYVoPULHWiih48WQQgRRjmYAjnxTyRuX0hXBnjgmwfjW6CGQ/eDDu3P4+7mMyzbbsf1zpm9phESxMiBwth4Yqgq4OKLIUA9MZbHdbRGVUrQiqWf3XRjmfou2wnVzrS306HhzoDneL6wOis+27BQuz9rd1kYo+gBF3qClZBzSBx87PJnTGv95y9ROqxCxyVrLS2+NepjqFNKaghfyod4UdiGgzaF89NKxMTQPeIcBFynjISb3iYwUcVzChOMZJY2Aq3cN8MS555Rb7iidtb4kDqiBnWatn/jRvcIlpRJzqoRLqrmVMV9SjmeBn80cUXduNw29jXHQmiFsm7f3D3z29kzdPE2t/fbN00wlZdy+eTretHlaGZTa0Kv45D0DHWrf1RN0rxn+XVIXu2h0sbgRiIV6lowTGFDg7X23wwHzSTBr3bHWbs3a+dGsPT7OhrQwsnWxpZORwMhVvuw8kU9XTinZ3M10CmkD8mOKuV480PQYjf+S+ttla98lqPa6eK3XBbt6HQurUz9A+5qgeXfm1MQm6CidiFrZhEJeJhxkomhv+27R4CgyuYxBTo9o+TZ4PYay6ppDk2mUuFGL9+miF9xFkf2CMt6/i176nPuScssuOuUuGqtddMpdNL5fFw0k5kDpojVrJ8zCoMX8C1rMvKD1UZxTOvLvjW717d271e9/pVt9xfZYuQyiPkLpwONT4et5Yg5zbvD5SZqgcEx7/4dmdeWAtNfOdK9N5yqVJAue+v7lzEcBe2bS64VOkvQSQ1hRYFhR7Fk9qz9wvF4Y9yPXc0Jh93qR1UvoL4zC2LLMXiiiBNbWlxJLL4kGeCcCETtJHBl9L8F/g4Hd96LQSAwDucPEDc2ex/8h509F+eFA9HrxwE2Qxu0ZoS161qAfeF7gmUJ4QWhYgdfzzLjK+bPM6VjeIDZEEppmH/RbbuRFkRsadhQMXDNJ+kHYCxzPTqxBL0Thg8gLHTFwgNwAll8llsCLhLDBhX7ohFaMXLZNXEjCQTAY4E1gRkkcJvRB4JERBUgF4ux4EMhvDE13YPWB8RuJMQlDJxChHcXCjiIRRm4solA4iUAW5gueunE/jJM4DsBGi/6Q/3uZHxxAJYCLcRCB2a7oJ04UCEd4iRsNkN0KRGIiTfEfcn4tcwqHqEVlibDvxEHiBIO+IwJbUk4l49s817P6+FwzBO30H/LnIef3vMgK3CTqown048AA1b1+ECFP3HfRRuKBlQg3cgZOaNMfco5lzn4c21GPSsBzEQYoPOwbaEZGaMY2+Od4VmjHwhvg42N8/YD+wgjvY8mjBOzxqEUJidERvUHQS6w+PlSYbs8d9LywF1ruIDCJlREqMkh6QYCaHsRBbxD1XDcJ0VyCEFiykLYqPaPIqXltYaLPh0q/sTWK/BLBT9tDddiem/CfG6ACI7iNaISmGcQJ2n7cN6I4Mg2z7/bMlVcy10oC9BzTCAq0nuhH4A+6R4HcMD3PFRuTSWw7EodJ37TiomgFsyTABqP6ya1Z1FI2ZnQd2zDc+5ZooPfZxq3Zd5deIJHuzlfwZCehn4WtNNT0YEv1BUk/BloWUSRpejRW0Atta+BQk44SNOEwgHfd79u9lVcy12oCzwr6tkQrerEj+vEgMWJbIjfD3rZkEtuOxINBDyyRRauYJQFuEAi0rNuyqKVszOjgU5zwviUij2OGt2bfXXqBpK6+OVdfgOqLtlSfGAQ2RJusCDPueQFoiA0z6oeJGXpxEPaF2fcg0yLLW3klc60kQLsLe3GBNhbQEiQ9Y0MidyDILHNjMoltR+IY2orkLxetYJYEkH50zFuzqKVszNgXhula9y3R6nmOObg1++7SCyR19SVcfRGqb7al+gaDvih7X2IGtsMSANoPytEKYC9AAfQ9W0BmGubqK5lrJYFj9fp9iTaGJhJhIoQRehJ5aENoeJuTSWzbE0Mp2UEki25glgQYfct0bs+ilrIpoxVT97lvib3EDo3+7dl3ll4gqavvkqtvhuq72Nb7YPR4RUV4vWAAww5NF8LQMmBCuH1rYJENY0CxhcbKK5lrJUFomX0rLNDGcRj1YlPAwJPILQh5Vq/ryQrBsj0xLC/DiYuiFcySAMceQHPcmkUtZWNGDzLMTO5bouHahmfemn136QWSuvpirr4LVN90d/Ul0hpli65ZRzCK8OcY9LdaffzfSoL1eoHUwJ9E7sT0t7n6+L8dide5IRNLAvo9+rs1i1rKxoy7+b8tI0xn/N1efTtLL5DU1XfO1TdF9S23VB+Z2+6AqyEZwCiPSf/GPXNAfgdpVfT8gUBLgRPjrbySudYS2ORuSbSQEgNQmthJXyJ3YEqHzsZkEtuuxI4XO3ZRtIJZEtBzgjg2b82ilrIxY+CifXr3LdE2bW/g3pp9d+kFkrr6rrj6lqi+sztVX5R4xmr1efHAQ6MYQK1urr7VBM166ROVST+UyJGs7xobk0lsuxKvcKPELAnwPLR2+9YsaikbM+7i//YSDcOThuvu7LtLL5DU1Rdy9Z3Rboq7VN8Al85674sDxwr7dhhs632NBK4NV1+tFzK0Bn2J3Lb64MHGZEXL3JF4jRsysSRA+u63ZlFL2ZhxANPRse5boovUgXVr9t2lF0jq6ltw9Y1QfdfbdB85ktAzcT+CAAwsl0wXESf9JAwtgT/G71h2H7Js8yvOhZYTW1GVIIpEJDyJ9l7JHDMQ8Jq4OPJ/LWpO0PdoMZLUfyALkbTmc71g1l2DdW+2sc4QUeIMRBjFQb/vekGv5g+PXVFxkdfvwxuIt7yiXH3TSHo1T9A7YccXaO+VLPLC0JTFeWhFXljzgUn927NIkhw2thXWPWHWvQHrXm9lXWLD6+3DIHAdO0DboHKNZCAglYQDKwFNIyKZEIVi4yuZy+h7fTY4ZQI5ECbR3i+ZCO3YlsUZfbc/ECUfDEnqP5CFSDL6jtFXjdWnzLrXYN3LbfJW4AP6MC3CviNsJ7BtKlckRgwHPIr6gRSJJP/NZOMrmSu0eV1SnSBGU5Zo75cs8VynL4sbDMrEcJHRfApS/+YskiQakDXUMa53zLqXYN3n21pdJKzECKDv4tCMBgbb+YlH/nwYRwNhSo/JsPpmP9j4SuZCP4ncOm9swBfxJNp7JYOpZEDwcHFI7LglH5JQkvpPZAFJUDCe7Sms+45Z9zlY98d21vUSS6Kte6UpUC+SPzACiXU0/2BsfFU0e4d6RJVApfZeyYqP4uIM2xE8XFnxAaT+/VmYJAM6w1UHBz5l1v0B1n2xjXU9YYokgisHzzc2o16v/q5e6Mb9GG07NCJhWq638ZXMNeiDBrtO4ISDOCjQ3ieZnB2SxQ1MsCKRgsuBaGRS//4sTJL0ChXW/cCs+wKse7ZN1kELxXESDJLQpbE42SuFCNHSwxBlJj1IUehyw+yJja9krh4avmS7TBBFbmRItPdKFse2M+jJ4urE1ITsgtR/JosDIempTvF7Zt0zsO7Hba0ORkJoQh1BiMKxTcK+LBfFoYQgJGvHg4a1XBFsecW5LBfEOFUCeP+D0JFo75XMjGH1G7I4I7KifpkYrgiT+rdnkSRBvcaNDvucWfcjWPdqW6sDxnAAnzbu0+yl7SrfZZEd2YMN1BtAEjiyo629krkqj0wmoNH+wJZo75UMxipkgSwOwiiwrSIxrFsm9R/I4slpCNdSx7E/Y9a9AuvebmMd6Usocdg6Cc9Ii7LKePK2LxIxGFgwyB3U0sZXMtdgYDuGoyQQ9sCUaO+VTEQ9KDtZXD+ChHdqPhSk/s1ZJEmeZ7mGqmG/Zda9Bet+38o6EQdGIkLLgR61Q6vQ7ElooSzIiATqwI7kfPrGVzJXGJP7rySIBz2vQHuvZJEjrEAWF5pK4igqSf27szBJ0BWUsWbdV8y638G6X7ZNPQsa00c1BMK0edCRvKQEEjaBLocQ9eA5xJ5l9szQ3fhK5oIZbw6iKkHkxaFIJNp7JXNovL8oDha+HBIhOwONlEn9B7IQSUbfNjzVEfuSWfcLWPfTDvdf0DzdYBBWso6kKyQreVt2z4mc0lPe+KoSYrVfLwYkmaMC7b2SVVJI+vKF4CKvypWk/gNZNrr/PzPrfgLrft3WYQ36C2P6gzmNP1ku/uSykoFHf65FfxtfyVz83q0SFAs7GO29kvVs+pPF1Ynlf0zqP5TFMFYcsW+Ydb+Cdd9vnXBB/bu0ECqOei6NJ1C58F7AnxAuA0TqIIj6XuCi1Wx8JXPxBF9SJYgDmt2TaO+VrG/04jCQxTmB6fRZcEU0UCpJ/duzSJJs+LC9WGHd18y678G6fLTV/TdimKYDq2fFwoqljBW0ICiBbIBiCr3ACSB/YfhsfCVzBa6RmK6SIAwDU6K9VzKRQJtEsjj25WPZhKCeS1L/5iySJPImDJV14xGxLh9putjOOi8SPJoaCs91jYI/cUxDDaLvSpUUD5wez6Gvv5K5AnRHw1YSxEZgSbT3SpaYcKZsFNc3TNXScHmCm0n9m7NIkuDq9pCxZl3GrBMjub0nHfkXaetN1oIZqO+7uqHpuOlaDt9xiK4yRZe25u33XH3fdjlV39BNJNrvU4S4MpXlbU80H/lv6MxAKjga+c9oI20ykhEPvnt+YOuzkW+1q9t62fPlSN1p2QwDpAaeKxeZnmxa5zzumo0Dfdp0gvOpDGx0MfJRBi+kcwyIEEC4stAXjtsDdKGiPaPnBoB9NwIM3BgwdAWaT+wZgMIznZ5peDag6TmANo1imY7XA/S8PmDPQ82YEHWAATyYPi0zAYw8ARh7CWCC6upbRg9SBureBoTuBXR6wGa50Gd9y4OX2Lf6PeC0BrDmexbcWcCIYdyDn2SJHpSfBQHoeLbRE4AWQ5vmiYAWn2a7IM+1ewz7KMKxB32bhlEZhuQd2DFD9ArHshOC8LJgjji0fsh0QASgAwh8/T5Zw/2+nTg9hv3+wBbOgGHAMOoHduzEDAVg5NAS0gg2TWiHrsnQAgxAEEGnH9kD12XoAfZRCMEBIOqDYYiW77kRQ+oFrisYJoBUYQRNQJuWaQLagBbYKABd8vpQOQR7DPuAhjdgGPSFlXghwwhQeDFDwRBGDXhtMDRp4WUBeRFmzwaEBcIQpaCGPIY9hiiFao5hwJBK6fcihlRKrycYUim9PpXi9U2GVgXdvs3QYUilQDUxpFJQpQwHDIN+bIGzDCOG4JUFjAwTggODIQkbY2Ap0O5HZoKmS9CFL54MPIY9hn2Ggz6k+CAAhMnIMOoPAGNAGocnmPTRvgODoVnAHiA+2YKH2vcA8QWWGeBrAD1AYhZBNC7LDtA+LSdA+7TcIOzDKIGqtaC54r5p9Rj2A9GHZ0YL3awgNAChSXqoo9DqxZaAJRtBzzi9yDZpqN62aOTUdkJy0d2wB4iq6IGx4aDXs4MQ9WaHIeqQRvl7jp0A0kKpuGc5VijQT52Q+qwXGdR/IxN9OQCM4SNa6OMisj3Y7BAaAa0x8wauA9h3vcjz0DCiHvQHmT+OGwHaroC9CCEaBR5kSRS6CZo25IzXI9/PG0SxG3oRYOCJSLj9ngHTF4TGBrSkC+j0erGJTh0Amr0ohs3WS9AFBASMjZ7nxCC478Uu9UtAmkr00GvJyXAHRtyj9TWA5gCdyTEGaCY2ajQe2NEgBgwDaDt7EFiAPYjB0EY3AUStxJFtBbCAbIPGJ8FlCzCG8Y0+gIaHVh6SpYEC4wSsMQBd6LXEggAQhmWi8RuWQU4P7IEYEPoNEN8gLJMmPNEkqGuYg5i8SJAD2I8TguiQDh0RAEjDlAQDAeOLmGTCmQKEdgSMEweiWiSeQGtD50JrS1CNFo3Q9WAT0xlOlTZgaxcaAdAFhHhniAYGOACEb80wNmz8JQRNi1YGmQ5yOCYq0YBYYxgYPcMz4bhBuNPiCrR5A53BIhwDiNUI0DNIpdO6jdAirxosNE0DLRZYY9s0bUDCLWzPdAGhWQyYSyghsWN0XcNO4F0bDphpkpeD3NBEYKIzAMmmE1omoLDw4xoQ4paLngToWj1AaBM8D6wAMLIiwITK90yUb0J1IK/n4seAZ+AADkAFnFBQYXiQ0AaYaocwug00xwQKkAxwfBig44DZ0GAOINqZaUCDQVtCgw0YgmboMZQIDQZqaY8FOjQ0AmAEUYBe6zqAsUtqNnZ7ptsT7oBhANEtXHS5HgxxExLTTSBWaEEHrHBU7wAQTiCgyxA+NCC0LpgXMAxNSA4vZihM9BTYhAmgxdC2DEAQQQqcIeoMcAAIGiFbQSNDkrwWGgcY2Sd2mpBTJLUdhh7kOEhiCMEKGFqDPknbAUv2oA8JzNC0QkCaPDQGjhUBegz7Vgw4YBhCwyeDiKGghYWBwdAkbR/YDF0bkg92oAk3CKQA4gVgCBgFaEmAAjAMDRuyEJ9CECqyB5eZIfy/HsQ5QwhoCHzUM2AM2AsTG/osMgA9MAAyMnJs+HiRC+hATMY9O4L0AAxon0pEq17RnR10gCgBRGNHF0liSFKPZJTtCUgkx4tJFnkR5A9B2F4efFK48pAwUA+DGDaF16d1ZhBbhhN5xPjYQ+ND14YEcBI6PdBFrQtUm0fGC3S/gOQFDFwP3R+i3zNE5PYBIUtd8nggZQVakCsSg4YSYEsbLgkqiyHkcwIDAxAWHcMBIFxOQM+LGKIVJr2ewRCiLYFZxBAinJQl8EDnM4RQTIIelRX0qCzUupskYDRDF50aSsiDGOwPGNKiwagfeTag8By4S2jNtMPEA+No8xEgzBhA8CehnTMBYAi/ABrYiwATD4ISXQWiMLC9BBCdCBCUAg56NmDQcwAjGrULBDqSgP7s0wheLwBEOwGEIgKEdQI46AEPRDvwhHEfeMKkDwyRCR9KRNDqNHDaB4bI6wMDvGIaLg5IZEPZIS8qF24gmENjkuaABodh6AG6QC3i3mAA2Icyj2OaomPvGlAEBs2nwOCAOglIcsNUpAUgYCakeECr0wcBrd8OgyiJaBwNEF9DE/YhOJlYEDC04sEDhIEH2Avh8CaDMCS/PowT3sZE2mB6N20QsB6IGAroAcuktFIb2IU2gPwHhOSHNgiRD9oIegAVjNw91gM91gN91gN91gMD1gMD1gOBbZhkKFkmrdR2IMJhzqCZhjaMNiOyI+CObAHckQO9CWhD00SQtwkg/AnAwLIBIyrHScjQgPjvw5OxUVoIPRACwocAHND8uRtC3AcuNDsgOhggugEEkmmzWILUH0AzQIN5DqT+APoBNHsepH4Azwe54Pk4DF1AcrfJyR8wDAzaZBYxjOFHgSKCUA9wb13wkcwUaJUYnZkg+Vck9QlCR1F/My3AmGFi0qmgJkNwCBAcAnQZgk+AA4aBSUf9oJkCxgwTc+DBlmNIhqeAAUQQ9QQIceXFvT7DAH5a3IsY0hRy3INZAe8AGsMjWxSaEPIeWpEsWMAeQzZS+wFDiEr4FzHDxIIcGZCzCZXAEBoDpqjLsGf1PCRiCCPZcyH1wedBzJCm6GnzHUELZix6ghV5JpmZcFA9C35p0LfAl2AAKAI0fMDYhlSD1IeUgtQ33TA02Zi2GcLVQyHwD2Hm9+BDoVcAepD9EH0heVsOZD/kKWQ/iCTZD8PKBETDs6lTQQPA5vXIy4MGgMcXkScYRrRgOohCGC80IwRFGQmHFFDikMCH9+i40ANwnEktoSnBqaSVcU4AI6bnhOjkfQdtG8IutmkpnLAjmJaGDWPSRfno/FDBcQLzpCfgsKMRoNphTsNlhlrAV8GJddwAHQIy3EbTQnEJKhiGo4AWsCAxYOeEpC6tAGLOsQaAcBnxMT00r9gbWC7tsLQcGI+oQzIhYSDA6odpY6LtJIA27EsLbQe6AuIbTEKrGcAdRv+EmU5ztC6Z5wlUlgk1hVYDlYiOCdXdh0UFBwktHbBnCED0ZrhX6JGAkREAom+hOg2jT5UKwz4YQI0m4QB2JmCP4YBhyDA2aK9pQhAmFuQcRAgNEKIvJuRiQDrCJIK0CyBSASMyvWGA07CcAQojGIyQkag2WoWGxpWQuI8THrMDjMh6DuFfJgFEnwcIowjQsQJAtEGYKFAwgGjYgCEUXD+ivV5QBXZAK/vtGNCW3RzuFTqUQ3ttBmjg8C4cNJA4ptWRVLew3VGriY36DABd0sy0DQYQvQMQEgbdEf0UEF45IKzOBL+9AW0b7SE9nDQrsROofkDSSw44LXhhJNx8cNSjFXfQOeDTAFo6iWl4MkkCh7TBea0NIKHhvRpQkX0yuuDheoABZLAHNxD878OiNMgfpynWhEQDeroDCHFlQIxB7kLIWgEgei6gY6HpolvBAIFQNQF7MOQIQnsMaJbWoU3CgAE6PsEIMITERaeCtQ2IRgT54MAPGcAQYugB4qMZDgzKiI4fmDSBCQiXK6BxfYImoO3aDOEeBDC/DBOwz3AACCHAMKLxRThtgJ7BEIwgV5mhw9Bj2AOETcIwYBgxFAwTgsTEgIYAYJ73HIYuwx7DPkMSdP1eyBDeFqAgSKtNAPHVAZx2AxYAnFaC6BFQOj2jB9g3YED1A2MQQKwZASD0GyB0Y+D0oXMCckNgF6FPJYBgIpwwOB+oTCg6wL4JZTWAvzFIBjCiACM0KdhWMOXjgTAHcElpATl6mYm+F1gmbDASNoAujY5AHsN+D6ANaMDHggAPoIkHELmWM3BoHx5gbPUGdgAPGUqfZpfN0LTQ20NIdzRJtJE+rDA0dQg+Cx0Ictroh5DTZj+A6YhskNM2HHrYBn2y1F0wDH2t74XwFPsuyWwIUWIbTAU77FsQY/B/IhrlI2MBvgTcLHgOEVRnD/LbgWcDdWb3wmjgOL0A7HJ7JMWhnCDFe70+IDwB2PTkAwgnZNMYGSHRYf3HaF8wJiwHdn9su5CSsQNX04hJQCeADglWKJg47sEuh8UPuzyMB+icQRy4AcMQFj+sbHSnyI29HuQ9ujyt9oUIh773IBk8svINmjkTuPdouTIcRVq07JGrTOYo2esw8r0AmchqR1ay2gUsARf+P0ROINBcXNrjYKJpQPnCuYRFDIivggkR0lCNiHrQgWSawtCBNeBCfZCfCjkTMRQQ4Aatlkpg4EFVwF8EgfAEIcmsPg0WQX0y7DkBDZE61DkHaIZomw70Qz+C/MPHOvjAPrRj0hsYDE1IR7QPB1WPyoBrOiDjaECmOw2/QSGhmQEGkAi0jgr2ICA8ckgzkrUQ2RABaJs26wGGrk2aAYwjPQDZHAUoIGEPETBiKGyaY0hsWNuwFWB5oz0mtN2FIRhA/gAkvaAGBRgwDC3yFmKLPAdBkNZLJDH0A0E0VkA0BUCPYZ9hQI4glI5Hi2Msl/b+E4wNhrCQEjRoNKcwdhnCXk4CuB4EoZmTAQogSHn7NL6U9GlVGqrFYuhYLo/8eLSzGtAVA4YhbZ8Q6H/QKoIgxVcgjQFoJuSemolLS9ppQIMWFlsmtEE9Q7EcbQqZopyhUBwsfDWqzo7Uz8rrPBhbeljcRZOZPiquR8FCX5TX6Vi/Lq5nuH5RXr/Pcv3NyDdF17T0J9V0iv565D8ZHVj6U5pUeTKqaX2p0po/9s3j16NhfuR3zeMuriRNMwq8o0TXeMeZLkX+ydi362gecXqe5kpgLcGHhTxYDUNSnYPDZ/BwbCihjX0+FocOBCmOnGwckSr4wJ4HLVBoaFp+kU2u5WkMFBDlaZYhyf9Nx1fBZRp/IskYfvLpn+Lm/2qHYz+/qTivt+hEV2T8MaCIXHWoxQYb9tPxWGQ/BHE6VwJgfddMM5nn62n+aKaZ5UGWPxmfXwolhHsziRjHKwm+aCSg8yCnwWqaH0bNiF1yQmzu512hR/64m+mJ3wqOJ8PuRDt4MWrN2/NO1I4oSkvSjvRLv5u05/qFn3dmeuyPO5f61Be4PvczXC/91kVnqqG9XPmtuHNOV2f+tHuhh/55N9ZH/ln7rBO2Q33hp92Jfu1ftM+703asv/Bb4ZHBUWC0NsodjVqGvmgv2qPudfsaJtMbv3XdDrtn7RfawUh/4rfw/KwbytvX/LJTvHwqX3aKly/9N92l/s5/0r3SP/df4/o7/2n3qmx+L9svO+/a7x5/3v688137u0ePWm/81yjgqab/GS2Gb/RoOXyiLwxz2J3pS/q51BemOXzTbqUHi66p6UvcPSnv5FTgM3QbjiZXhzTkyDBKaEClsvYm4e8iypWobY8e7ck2T6f65Mf5UI1Np4YPZCz5RTrbP0Prz8Ui95VAoM9HK9Hxfmxmf9VoMSfGqRJHq/nKVF69HalBUSG0HhgUDIdPAkz95yN9Iq8DH/19rsi3Oe44V6Qn+gyNqTX331MSrTxkSAaqotOKuXvTubETP23N/IBPzo584zA68i8PO51Ie9CKji4fPRKtxJ+fRKc6nzLm+/4FMlEopQvteLJ/mY7Fa+pMdC4s3z0dxxTsFqkm+9NJOs5bnbyVcG69My6uWGrMtCrAEX/PrLO39+EDXVZywd8Ucg/VVZ32lR+/Gg1ZruvjTYnHx+M68fj4M0481vT5/qIRaHBrZKaNJBBW4OkQIm0I6TXfX94t0NNGIumLCF3O6OhgoP1YJOBlfDekYgfSBw8kVkFYo3l2Je4eNE6eaVc2kkxjRCkjKvrC3b65CIGY+bKih4zNl3RlQKdEXRs1TyIo2nzRB6p2jz4wl9cR9YFEPUy4VQbp1C/1Cz3Wp5CdaMLvKVnVD5boB5Ch9aKUc4q9qd4qvYROnJujh0z9iHvJDL1kduSfo5fMpCZtzY7OHz1KW6ivk9kpul7CPWWp4SWKWmqX/gxcCzIRFJ0Fd0rXkeqVSpzXfaiZhEKMds3Di8fond3uhTYvOtfVycWpfgagHTbzUmF8fbME/Vegy0dHjJk4ZKDbcXlbIsuOO1nxbEg5dHHcEeUDyqNpN/ikadlxi0qY1h1XCQFZtQjIM61s0K1Uk62wFWhlK6LT0u7d4Tu7ejzeK53eGFJH3dhJ6AzsKqUoxENHUIjFv0k+FG04YTEBrMbfg7bCZ96tD0oyiH3cA3cLoYS7ZfJ3yTRRsWDMWI2/B22F744sEPdkgSDk1KN+AcF88dbYEBMPDX2fgvHuLzmUbJHS3J1SVCl/2Z4yq3HeSx2kt6mDIhjofdRBUKmDUhpONEYUMKKPUQcTX4qPIWPzJV0ToFNiFI6awUZlHMPx4/yYIHAYw5fBSyW6YMOouvlxVNuH/p+V9B0qDJemHVWEb9zohczckoCK0iuRvJ6IZSihKcSwmqJV4/nwwXiA76/uHz0y/fKeUWhwLVSLcz+6nMzEdwGfs6nQY3brmxudszZO2NX+nF2neXTB4Ud1iu6rq6X8GQUz8YkxVIk3FfzHTSLo0ZsJ4x0234wmV+WbwxAcfHfImM0GZusQbTiYX+bDrWhvbm541eEvI/+nUev5SNHqX6p2OLdaxQr/iV9Wt6pgJY1OeVsUnrgKWVui0JWzJX5urF7kBLUDHZCTh8cLPRbwrsUndEmhn8nJxPNl/Xyp5/foV+MWEw9Jhh4vybrRlU/7dVQLBVDImlSqz19GaizYb0Z1MM9GGr36GorrW4gzChxaCB8YV3kh22BeFZfmrV9e+8/0zlBe0ikCpetM70zlnbmDZ4pnTy8VlEtCqTj19FrBuiSsVa+U5a5LVDBPyPikZb6CFXlpNO3ImW3IWZb6XKF7Y+Z0PfPbsthXyldtzDzZkNn8W1vY9w0ReyKDgLfLQa5W3q1W/lpoTO1yZAsoT2++vKt85WJV83eHqK3TSut1l8SVaRUreaPsXU1b4N0kMNWk0iRufDIY0K1Zg6q5OYwug9nsk69HcnAsm0cc81rBVY4aFJJ14Y9vFEY0FVD11atqR/nEFWVTfdA/r2IkQ/7TFctiBX0o/khF9jlVKeGSaQy/uoK1d2AV1JGoKR7DC91A0WZkVe4S69JAJyKsCl5ScFXp9Qs0hxvZhvJFsw2tjzvdpRWotQRXra4hY6UFNGpHHd8VPsmE1U8jT2bT85VPpgjULFLqfBO/kDGHG2t3f39flG1uM5uRItMBUgKTrVysDYDFyqjc11T+A0M93W1zElM9zG01Sb5ojO2l6ntoxMk8i5SB4EnzNWrtXChiN1jUI/XpgqKhL8DgVyOw7zNlgI9/5jTGESnWUNSSWaNDWWOJ/2y0HwWXl6065DaF/S4jcYNJ5OVf+qL5pB7nJ6MeJn4r8uc8xBE0hh6SE+PUn+FhMZ6XrSDupM0HRY7L++QIlMGL8szzTwoGRGsDg1HB77t6kjlwkrcYFRVxV4+R8wnKt7irn73br4zYtY7u6lrvcuUKdCmhW3PAdo0tlKefTHzJ3yHVPJoco4MDFhXTYPOF/2LUsoutQAv/zzgLrqVkKSXFPoX08mhCYdxZABxYfdpYpJG0EBCAqZ+154vDqrMbOvX1UuQbepdvi5fdVO9myutUz5pvmy+R9gbe4ka6iKCDJ/AgquyCdk3Bns0iFAsy8O/piBDMtiNwIdBqDF27LQqCCxq6G+6RSHmy6YF6u4aSHjTTN++a2LobHjRuK3SKfiejhb/ykuvXPLA1/WLhW+3LBdd0vJ0hFwuuWEqpVGnjAzLJ56qGG+QULxvE6NPNLcujNb3csrSthYldhYlNhZ1vLqzfc90BF9blZtzT6YTiuuqbBRV329s0Clpu5SKxsCu4ZWUiysGxTKdaQqarzdQ5jm2ucmK1YdzWMLe2Alik16PWk9GBaWgHuOq15bUe8ounfNM+W+ijhd8NlQfcWBbbPnO/PzBoxdXAdK2B1XetNn94uECLTP0RfnY0oVQOv0v1aB6Oj9zDTqfCP/GfjtrondCPoGeiQUFe0+9hhWFO3Spo9IygnXXn7VSft7NO0E5hRWzkxrUq815s/LgudwX01OuF1miaVrMrXi9WO7fyZFPZb9Syn2zpFX3LaZetSEpY0X6zUOXUCjebYrOUopvKf40K3nf1pwUZQP5y4Zs0S23Crnu38O126yWK6piSxM+3C4p3C5W+lwtYNBmqiy47AvXVneiRH9Q0U5XXRNK8eX03h1qq714vUJFPF6hJgKyD27T5dkJvA3o7obdB8+2c3kb0dk5vVzF3GDMhpXTZCuYOYyak9HaygrnDmAkpvZ2vy57vtlSp2VdFj6eb+70V4dPdoBLqt2uCoKrRPxb+SbKAitPjBSSSvljoLxb654tT/VP55nwBqvQnCz1aQPhAFJ/WVuYXC3In6pUNi3JqLt9mqLesdi5dKkBTO7B1+WTJT5byiUwhU1ZPlsWTRhpHpiG/witTOTJVR+CZYow/W+ycp3+/+/WPu18/X6gOfRjM0hlPFXKhhQsSihzG1M2zxb90xJl8IHlh+pUrVFyYlFtvuombRkdKV37NgbeHVOVkn5dllO4W+j+nsLaM5a4lv/nf4W/1ldV4ZesbS2q57XqIouAod4Ty+bJ8Tp3G06phkKrWmiMOzUqhBqOvNZmqxsif1t9vacxfLKpmi8t7Nc+FVV7Y5YWzoeUWF2XiZZl46fzVRm1uqbyCupIB1uqIhNIGN9XkCroKH0m14nulYCvQV8+X9Hy1sLIFlFlrLJaKpX6+tDZg2UKyLUkuhom2fHfjbdlAl/amt0751mFj/u/shtRaKsr88Y7eVWaw6wx2M8PmPketr6LfH+s7a5O1T9GeadTQ0+uxr/LNUqqrkuN/e5/88b+fgtkp++3/HNn/ccL7UK7S295GMn9rKzm8TdvQEaibJQy92dCrC6qcv7/hPW80vF1Nxj85LbPWl2w13TpTI2cwCzw0dSnRyKnL4sAzGrQUjw2tPEMwoylMOnd34o/pJ8CdOIWfM8c9LsjTQK5OJzryxaGW+dGBaBClSjMy49r5SXTaaZVNjB5p7VbaydiXqJONNyWbIBktbyx5UTKCxzFXWXHrRBR4Pp9d8Ehfgah4QJPl3PJe1eOSn9Asdz0NLpSBRZPXQVU265CuCqu2HFEV+2zCbhhAzLk4XdzAp3eVUejPbncIpP0O+K7N11aXLXvyV6gPVC+W/GIpX0Br1jlMOsGSUyipTekPsd5ipaWsnV3smnx757cI4YF38/bfLUcrS2ij3fMXrZzdhrmi7Zsi5LOt9v7/GvDWBllp7jQxKhn82V1lcLN6VOtnk1QuK1GxkAqh8O2dhAIJgberQiAX4xkS7pYDhiIFfr9jh/v9X+pMLNz7eRXFhfvPuhdrhvR93YtmP743uk2m/52N+w1v3fKt+/eb/tst+c39cjPHm+b9Rt6uOARuncOtyv239eSv7tyTf//LPfmXO/bkX/4nqM7/2U7J7VpwzRK467jIXZyOf3k3+fLO3eSXv9xNfqrMXrlFha1UXkZJxE58aZcGfG+Rs4KLS8M8Cx6/GZW7AXmsmx5aQccurwO+MK2zoFNcWAF8F+V9hapMEGiHcC/hcUi7ul3l4xF4pRTtIAKJrVSmXK6kXDZT3hREW7ZCdFIQjYcV0ZRgE9EzX3lfoVKInvitSTuR0wQ11u64Jks7mIGHrUCmWqqpRCPVzVbno9iBucVR+HmntAsupxc0nv/zfxdZx82iFGLE5PKaOO/XaSw1kaWmqm7+lR7Huk2hJP03OR2NVXONL5VDPSWh3ZzWURfEdseHKsOrTd+tBoP58XRy3RJt0cnamdraNO1mK3f/E2YpKun+07p0X2t9unKttkSlta60RF29aTTLaknmP6lBfr2bBuExlEJ0DCsHylD0iZQcu4dR1FGUb+4kh7757+Y9/bvl0f86Yv9Nhdp/puP3P1LmfX8PmfeNIvN+/6sy7+s7ybyv/9f2+g9wWf/zBcd/Sxf5f6RAya/vLlC+VgTKL39VoIyvdy7gEtfqXowiDI6y0+N6g0cvPWo4zeOu9PDhs8q5JzlTddDKPnxIj4xHj7qGRq6q6Bbr11rphw9Z+WJOnm7aCdoZ5eikWrG1sgWaJloHEE29XR1/UYadolWt1XWg6ftuu7qdaxr6v7IR5VoNF6MQX+7iFMctu90kXtBQnjVU9r9ONjDBKIY1jGJYwyyGNUz+rC4+yT7c7n535nrambfH+qQ714MurcmlhZ3KHpjdtTbf8JpaS3Td2IcT7caS7H49u662/VLQJmWemaq+igeScfAR9TZo3PJy5ZQ2vYBX9GPpAf3QxDSt0jkxT3W5kjnjueixlp6MT2H0TOjHQWL6QbqxTD7umKcFTmQgdBN50UNSvugjFV108FPhZszCJ9wHwIzXXEDXF1wCftsBP1ZxS4QHsgBgyrrW4fixbxx2uwWZLc6cMlUaIZb5C5JaREFHIqNFw2Nkrb+TP7D8pAJH0TBPUn2ihD26vN5lFaDu66QX15VyaqVVnWmPzWpVQBGAy+cme0ILA07RaIPyWJrJUQrqJpw884Mi0QSJYEkciqM53gotOBGnqLmOzxeoznQGrd/K5GPtOJOPh8WDmr6YW1VJS30cDoXCqFoNrFJwmBitCWLSuOqvNaLpdSMAArWP+uU5lyJX+o79k5Ktn4z334llc3f7sm7mIIZOGbq6LkWRpHZ/NoF+binKvz6qZ3ySn3ZpMcWNuuf8qvmR+DZ0msyXQqP43gmeHRjETDBco83FecG8xxMOKzSmZeIVJVmN/WyN4vAvUxyuUUxb4bumQjFIzWpSMyYVhIoOORFV/Yyv/6I7vsvOU1LssOK2LBvZZKrtGCNSravKBdswZERuZbDlo/8tS88KoWD8sysl1BXPDaOOtOVFtVIiR5tfeaD9u0YvpRUArvDmTmoJbL9rVfkL88OHcXWHL9vOnP+EYUe9ZHXJYeFn17XtrKHTr/jqa3WzkmPnjNQuw3dcofTFDTpEa672iFccY3A/Ai25aKmdRdPkaI3frCk1iUwg9/AypSgLXTxqdDnJy80RC5rsLnKXbWhDMIRNAkXW4k78RUVL/A17r5GtjH+5mr1pIdIOe9r6NtFT3sn5L5YvzXWKH7kekVcjUpi3W/sGrU0kO2RbD6ne6xbFItO2YCETjZQS79j/pFoE6bMhC0WG3zEZqwZsGvMwOBJk5+idTqDtqooMBcP80dPiN0MR8l7+5icBlRug3FvFmvgYYVZ2wZLFvGDyo5dG6pf/6rZUkn03dWQcFZKk5FR+ZD56ZDV1wioXm6qp/GpN/wf0DIxSGD2l4V3WU76t8rYYI/9Jq/cq7VB11fzIN7Z0srK/b9mXwUVxwIzGEFi7Wguca528WOmdH25EIerq2/KemnHVuCo5VY60jK793H9MMZPzehRkQc7CnzIwwtMrgfoAyzncwRDlZcF4BnExGmZ6nM6mAapmmN5ofxZ6S0aY+y6bTEWWp2Im1dCf1IGG+M7LuRjCwB7PRyILwksxfGDooDlJz+fl/Y2uFl3kGd+WpyCwSC5uTV59RpEjuy3HWZkyvblRfIHraryDefuuZPKiVPNLKPnrhhhRorMMr6/1GbS1UJp8Y7W1NLp5dOtaGh/779plEUUBWvE5lzAYVrpOgYljtjySUSzX8RXYOk3sy/KeBso4yMYGGk9I3cgm+q5TEgVZ33i0PC0Q/LLpK/Nm9iLp29uTLm/0dHwlVDla08V6UHajhXZQfCervW7BtOLhaYllE3GtfAVFmXgTeWXiZZ04E1y5m797P5pMlxTRdDIKKCrUfkaxzlvy8F7GUBDG9VE8Lp7pFDSqRL+ZV3dF/3Yr+nzyOs/S8bmqcYpA2FV7a+0V9dbZ04vLZWdP+4QJK1++w5O9QuK8uPaLxmfqhq4uiHpTedWHD/L9s7M/JpPRoSajwvsUIz2DPHg5iWEHF9/44roOMCfT1/3yiRyv25/lk+nz0UjEKaglsRScB/Jb6rSvi7TTTJDM+UKKeNJkd8r+VBkWBq37UZ5dfiOWjx7tXV8IcblHqnSfuv6HD7CX5nk+USPTv7xuGIjVF32SQkoE44gitbz+6cunl4KirxwzLybXY5HVD4FX278IZk9y1BcKAOOvUnH92WSxpx2fnHCW4sF+CKX2U3Cpcfi95al+klPP379O4/yCnuD6QqTnF/np6fDkBDXESfh1mXef5aBeJmw+bmSLLlOQ93OBW959VWBXThu4Vs5OYAXFdfnhw4trJYC/wuQuqZnLPHgLVUmSTd69QNM43jfcoXpvDvcNw9LadbUcm8ZQjc/0nVL6OLhKUb+TjA5jeDOZRxffkdqfffiwB71K9xywkIO9g1DlWIC1Ue+i77bIFCdrvCvkBY8R1S/N8iVf8Ph40S1lTrPMafKOJOWlWb7ki7oj1F0zfZwd81zBgTWsZgYMPdPA2frI7FTTg8eT49YEpn0z4aSZkObS3qiKTNVqqN4ncSwy/w2uvhCXwXwcLP1v57h7Bi0b5K+nIkoTuAp+nuDhc5gp2fhFMPWrq+rpa5H71RWeUp/3v49xRQam/yMtxftpkk3Gk9R/TyX8itbyplToIIvi86BeGpENqzENPZOzEWfMqJTekvOVyjHc/9/em361jTSPwt/fvyJwcjmSLRnbhGRiaDhZyDKTbUIyM4kvLz8htW0NsqRoMTiB//1WVS9qyTKBmee5n+7MCVaXuqtbvVZV1wKr7l7MlGcj8moUdzc3oZdQRowi8ezERreVBT/4Fm5t8V7szTkerDrqBexuaWKNxzDHna8JzIpupkV+ghsh90FshT98Ngfy9sPcIV/9pqv+7+jJ6/4cJsDzmxyWSwVL8tgPy9hwjGW485oBAb3mVcDC9jfu8dxJWbL+5ZQt5lbqBrazZOlBgP1ZXl1ZJZuQq3NnhgEArJxh4IAIWoftQI1QyDc9OJq78FgqAnzWOZtbgGnWucBf4YJcOFsSbtg3gNiNoDT6D1aFIiyUAhwLpbVCERQJnKVtkNoL59Q5YxjmInUu4fcCft+yqfMJ/j1hXvt3bg+dY/ZE1Iv+zdtzjd7OoTFRd9aZQSuO2OXcgq6ZuRGW7/L2Qrbzjh055+wIO+5Yq8o+Y+/m1vE2fdMTyPRBpGcyvWe9ddmw88yGAofWZZc96zDY3UbuwLlw2TN7ZL0F7v2SXWCIj5R86lmfsMQHUeKsyz7oEnOXfYASn6DEGZvrEhQk4zujMTmznfuMKoen54y6/MJ2PjJq4AV5gTvSjX/hfBPF5rbzWRSDp9ei2KXtvBfFLqnYdP8JTYYXtQVbRT9xVDwKxt3CmbDMjZ2ceW4Ic6l0E5xVHd/NOxMRRAY6fx/aYSsatWvNmJV3rNhNbDeCs8ANbXt7Znd8J4aRmpxcW9+d+85r573zzfnsPHc+2qK+p+y7+wL35S/sPjzAHvyGfROQv9lnAXnFBujuqI0EOxgcAmO67w4On6hIO8Lh57VlPe286X7p/G1vWzBjnnaeQuILRVR5Ay/+hhc2jdhf6AcHK+zgny7W2HlBcpt3OLeOHCty/wIkr9wBzJBzCZsJWBdg1yTfecfOWf/6E477OQ3+gn2cW/jB+OEz5xwWiHOKMNkBCqZX2KLnX3YXvcv+wIHHJTwu+wOocf/oUKw1zECvoOApzHp871ABG9OnlD4VaVjCI+tWxSA9oPRAFKvtBvRetIUyiRYOVIXw5pTenOKb0yYOhOIrWbPKWpWvN9imJsvegF6rN+XMmVOmUT2L2KfeYpe/q/od+xf7OXLcd7rj1QxUwFLx8Gt6/l1Lz7/7Zz3fWuyGno/+Uc+3dPy7W3a8WfWFcwmoRrp7cLWKSV5Wnqv6tK2UNbHUpBFtYrLiDXLS82E/zpIwaB7OnFnrTtTuvXUHKm75GRRcc6pCwTVHKhR0MZqXut+GHTOzO9y5EL8n6Co/bPMX/Z+IBJG0+ZL+T8RX8JOspcn/NB6NGVwh9YK7oP1HMSwMT+W3quRnHjdV7AS+4jH8JqzJz7EmskfugNX7Oda7h2co671cIJYSozIQ+cs99mYun3DsvIj9RukclmAQxlMUn/W8skg+Iath1qjv3ZFWL2pU/Tg+Af4nnFu2IOnhz2aRlRy+ikGKbfTFdQfCJx486ReD6sU7750C4/WnggudDc6An5LBejKgl+co/7S2/39r7HZP/nfwY3htH8LPg2vLpZT8sQ/tQ+sTPY4EXP787x787oj3X680kpEudX8bNkDs+DAu+d7S39rKxg9OtrY2svEj+IF5FvYynkaez61td3vqbG5v2hXk07azeQ9D2QotpOfEF8r9MmRcfp2IzYfdx0Ijlh4MwGWYP02KIpm3DfqHwnpb0BWeyPmGT1onB+T7ZOb7iBKANRkvzIyfknRNtkuV7SyM2e/0m3O/YLl+fMaRhWQTDaDW+TopGlHqdJKxDBNRctZgG9XpwOkWAiC9YsZja+GLBkRl1ihAs0N4wF8fznBThTPMNu099FBZvwzcQG6zFiDxNrhkMDoRTJFfXW1otrSQrvwyhhpDxAJTpDurUpqBxofk0hbO3cwKnaJKGG8K9dFDYOXE0+u5N+UMRTxnWZnPWkIQXHhW5InuwhzHPOKUoza6Sknn9JQyaZ75MO4F4RwPprQsrLiXq9JwsEh+mgr81V7xxKj4S3uWXGYpJxPeHMw1o38qRt+fJVnQgvS7Z20MyBG4yvQ8RC+tfF3mfi0zSTNSoF3Wo+6L3FGZF2abdfiOAJX5HM5QlwqD9Wk1T1j/lAf4KtbfC3vc82dPJoDE0IHSCiAxtCeMgozHexyO+nb31eiANihhLv0dAOW1rabxNUxaJ253UY1OW2ShV1gI8wJlihUkh16XwTg7iT3qU3nUG43ta1u4Cy3bT4M9ilCiGmsX5MVHi8Wu4asd/9YlY62+2UAxYWXv0i3ImSiQdznzUXxqYSxCTa/dM/s0OzTrLOD7LPjjhr1Lu4NH3JJZYW/pwgNQdtej1swTYOZy+KsKDFwscwjP2/A7Ai4Pimq15xAWSOplXn193Uwaxk5I5B+UDb/fkmrAaeWQelsf1R27pFMAaDJx4I+Bf8fLlV6cBPz4Llj77VgJoVzxIc39JIJN+zunRxTPZs/RCLtYrq6GSQk48xIQRiWsh8cPUbtwt48Ta4gaDkOnZDsddPGUdYed8uDAg5EO1WPOfvesoXlXMQNCnFCLY/VFlHjFzlDoY/qdCXrN11YJQ8f1UO7mioiZ0vfwPSCxJI4ARtlC3YqZk9nd0u7kTsqsGEAVYMq6XAJIYLK1FdDlerAPFEFKj+m+jFi4NM+NwHYWZjpFdjNwl+ih94yl7gIe9sIxsHId/6SLc+vUxhvoM7szdRA+kG9OG1Br0R3Y8s2ZhFYwgQfg12paRtaPwCu8UejQZcLId8T1wQgowqSTw5Fk6L1Wx8HMoshvufBUbHTqsOPpo0tEXQ1zMQDcvrqCw/Ol9a6cn/Gs9/b1u9M/nrz5fOT8Cli2M4cjPVRaNk12a+w7kxPc1TOez5IoyC1Ol2GwLA6KTgbkF5QSENr/2QEsSrrrgDEBkslJMYSLqR+aNu7hYEMPY6C88h5MgCPYGjBMpKE8PhWrXb1cGqiW9VcLU2+WXint8I7RNZ7tlnQNy+gutvHG0I2tDhUx8S1aBXZj+gdqCAO1zvKWc1sOVLNfVwcNaQ92QCqme2IJpdDjEjMqc2GfV1up6GkgQK4VrE3TYAn0yubcu9x0fqAaAGo0iMG+xonlBP86DCPsAMglB7RNBv86pCGiKwhdjOgu+DqS+A5ccYWTI86VnfyGWN1jYJ9O9sRA1rZeQYrGtMHwBgHaoD2xvs2KmsQzhXHnFDUCYeLwKFo5BG4KHj7Y3/ckHUx6pwdscEPdiL7RAM/c9egxSnChbdPzm3dDW7WtWvm3G4B83QDUt6HCPoQR+epJbUwgbyApxifHas+8OKCt8NZ9Utm/JeghcGDb9R66aXR0bVUPJcyqMD7oFJ0CULoDCgZOPXNdnaw5LGxKlXHBFo7ST23rsK+x9aVAvXr67iDx6Vt66kHeWduCfEUscIh/KSiR5MYQ9Ho9wyyhrcvHlZUNsMItTYlhB0c8MWpRwxaU4mUUOtmUpgBzW2zsp/YNJjvQKb1JCJ9CMYjGtCSy/f7VFe/lyZxbZ1ofIaEDfm/P/pEIJcJQHht4MwxNQZOF+ASOCuL3PJaJ/N1uOPZOUOMRfvZoCqCqjqdvFA8TwgP8TgJHtee6J6yPisPQZfmCXfjiQdyzsqyWfJoESxbWQB+TC+Y1ITlLaqA/aNctJeyDlwErEpspKsMJUp7xGY/CS/Ypo+Q8L+cNJkowE2gloa3JiGZ6+MAMmO4YwXbhiOBdmNZXV/1RKJ5jjEHQ7QLjD0AxfVDt9Ck5Um8bfeWnsp71GcqEW0OgYoFvqwXepzxel/1zPXs5T/9i8aWZ/sK4kY6DiLP3GvDMI9IgYm9WQLKZr1ZeUHNeGuBiDjTxx2TOvrYAJZrfW14RouJCvXgDp6mXYUzsGuDm7iKLSf39b5M4KZKY/7Uuu9ea/cu67GUt+zsPXkBfrck8qWU+Lnir7AhzkoVYb7eemdi1G0sM6gWecli9rTugLiFmacC1UJNTchEK5gy7PghR5sDjWgwqh/asH8JOUatCQA0GB8GRg4jtChAjgNuk/cILblWGRiSyCcL87xbrARU+Ih4fL+dnSdQLoTbck08s0kAwG7DXqEwcVxmqHmFgVKkBNaDdDQg2sbtZWuszgKEehdeM92KM1m3bW1sbodjvJEkX5mQSUGHKel6AzIDiIkh1s6f0Ttl9PDaCzJuucHzq9pjlHDbtiAOPN8OAIQEHHu/HNZC39wtrU2jzOJuIAn5gkDYpLLsTwT5lMHtEgwPyzXlSwmJILuKeKBLQ0YB8fmlThkpJSOZYGnC8npLghcO58QZqphf3KOWj2lckc56iuskSlenoneuJU9DZjKE7N/VL94KfnYeFW3ipOwNiMkKC0iUWGfJm0zOP7s/wamzTNjktulxHMiLb2goNyxGEq1v3MwFKGq/xjyP6BKgKYEQtOPs9UjWzq+4yvjp1Mm68KVMJnyLc8bgq7IQY1x1O6o2BUzBPao79BTy8ev7i+Hr4UDHJZL4y+p6Eo3ntBld8eqawuAVGkVF43HgPmJZO2E06yUF07feoZZacEpnd4NK+oiblug+8V/8qFFXYTsllCYyvkqABu6MrwQnnFHV2TwqQzaEgcyN9z+GRtAqFvwGpqPEc5nXSyI5hcZQ0GZehMEf1yRzVytSAlpjXQavUXhhAb5CCFqVxcVohtTbTHV3IV9cNJtQ0e260DPvdaIaw6Q3Johfa5I8zvLKp6iYjSdFJegwKJyOqyeRbjUrD1UoTFpqVwsT2IzjJPoVznpQFTosM9oVCpS1j8xB3g8A07vb7tjRBTqrmhi3NDVVzxWg6YaO1Z3VLJhJhOhGqMrGJVNJ1prDRWgmQlGgSIKMpbjArYIp7cOiEg0rO6NSRA1JT0udKB37mVC0chY5QhRvlzuVoipzdEn4GJ05wOeo7wRL/KDX+FL4b5R36nhzYZhfLAL0FWyJwvS4WxZT+OpRKeY6SPDkLNt2T9hqJsM2Qk2cEnXcC59+S5d2uYWBBvTaSkYkxj+O6uXhDwz+irplcXXk4q6H0dSq6JHF0pyT1jvCcvKTzZBTc3CVL2SXdUnZKN8JuQZC7wK4KBBgS2GH1btKCrZk8Av7lvbDPrY0NmEgzuhieEePlAQV2S7xrb4Z9mp4zuhgGXk/0zL+8F9Y4PcRJ5xLaSdz2YvjnPVAiXlN8rQW5AJVKExNDY0JTOsA7TA5nKKOZ4Q7vnz8PhRb17doWMcFLdwpsRcUdR0DIza4lsQEo6Ws9LgFHMaVJJzoAjqypxGb/QLc6zdq2tlr6gaN2IcMg64IXsqWI7NcSqT/Z7rlPHKW4iGrTPAtRWx4OmALnqeC0A80g/oqMPIcF9tTzz9mbxEi9jtnTevp9WdSzIOCLBiQldu3revp1K7c0cF8naNlErTEzI8YWawqr6LChvc8Gh7rkCH4Ld2B3UUZRR4NIdDOehRls+OxdPb2uWdUoQx2dqn2qFKJuoGpv8j0T0z23jqw8C4GOSsxke4MKFMRc1/NhffWy7S2gOlGMo8ofRV5eQMV/JXUAVP1qBYQ4XzagCKsKX6bsyEi0f8AxDla3+nTKiHjMomt6cOBC6aqoZEkLdtAtJOhDEi3ZRWKkoBXzehqR17Ig4FIBfi+9gJ2aqbUDcV3LhFhq5dZ8RNGxhsY8Pw5j9iSpEmvmIYN953AwGhiB4TufEhOLaIGJ6sZ5iEY/GsOCZ8sG50dKMGoD2tCybkOEiKo3UoxYAMlxL8zvAcN+z7uniynNhdrdViZ4Q+QpYitzgOSs83QGJwd8IOyI7C08TloFR5o9xeZQZeho4w4yJGIgSYxkkxxJpFGU1O1mUpREXbRyiP/n+kh9xPik+oKqu0LRXVWT0KpAiA8NVyHYwsgrXmZJma5KCpRqgPVBgdDwU5b5mERRvVDsULT0qtjzCogRZB26cfK50qFZleUBBV3TKZBcFiprA38vvbaUwEn7yEmjkyDUNdj3UNhpl10G9AoHYg/NkPwucC9LylQyq9z2YO10Miho+fAc47NZuCrpshJY0qXLfEWKSY0ztDlmSL4LMw5IxpgMe2EcFqEXNe8hOKOr71tfEXWr6/Jb3wPBBhbSZU8IHHtG4NteiIuimbz1FgMDQwoU7eo1nJR6oJsxY3w8q1J3ACbO8R2yEkGDCqZUHYAd6e+lxOykJFXy2H2kM177znvfBg42Dwuh0oAhSSFvsR9A3sL2GXrJwajwYx96OOCXJ6SQHzkT0o7we4tLUpRY4uPS8QQua2rcp08lqYSOvaRvcyBZvMKDBha9DNoWdcmsZKPUUvGDSTe9ukr2Jy788IMcU95+7qZC9ZdaciBbJJBO2cRF9Y0SWwSsBDwsMUFsS2faXXaWe4v9tJPCjMEdZAq/C5irU/bZB67R7kxtB+FLCV8q+BIv2a3UtRaGj8IFqvAvOqGDHYBYOmxhd6wU2LoOC+xta9ZF8xbsE8RFb1MH2+ZCayDfwE1RZXoBM3zZSYHhMHyayasi0Ulax6sHpONYwORI7JnOozJiZx8QO4vKfltbpDGZHcArXDOQQQBMt2gWVSTXvXCGFdclC9VdSWILCT/NoswOYWZkJw4sV9kamMoowyejdGlJurq7iuX7zbeU/uhgBLPMdrz25YtGd/Bx6P/J8fHaypMiTHh7ywu9BJeYRxySd8fVGcqiIRbN/hPq2PDheNEMn4J4YZPx9KoHcuh83ZIXZjLsqd/QclLkxbY27Athhgh2Wa1WhAhGWUJsFJBCQ3b6KA41NpIIhWtqSsGu7JSG0uJ+Thu0eo2bTCRttqaw3Pp7S/KHtrQnsLXDTFuiJR01BPYLYL182QjY2rsRLoMJ6j7Bw9UVrDMPDdQi2EQiXBGTHv5bLNWrWYfBwoJFU62/WQcWWAeWmMuxqu20k3VieHJg+aUOVcBmHVjcCb52CC0LOlNnQuuVXg1cWPITWqHwploVM7EqpAIPbaha0AU9pv2WRbQ43nqpldU0SMYlbXgYGJruA8V+269dPE7sPY+61LOpuzzoLhoe5jmbCbHx1aLxZU/C2lGP7ItvRY5KwQJqKSQ6nAqJR1VIjgQcmmO/PluYtQJCGqo7oKy1aSSy1kAiq/5e0xliXn2v+FwnwWvRldq2VxvQXanH3otrqJ3Asmte8wCUWqYkM1BDql3/1VzQ7XESW3IbvcGxrm/hba7Da9LbtIkirqNQkk9y09eF3Ru1h8gHUgv9MqY52b7l4cYCW57HYkd4XEJjmPNb7zxUyolod4EqWi/32uQ2BZYpqcwdd9gct8mIFB+iO+6w/jpxEW6UhRhYwOwj5uBOwp7JTzCnAvMEMOst+K0XL+lOfd2FE0xpKO7ukDNXdHA62EYiuPfLwDTV5ZpervYKorcK5y/feVmntyKxP+ABJwjhhPZZOPRQXKrIqZkxEXMxEVs9kkpqvOaEVLralG4/aVqGY73gu+RHBqfptXEQ1I4fcfgIap/IEqm48kM0PGGoauwR6eGhT0TazdAfItPuaGOh6UUXD8AgyCRyB1AB/OnEwCsk4mGJYe0vWbbtk0Jssu2TRcMPxGyj6xVBAl2S9rBMLPeC5AcgDsexSSBdX8zCiEPBmG4l7Wul21eau30BXwgks7gokzkUR9snEV3EUFMX2ziDpyU8LeG8yt0EaVdhEIw9AwfStr+fKoot3S8lrYkG0mkXj0E40KAXOpGgNWcSPlPwGUzMfQ+hxlnnddDoOaaDK+rIBnay7RRhSzzMDJjtbPSF4pAap6ur9IDhdZ8kKDeAa0JnFdQj/7kG2jgEVQ2QJWBhnV5VbabvCHTrA1uOE2ruiHGqjPba9kg8W/H+HJ32OTnukZM77jtrBepyd8itytxK7Ttvw1bZTptkveiQRZTRQ3YNk9eqad+6KzcxlYSpmNXisN68xa7gQOuGid71pIVWXa5tcASwd0Gv9AYGR1eaKvYeUYr6JtAjOtBTt8sZnvXEK7ow6wbcfSjYRZfLVGRMpEln0s075MjAQvrAjewOqk91iu1oT3Bak85MclV5Z3a9wspkeuOq302aeyKv+2nmaovklS9iYGUycX5nNt35Sa+++NI+7I+6XvX+NtwO8TgNiYVIctoo0Qn4OgEGEgPE+5R3nORrb3jkJEcupKRrnvI/zt2URH+U7SYla0QoJYlQytuKXbgsw6GMnszH4byMGtYR1WFG9jK9fh+VAKUsFlWXM2ewvdPvK4+IvYfoh0OQ9nDovQvhkJY6JUXonxu6JAadQGoxTAkvLVIkZ9Ybv1N0//bt//XKt7df+deWbbJb9g8yXRZXnhI39B/fzwSlX6BOo35PN9CxefmsDRVI5FMRAVpKmtGF08DWggJUfYmIFoiIjuUorHM5rDLod6WHXrt0KmB9XKMkA0r6RMH7tpi5QGJhEGy7N7k8BGYOliYs0A7zRtYEhx3AxGxVUx1AS8i5pJxLmXNJYGLDIKc2C6uT7k1vzAbdnhHdTk6+Ywrqrfgo7oh79hgagkuOKIfJpV2BlwRe0iOsclrgkM2+ulLPS1spmAz6nWqb6u12aQ/hnT/8PUQcdrRcPxFWURKCcvrEvrYUwoWJfbEkegihSBHh99dUXao1GBt7w9aWmYLdGrbLeB2PgfRzzH7g1BrNHKlasOryC5hF+Q6nOixCnHqt2eSchCxo+ZNXefiNGwanllRTLLXJR+O1Q0Ec2lycrVnvMa13KgXn8e0KZrJgJgs+577X5u9unQQIinZDWfaTUDm4veQpJipiwaPED4vlHar20HsmFh+4sENnXhwk82Pii29XHvaDlQ4HDo12SdOR4PqBOxgcSjEdPyyV4mGB3hly1FcEFgoFDzECpqTACNhD04epvB/XlwdOSbKUvrlXkeIQVZIdZshPjbIOUHUTvFmg7WZiQ1fg+e0iOTRGa55L2K+6eFWAMl67k9hiw2Ro/VXZDQHTmMS3/1JUPqBM+EUiYQs9bOqyv9bJ5laIo8QkjkJ5pmipakI3HYmNXzRO4GNIfJzBozAb5PDUMcyHvJqINjFRNQW0ntLp1EmoW1eIiHVsgoRIHGwAjAucKUjShFX6LgLcvhDgJuvIFxTfeki+JHeWvt5MvgBStCINEfO/NQCSlItECftSogf+y39t4JfVwC//38D/s4Ff/rcGfu4pV5FvEnR3ySYT/UJC/ApSOcD7FaUWk5/ddcPAVlfZRIkh/Sj1roVzAbwoxuts5Ua4drmMCXm1jGdUdb2si4VK7til6+UpT55EZzzL2WVgJj/n3g3SLph0l3Rwszn89LIEXeNZ48HuA6cPM9inG2Rr7A6d3V96uwBB0+QogvZa491d5yGAgHBslH1UL7vjDB73HtfL/uIMfjlBmvtHm8vohI3h9+T6ulp6ueFiAHX7PDKOrGyhyCeQdKAPxxKukKsrK6sB0LA0rENMkVilAcKED0EnV1SX8rbaYjjp9YSzVJRPe4b7Rlyxwo0tOoC0t9GeTniwRZ+PkFaMRHjAeoPh1la43xvuPNjayg6Y23sw3IWnfbc3HDw4LEeU5+HDRiZ4JzINBruH/sizZSvpoM5pTXrGLK1OR1jpMRoswYoD2mnsyawwLbktmVBIcbzd1M8nhjKwU7SPWyV7p7A/FO0Fo+KoMJWk1ZCnM55xk/bUd9uiWCGKFSc9kVUFJVjxur62nM6tijYcr99YEPKKuCrRcprEt6/ULGAguG3VVXa81xCKgxnqDOTo2NYP6+HJb6QrqwKo51nWk349CdPeHpklxNQRG+LtahPzn2oSj72d3Q7VpN/kxsKoLRKqXC6gazPbra0qa+j2mmsykfawubSHVQo5taWKxo5RmB6RNpM1Hiew/nZ3O7GTwxrb+aUTnzjjpKtgXQkjR6K0OCa41ksDIWLY6T+SufsDyN1SxRDQdYMJ5hkM6RHroWXdiV3xAhY7PddrC/GytVbbsK/ahqhaaiOkqraHD43qYPP4SXWRGJtJWAiMzbssqW8eWDKQoch73HLrJen2Rs4/G2a0pt+WRtZXTUtrI29u5hUTYNB/JIy48DhEr1UtU7rMxZHtvJkAOh+Y7WGnzFWh7+G8LGZedPSt9KI6Co1hGVifAltVOXzQe7QrBoCceFmDR3D8PX5sr0X50btgn4LVt6EQJxftVT7RVQL+B4NffrllnQor1vpE1opauEGLWwBTOQFJmt8n7LcJc60/J+zrBHk5lKpgBBXquxc5uRDQK5Q2O0hShK5XKMUgzaZxBnkwFJuWyP6VW5mDvrBylL7icXl1RbCQAqxZf+cUmkQkD1Qqk1G58JfRKwdehfpVS0YM3obogWUXOnrQFHV9jyHKUE4MazkZc5YYPmTifcb3IKtDIfsYyogd4FUJ/0CES7HtA7w08YBFhc6hRkBPUc3as0vOklwQFpCFYfddXX2VT4fjMQYNgX+wKtUTOuP+c+J8xZX628T5HdalHNBnK54OYcjmQPvl7CJnb3P2KWdPcnacsyM0iHun5vi5enhWm/Uvc7V1dt9hbKXueQ7d0H2GFkBHE8nma6cO++mERNxPMOsx5jzKnct8PxDgCwS/RfAnGHPLwGBDSftQf95o/HZCMS46ZxPn48TKtkN81N8o9MDbiFcWRha5KcedF54f40TEhyFu+U3ahGQUhRhwoM8pDTMV3W4wqBnpMXwwyU1P1obqkO3ulvFCpPVNZz4BkniN10h4WRk7jDHOYhlZLgaJxGLwMKCHviLlnBmayqBUZYA30iIQx+YHQStsOoZzkhEQEdBxinT1rvX56DfVQP+JdwrscHGU0kF6QupNvE1t6mZB3Xr0xPgJGd5dKZ61/GSFNpSaWDivaJcswjnPYC/0YvYpql7ISffEADUPvRoTRSoiqAmDTok8dEpU0Rg/xBHaJkI1KPCCfY8sucvaRIJfO0KxuipY3iz8LLVzevGIAT/xUXil9+QjQPX04DZsLeg1BEgAx4Nt5dronI/chwMC/U9+V92QxKEPf4gXjlrOo9PAOq+OwP7j3m6N3dvpOzv9E3Ua1bHhOXQeGG+qo3beCsYCZ403NxyV0LQPVdN2Bj1gbivutO8MdnqPd355XG9d45z8UFWHVl15KwFiwaA+jdCc+v1FrB3biNgR9uHTaCweT0ZvIlvyQoRU2zi9l71NX3oEbESbLz44+b9Vn/PoEXzOLwpTVRAb/S3QUHJeB0NaRl7WjvNZhXN32Hu4Y6A0CyPeZxLvyziZY1+1I/xcIXzwoNd/8NgkTx5qqkwhQcSfFWJUTvJLmH+/RQ3IoN9S229AoFoK4WuyFGzxIlb3SA6UiA/rVsiqB04E/2bwHIjlkUJyCv+WLAysVlZXsLlnFgkqbBHeSSx3yexycsND5/816hfzWXW6GJ6bUlaSf7CyEzmoZ0PVn5nmpzoqBR1YKbrlwVNiivTYTMoOWdgp3KwTA5GSdYpu2EFpQyKPgHHW9Z2wC+eqrPNsRZpRq8P1ZR3upFlHV9fhNuvYhpZtT+EIOlsRPFRbd7K15VFYpGSUsKW1QE0KtN84g07LC5wft9vwF6yAoeIMDn/RY6fIxi4Qkd+yY9+MSok7rRpGPrNHsDEHgoHUPpXE7poJdlLuuYWM5iFaIdAF0o3eOHA4bLK41Yq+uT1nXeLtEqEssWQ7a3yDVog4rifSCR8hIqdeiMyruxe+6W4vZs9gEjD+v3Ye9oE2QeuBTzgrBMYZEGyIMOMTdOvZ6jqk9eqKoq8LHPl+30DR6k6kzdbTRBEJFD9nUc8kh3j2Uxa1lvNmFrWW9Scsqs6r9is8h9KkMbBGJHdJG2bCGxw8heQbE58SFkuYh2OSIVX6jH59TCcoYH1GvznzOp9QcRF2Oq/zjJ5mzEdYiJrZPsLgKWXDDlDi3yfWiwnFdu96Hb8Dz6HLbRst3SFfSoFCap4xBfMA74oOS+3tKSwWzOgW+AzbSifvxp0Z7iudCJ4Culsv4UmRw8gKhECXIysAj4kDTcg6GWxloS2YgtXb6jHH3Bm9VVTXstIiTZ2l7OM34m7imzxN3vLMJ79Vq0fJUWAd64Pr8cPB9ulEHSyqFJ5Ux/Kkkj5t6MgdtJ+Dr43Derc3fLyr8NXKItLXEul7ACTTzEtn687W9xrn8AGRWtXJ+rjfDXSTTUxYw3tZAwXiqU82MgSkS68dGJsHvV2TFypMutVqobVhX5eiduHJ3VrrG1/wm+jcA54zVEqgWF0Vt+KtEdPIcjkGZslnVUHgFubcy8t2Xz6y1G9Y6rd6qbNVmUe90BwLzeuFViMMrBR7j8Xe14ulWfJ302XyTbdZXMcwQn1vdRzhs5LLKeuSu3l1r3znW5IRQCEAx8skm6IKPp2REq7Tcj24MsYJMVYxfV8F/pfqmVZjHkFbJAdH5j1BOA2Leh03CYdD5Y0D6rCln3S6a1N+6Qwng4VdeUtc46j7f5Q7PtGM0b37P4rr/4FyrKGfQzqA4sZWdC4yn+Y0QJmzQAJv1RhamiX4UM2XZdAEvS0L2r0W8s1HvHjDrJHc347hROE37yBPqx1kt18THD4YqkbU0OD28TRQL4i+ezMRySp21+rQKxY4FG6gjAJAgOa8bScWtyOwEX8JUGJYSFaNoi2LO0YtQbmLaCO2xi4RQnigngAphKsJSAcEuQTD1okKboWQWxQ+0xFIlZ7J8LAYD0+6j/ujx31ZC15zVBnhrQuvgMcnCZaD2TTn9Ri4OX1ArHYTDsIXGoTMa9qDq/mHftfQ4zviVpvIYCRnFnl9zAuWFEbqNWnTmWo0TNhOUxjnxooqClKhEZbQcFq4KNGtGUTLO26MN22F+/1DvAHnVkyKXaTYfdC3xepA/qGSKooGon30M/V0nNSuXIWykWS2hxtV4w4/W/fla8dClkyR3DY7QHFfaF9dxeROA7a5z9YzehQ5M8gJLCHmhEOJ7ogxZ4gugaXN17jAt9LlJbUrZx/gceZHLECfibOQZ17mz5bsZUDJvMBlM6fIBrM8Yq8o3GIxj9gRKg+E5HB/7fDBSp+HOTe0NCslK+HRDctrjc+Egt7ZIWp+oJrHXthLYo77FYMugOco8Wpu6ymEBBoyZz4rpH+RsDkHaobpLwBw7nyUIgvKy/Mbc1c2/UaxitB9mdUBlL1dqPI6g23x8HM2ep9VUhOjqPAfeZS1QKXvw3fNd1EJrX951oBmT1+ypAksX8IZsQL8ULInDeCzcIECo7ado2BGGEZtxzlAXQ5y7WZtdtsyDHd3RSJDQsVygSZ74BYda2e3t0MPw51fBr1HO/j48EF/2HuET4/6eP80dIePBv3e7qMO+baG/7qbzr1b1bMz7D143AVMg0d9wI5Pu8PeL0NEjtKzBw/p6dHD3u4v7sNHvZ1/UAe0e/gAMT94MOztEMLhg1+gYvExA0A7pE98+HDwoPf4gTt8ALTzQ7Mme7MxD54lCbA28wZQOzeNwjVvpA4QC9cVfZPEUzZrFMdILOxpY2I9D3MfxrzFrr/ShlRMY4tIeNzWczFssGYckU4Mn39y3fj4l/HTkh01puTLjPM4Z3+ugpc5+60BfQWbmR+uwOjjJ004bGnJKozyek142c7WfsiAtnO6lZfL1T7jhs+k2EXpg9ER8fYOChEb/fA6nvAsTljaGMw3XjMqjGjF/Qy9L3tI/Nm9yAHa18PtBp7xYgneFj3PiXvk9ZxSZ5A6wzsmSiWphzq/AJNPq19TbYswBfAcxLDEHsvEwxkLxYMszxJKdjc3m1/21pvOPRY0vku4yGdfsjaw2FQ/N94JX53sTROcfQzY+VkTiLRvzrJGtR8+wrZYNjJ/CL+8ZJMmMPJyaPe0iaCE+Xq/mbek7fbDCvh9xqIVIDT34wowSyNo7q8N+EcvjM+Si9qytAr0AV0cDJAWKdw6I6AuQ7V1Y+ECl63Gtpz3ZgynY+EO+n0Hkjkb9HZd+NeJMRmx3i9u7zElcCgbrQng24NmE4OXSzZdAcJB820F+CUCBIsWMHTeWRPMgcWNG73/cXrGnmcrMHGSvljzQh6m35qvcUNnfzSgx2HMmz0ugrXoM9GCHitssaQ/vHb8eS9jcEx0LNnt5ADJxqAp8Gq6+qo7mau3Zy1vc/V2dQBQlbNAT8SXjc4S8dLZX42P0fzNszxnRbjm5fFiyuLmyzI7S/57JMHOg97DAR3Vg0dwjtLhOeg/erzT26UzdWdnp9/vDejo3vll5/EDONndARy0u73+7t1P7eFOb4eq292FY58og8EQcImKd3YfwVH9ULZhp/foUfdR/xG05B9UBMc/Yt8ZDga9AWHc3QHgY6Jwho9+GQj6Z7j7EBgmoEJ+2fml9/DhTdTBH2FG5NmssRT+9IBtTRpAWklPz1aBsO5er4DfZ08z9qYFDDvUqwYYQ12zTM+SrEwL9lIn85WoWms9STto8YzsyQLOyGLU8CtdGH6lM+FomlwEk6tnbqMyhDT24OTeiqLT3StqseOoRYt1ZqPUoKMQZdF7NclHfGhl2tRIlADmBcU6pxLK9HtHP61UggrSjpKC8cMnoWWPusAGaSwVd3QvsTz7h9dlofk6ccIuo9rJNtcmtNdOS9voY/NEuld8fiqSwmf+C0z9ndfHZH1UsU8iqlgE1IaHm0jkzxpfVjGw6DJuxank4QyPH5LEpZkw23eU7cxgJNoacS8vVth1xY9vDPaanDu9SwwO3ZPev0UKBRSevWeFh4gssff7I1JatwqhbQ6cuoeODhA5UlwUc3CF3YfigruXxQXHXzH6G5XpX6a/QkgeZiiMQM1b9mUun6TF8leZPmfepXx6lWThd7yFb9NCgF0lvhSdBFmbZs/VB0O+7LLyOipvw4repSM92eJjoTRbCvQFoOBLEUEP8f/BsyL01zWEy4agJQH7HUN/wXJtTKN2/3TFii/3dod15BEgVy7rKPNZxEX0wNu7vYNWpTxrdXwnP6bmn88iYYQQq5A5An0lxdEEQvSPghKX7FfxKwa4ICj3mqtIOB8UYSVutJeQBp2kXUZRGfERHRNmsMYN64nQtJ5IzLJWwmIK0hXKSZ2wbgKIkgpRYl+HeC+mZuk2mVXMOakItS5/r6BABFImIXKuCNOMO8VG9gyFQNQ1Iezm8kGU55RKgibvZNqYiOPgrZfesu9i6jZOpn2xY3Ey6Ytt4dLnJyYoshNhtzftUMIDFiqMocIYKozXakvqV1sPaUtQnIP4IKTwpzFebNa3htib8xz4Ic5eF2YyZ58pHcKbr/gABOYTPDxT9IS7IkEW1xs6iGKcNoIoykhuDA5RI17VJYu3h+QZkMNvcSiCAYpgEdYlxQozwgNepFaGQ5pIqMz3NrUGtj1qlp2nzcJx6gx0YQNl2Msqj190Tq3WUHu/bQ07UAgv1cIqkuDdbP5/DSi06J0jCbaE+9PRA1MvoMgZ/047kKd0EWS4UcQhP4opPnirTjcMlIMDa6vMx+EZ7NnTVgHdmc4tNvfUC7O6ihfLi2rxKT+g4rRtBAUs7FA7AI1JoIyShIROQK0ZKCqB06NO7qmZO5DTtr829icLeyL8XndgTN0+gJd99DPUuxzggd1bDmA6Q+Xm1GmnZBQQ6RMdTXNr6wnOxgxQO0BwZ0A1psUM/TfHCByYwCEAlbtrKoBRGpaoE4k5XU4Ks0t42PP2xdJHo9+uZ28PbafcT2hPLmGj7pYEyuh7HMQB3Yc4gAxBDKy8vqbwopAHY14Yn/YprU9/4k1vOfU2NrSfzsbcv9nwvUuKXjH+yrlPpmt3nftc+gnleoIXM/bak08fG1/Cdmo3Bp8pdBwV49m8LDj7hs/hqvI0ezWHtv49l7Q1TLDl3CLlafg9mqNkiwDm7b/y6Vn5HWWWx77N4YWtDMICmKypYaE6E0ERjOSSddcoTKsIl7iXHc0dzSC6kFijRu0ubQyEqYtpQc3C3p45a3UPzjAM5mK/T4pDtvRZ298r92d7XZh2VsSm43RcnrCSjGg9eHRKDFBy0EdvR10mfXnJM/UwFaYN5pKqJktsTdGx6hQ9VlxLvbAN9AbTUqpaiECLYykPDSHQK0dJSorBobVwZ50zezsY6faiD1TbZ9hgJ2fLrkXt90+gtYdRZzKCU/jMQQAToTs9eHTo8mZUOiKqT+QQM0RXv6Olo6LZj3JHhaAfnWrVmmmlpCF8bN3yXFljmIvR6WPtJZP6hMKW3VKDAI2P5SRWWgh5kt06CCNu6qowF45DVUf8y8MKv8tQZVd9+i812Sus5KtUDc+/1LaosCZSPx42DZ9fhHCsBkRaKV0MZGLmCsCR/68S7erQ94rKP2XByMzO8O5NtDyF44JzphBON1C1sBDxKHh+dYX3rk6d+SiA8eBUiTzZhSHEimmX6U7GHRj+ZNCf4zhzSUG+Tyaq2Z4ds5Dg/AQ91JFKHRrwuKRmF5pmxiJugay11QbHqNlBStpwICn9BZDX1XGIbfCpDRnagMasJHh2Qj7zhIofqu27qNHfiUmnv8usmAKeoMFRhzseAQYnpN8PAKVLl2xbfgfOCMfb9k/MFrerr2uzXdL/Mporm+lRa9Bl0pganQi90gRTOQZ5Ek6HQnI6xJHXKsYR2XE56D2QbLHKDTY5KLe2vH3LR3dEVulmQLVOUMUQPWQBnhzVFjm6YlX9nRttf4VikIbeD65jJeXY39GupVHLpxqDmh+wupcwI6iRMERDl18M7VziE2nqEpO+byw8MWfSlC2tOxQj92EUCwkLuZkoJAKyJuwvDGkFfQi/Ie7naOwDK4A60YeUCvQEPU1gw/AM+mJ8IhtZgfdQQ2nPdYHVE3QmzJox2qSdjIcnJ+qjuiW0T+P2qaFGfq/Kr0hAo7PfrDpzuHli65mSiJmSjJvT24OlWDqxi2RfQhOdJgh3mcrdFef5bJkmBTE1hp+XojIJehFe8oDlExP2IeMTvOStAQXRNEPYt9ILioxzdt8XqbgIMQRMYaQE5+2bINQ/gbrKCraiL1yZvFcTK1Z+tGPyo83hW1lhZdt4mWvXgwJ8K0P/POeo98yyQsqcpPXLb3OdxkgaQhom3AQ9RcUd9mtaAfDaE+Z9yPjUABYwIEY6jJM57uReBXvmlai44leQo8s0idGGAjIWFfilN597LDQAPJnzIgt9llXA13HB/qya9Tq7CONXHqzc3yvgG9+kicWgizfAgZEIAhbXldXfRzdXxf7gsNiOpqPqLk53IflgA1bp4cMHu2RMPegPdh73HwyHOxjxatqx4oODAxkgQtadTN8JG6bfUhMYUpyVSfUhMtfXKtcHD2pNWFzl+ZCEOcqG8wr0OQ5JE+6PqtyfPDzDvauUuaacRWKka+7AtdbVf0MiKOQ65lmqwlqIDdGMxGEpLw/2nqljRZJc4Qabky9mhSFh0is2t9CRgQj3JkLkOqUaqYJ9BlJhZ2g0IXOUO208zcXOypnQeSXwewPf6LWFDF8VSl2V1Vx5YgYP8YC28ew9DHl9aFXCMQ8jDZD2mYe+sxiKO6AKVgJVhb/vvHfXJEHB4eFBWY/qSRcTd5KtChztwlV5O8NWx9YSvSe8s7gkz2+SdHDY0fn3QwTllNQ8v4YBksE5gZcUXY+uOq9lKM9a7sTMjZE8hWksCkmB7axvUxknPcTm+fvfmKotQmdb1S+MvLLpGXuB5GcWnp3V5Sey8J+ezEkZAJV5FW3m+sMT+USIlfv6MWfP4Zm0Mp/CImbLqUo+D6ElU5Otv1dYSmPl3dR6c2rZ1nxabfMxBQlsqf7pKUZLJRFVMJUca2ywq9crVcI+1VbrC1Gr3YPNBqg7a9wbOPB//+QObeidedC9sfi5Q5M+QM/+fboCPv6WtZli/n2qkBLnpfH2uDxzLBnWt4FtOY/aP/21/PQ7fCitOw89AFWPP//gFavCe4Vy3MUrWUlmcGFS61w5g6S4dId8pC9ZM2WEh/I1MXJ4M0rnwy0Z4BpvdDqli9a4l0ehTysl65XxeZxc3NKIGnnijJjhbF0v4jcrpOg1FCO6NvEYjYqxUSM0sT1xYGlkRnfOU2hlWLBULywZLKxlkI+n1s8H+NNUr6ZZ20hiA+KqAStLSRkEwGJ6MjUXU+tKQspD19hYO2vqj3Xd72XQ8Kn+9g/1yM76oxZTazlds2SkdPF1HPMMbxuuK2SwJDXq3xWtu9KxSMaP0X5xjMww8hmVyE9JC9EhhpbHAcmvKQM8UEwXy0jZkjujeM9OxgXyMhiq1Sm2Kw0/wyV7+fOFEo5zDBJqa6vVUi6YFuNOMU9kmJr3E1NvcL9v+puID/qHwClB80bkGSTeV2wVghGYVdzXCboqlivztgYnmVp+e5li3Rp3ceSbXTqIxcvMq6tM3hZUt2CCGBJe64Tv5lvvCmGdykMMeBGlN4Xy7puC9MCsuaK8ZaYmZg1rdw+9qjJbfBMav5j7iV46Zdsm/HuTBas2CXlbMpDBs8a9XWRGaevZWzvrNgSDwYpDT0w2pw9k08nI8E3s66UgL0XNSR/ayoNXgtQjkKTdgd3JXKtwQ7uDl3Ih3qzq6a8ncsukWjsCY1inJyTrxGtq1s3Q+zbsqgi+89wAurc2PWw92wVWzxzGnyw376fLLQbeDdqJIgFIHLDwcJwIOUEGa1GsQ4cEF3eel7GYlyUWBPqS57MkCv4DE5O6VU1Or5qcsTk54SjB6OmrE7ShcVKbnniK4Y5Lp2FYu9dLVKe2WjJJpcYpwgwX1SY/fG1xgy2+J12B2ofxKDw09OoyFEnrfmnxaKhIfuVH8NWUsDvJnWYsV51ZkMtNnSREd5iuXA6Dla1QOsI059XUphqyaoxlBc37MmM6CJzIU1CfoEoTlrr9VWFIV4XKPakfefNbOi3gIrPuFpGi6u889xO68kjWz+iq151MfStaGlKduu41EzxpEE5JNcWP+bdSCofaGaD3/3kGqKpzPQf0/vSnRNt/jv2pGoTE1pfTVfgNZBfSWxmbT817fUFV6DNpwyCFNGVhWTmw54UzsIHW2ra43rrtysPYXckVrskVfmtyhTfJFa7JlfCaonQqddfklk6nMP6Funpv7A/GnmQGYEP7j1oP2GTR1kKhVPUae8gPUXBEoZYtUltkB16BKm3bhcS1dmVleppxc6KEN0+UNRzxlztxxAa6m1ji9/9XWOJ1PP46hqX9i276DmLEbs/5rf2OVoZMN+GTIh/az20iJatzu3lst5KT2VgsVUVO6sPnTsdog5IPK3UHHaK34lbkmdI8CG+7AO9cVe3M/QmlmK1SimMuqD8uqL//xgloLFN56Ge3OO6qaRHO2/YhXej1qVUuHH/hFAvn69K5XDrp0smXjrd0wiUgQf9yQqe8OpaQdUDLQWvId2ByQE82IEP7pJWw/Fy02fGbbUkWjrdw+ML5fem8WDrLpTNbOr5sS1n4zaZgpb3Pn55VTWlA2pvS1IRV0veZ8O6sjwTgA4TUfcRFyRmf8yc+2uuzl6caIkxx/zqrAGiFGxpptAi7MNMfSvapSj+DRk+TbDnos78qtM+97HzI/qgAZLpxXBWTppF/1CDLnH2tAO/PcrR/OCOfY39WqMiu452RT9rI8bkGkXmcV2X54IUZD9jXUwOSFzwasN+aoCH73QChRZ1v4EGrue/1NNT0zIS8z1hupqGxz820sJD7vQKROdrMTL9cstRMQ4+/MNNkf7asQ6AZpwYErc6KqkOOeTFgv56a6SErzsz0DouNtLLQmlewTzgUXgmDwSsgVfy+nobGfTYhZJ/zpQ6BXvmbIOLm9Wusn580tAzEhN7MyTTMVJ7BlfsHLKQg8WmJAPHBs+UxIUkyQAOlT5zqtXo4ijj+nAgrD8TwqqCsL6V4kjCgXuifVauAkvq7MFLYypcEmJWTCZCZgZHIWEqpZN68rL7T5RW6hmi9uRJq+zWfD5lUfZ2Qzisq1GvCVau9bgzo81BH6zM+FK1a28u5hWGNYhZcwOE7u4CjN71oU4ElJ37msbVGuXB6gWolpTrGJvWGF9hwEfQYtXO63clesu+LMB7lODkZT07w6O+iRw1M98750pngsW5T3ENW7KmypBKJrjptjaIce1DmRHpXSPTuiOIt2ykrsv0cN59/rU5nit7tSpO7oaz3b5TaFJWeZMFtPcrG2uVQcDFaj70ulsKKYqpoMsn5rZX6VE2zi1FNmZbm2ntCtXp/p5eGVUXDRh8lNa0oFdyItDGLMepDnSiTfn9/QkHTxERABS/O+nucoiRyjN5hUWD2MT85Qe1M1OlC4TOqaQqX1Al5qGZJl0Gb0WWKcGntOfTWI7DI2Rc5Q7vxVUeXqVeTX6hPymqf9KPxTTRrUXe/GcJGeO5m4jtEALawSxpyuCYGGAcar6XFwjFzVVm2WXg9uxAeOxqtfQd8AC7tGvA4jGZJyYsVN3gNPa/GZ4gQzWJAHNSLV34WZBD7RhBLDGPLKXpl2aUwtuNMf494xBCzGSpyMbfcHq77hD/DaV37UrU0NFtKOhMWV+2zfzYUA2hdJmJrqtcyLC+FyypJxa6sXuaEuYQvj1iOH0NfQuHYXQsA7kCCbHt7iDraewHNykDsoSkVD05O9mZdZqUage1ioip87XdZ5Ewwkmt0zdWbLpOPNIN91N932WTbt9dlWe1K3EWepCn3MnLYt7yov8mBXCQN+tP6i+dcv2nZGE4vVjQGqqKv4zwM+PuyhU2phVkm7TaUOJxdkE78Bd2liCkE4zGuqeaZ0ZfJN7y3Xx5auG5RpdSXjsdtWMSlhE00TGvfVS1G5tX3RBBXs+20bIJ6V3xsUcyQGIO2fkA/upM237jsPEWfjal5mb0a2U2q/5taPOg9MnZSxqXCvzRIkwxxdbE6kwIc1KJhB2Z7C/Y/5EdtT6h+aVcp39EsBy8Wt7Y25PPQFsrEkvnsO4ZC3eb2JrqWhbkGJ8r/bBPKa6tQrudtUlqiRnxIlSLoMZnAUTilzU27SRfApkcW04UIHIS50PJaKlHajpSEfSCrMGcmUu9SDJTMyBSAHeCuD52jNKRgclyLaAO4bc3Ul3q0sD07YTMRTBd/qIG/BxRvUpjf5SxAXhW/BjVmuwzaDA9AsGIU+NyZkiVeBL/Y6sg+PEpHE9sonrYVn6ApEvJluYqE0NcNgoHMMQwotseW+YRE0fLZlOz9ctt0lqeMSsM8h+U5urfZzcke1YehOUpXM3rzs3BaJmUus/ra9uiwehQdO7FHFYgBYebolsv44VBP2dKWMipC4HruZUlS5DDKJZugpedGS944oVzChlZPYdKeKgW9x9i7dGsL7avLqn1yGO3SAJIqsBtqmWqhhxsI0OKA4eGAHVsoShIx77luYU9EGqvHdpbqK49TpzStnepRXIUZFitkbmWqhW24rtsO/hZQUCCBlKR0IRxIK33hL31TIas0FFdueVMSo0lhIdRSUKtEVPn6lqV5VZqL0qZG8m1MGTMigDOx8y3huD4ljqo8q5OUhsnCKW4XwpJqNcCbNFe+XWg3DLx758BuWEiHdROad3mZ4v5dsFPi6RZT9g5VmHNSsmttoLTrOp/j/bTBOIn35BGTw37GWcgyMnlsZ5x6QeZdWNzpxuusqUJ9iyBnUXdz8+qKpq0Swt3AThRXVxSr9wZ+purlw4cPRmgsFJIH/X/PKf1DO9efMkexuDm4g0fWimkhf+F1toUG+Ule8CzMz5l/qWEqNIoByZI8Z3kFeB568wR4gmAFNGRpBfsQlTmbVunjbyWsUrZsQoZsYYAKL2OXVRplpTn7YACyUPhUeLsKG7InFfDPJRAdVfIvE0nOvhuJFyF0kwk4LrLknLP7CKL+nuPC0MoALzLOg7kXw0fDgIR1mxfU5FUKuAsh8RbG/I92bVc8DSuHT2hmKu7RfR5GwI24sTC47hgBxt3B9g66lyQph27FsZ8Uq95NGlVfGBoUbXXJ2NNnGV4+bVs7vQeP0St2syooj4LI30j47J9LhyZHU5l+HfsZiZ7YHxJyXPCU/SkTOXsppdbPvSVLl1UC5kddoF0Pm/nhtPZSQmcLBc3CABAeL2vpnN1XgFdJmbHcTOUsUsnXygvNH1MJeQvzIMy5j3P7zxZgzr5W0BhtYb1lLZ2zUgMgP7Ttop7O2bkBgEPnay0JPazSx+jCGzEcNSE5e65Boq1hPZ2zRANKasVlPZ2zdwrwaQZ9glmeNCGwRDSIhlj2lr8woPDBOllyQvR2WQfk7JmC/MmDWGT6tAKCNV7B+HnVZEwZDf6CmpzFwkjlLFbJBJiv+6FMZOydfnwBW9GMnVMavWoJ6/hpotIpGvtPC0ryFtPm+6np7gGNwFbFhn5tV67ZNMlwqGRPjdxGH421gO7di4GqSzEo+h7Sw4C6d6qpPDr+44osrZTDEh0tE5d4gnr8wmwrtEsdiqqiFsMTVXMGz+h/FtkLSaMpKwpPQ0RWOnb7ePOpyWJgH7xrPPmR6DbcSiQU+VGQhnPm+r3vjm8ShRhh2K4Z05eSesEOmrDQyeFfxIB+uIEGvdyf9C6JsEVjzt7lQU7JXCSJJD2IxC8xLgXaOJOdHJB2cNDnh4NRYQGbKeQVMxfQoV35tgWIurNugGblfNuSOK6uBvbN7QHOCwoGdgftcZZMtqEzvTaUJiptv0TrdBtDg5NJ9ZyGAfvYCw+zMfxFZVKabeQ95sfGmgkm/NyQXEFjMeRVrpvg9ED6MaTg0d+7wFIDv4o/SEv28q6F7m56vn1tSU8LCaMwM5CXjyttCEhD9+2FQLH0vkMN3zEedO8UKJNT5F7ngOO7i9en8DYR7pzQIcNqZntPf/gTg+YSXqzE15rBsGNcPbBmOJqINntMmoz25hiKAv5GsKjmGIKiNweG7GOKGnUJe57iRC23tpI928eUbzvAkMJr9DWA6IFmLqGRkZvAR0ygsSU0NsHGkrjtRWp9A1wOqnTAn9BGsRXMXaSrnahLlQIE2zHrYuX4ysM2bG1tUDVoHNQrWIlxBboscnNoF7yjtmAMeniXwNKBdxN3hnNDT6QM3VKETtVnV1ck563mlydm5SnMywJ7Wi9ImJyAsEo3NKVhDndYXJvBvLo8yDlG2qLN8paEcfwPqF90ReK0uHrJZKAb5fElTgJ+fBes/XashJAWlqSGcdOvudBS+/4X3Pc31MaPKsCIDOZjihMyRTuvFKYk/JnUvADlpkNG9DZSoK+RPu5bA4b2RcsBQy9uxvYS2RJ7vLVVND2PGKHdo2ojCWGPoCE7oY3kst/lsARiqAoeIoSgc5QZQtA5SrSfkdQ4YrDaI/KEMtvPaQ+dMSvvzgiEeKBtiIXlmBqwCFMDNnNiw32LZdTfxSsGaBfsrLCPYNx5qBdnv3iyIpeV9GivNsGaucyXL1cagzxzJiSD1a6a30WlMiaVypz4p/wOc1JGZFLhmBCD1IvOezXtu5+shyJFjjCnNZHfyW9LXrfDKLRdxvuyoPSokcM2aiDIv/TgIF0j5eTBIa/VfrcP+JSkRvM/onMhI/0U2BhhiicBb/ikqH0eljc/DtK3+zTv55/mGXg/NqIr3YC5/Dnm0sAsvvF2qP2fo/YN1Nhbt0M8+TniCSA2NsSnYexlywaPieSseVFuEB21y/CKXvW70iPOhC4dGfrHUPfYk3GCu4cH5yfegdOF8p4mdO5JGbu8JfWFLusB4+5ANAEYkHGsnWjkwrFTLhw75cKxE4p6gMaDDQzIGywTsQnepMxYtj3sRnjH0B3gLYOUou0F++mewD5lQTc9ODiAF+Ppyf7sMGDT7mCUsuk10I/jAAiiffg5cYHkBCT7wdaW6wZEP0Gv4YvIWbDMXZKhrRse+EAcEeZTlh1aYWfR9TpLezsbeXv4pYGzpC89hS+FvS+AT19AQnz6tSaZz7BwAoV9UdivFfacs6pw6JyJwtdW30EhBnWwHkZjrJ+j77snaQX4yHMUz+CdzhsDfIzXI+x1E0LF2yaKNdiShMXh63T0JLWNl0b1x6quL4Q5X7C3vniQwoaolnyaBEs2q4E+JhcsbUJyFtRA5AaITSVMeGKdmCkqkyOkjGtkT6/XM66cak5zjcudFR+58rYnllc8WuX0WtRwiRKR02WVyNmZVKvDN8vqOWcLpW8nxB5Pa8mc/SHTJPSYGQnoA5laEXDUYVK+QUASb/hLM5mziUoL4ca3WjJnf1fpYsZ+N1M5+1UmtWDjSwOQsz8VxBBr6KSUamBaCDVe1JI5eyPTWqTxvgHI2UsFMQUa3qICQiUqJcUZn5e1dM5eSUAlzHjdhOTsLw3i57qhQpKhmkmCDL6oEjnLFrRAUZgJiwmFj3jBirNw81Hvca+/CZCLMA5woiPJfjmP2DFO1e9hjXaVc2xaWHUly++JeQbVYw0fXQD5+e4CaNvvF0DbPruAnf3DBd5H953BNnFY4zHFMXcpOcZHfEI/PcPdPtCbWQh76v3C2iR/V5vOJtYHPzwONvEqd7ePjtwGkHcKpPCSDfoVwbwQvEiqQttunp6K0ucXdg8au3kx4zzqCdgn50fq5Xm44KONwbV4P0/KnEPPxDLPEwEOziIftqdzCT22e5MwQvKpFO/JIxS1V+Y4MuDzZMEl+J0Bhu8h6D1K+ThYqmXntrgOsjbdC352HhZu4aXuDOiKCGkL10+iJNskP+ye1adASn1702DjTmsBagwLWR+JUa067ZPnINu28Vq6dw5nOG5IFxcWTQvkLwycZw332uh/igK+QkmK+DjA9IDSWlZMiC+3tkJ6WFY1YCHauzX+eUV1jC0V0rR7T4UxRa7AUuFNFXiA4JMKx2Xlw7qgnjbHxDLm7MXKZRJfoOZ/Zgs3axaKfQiDdoMuBkuN2q3RQQGBrLjgHPCtFhY8IiFIKmt1WD0X5O1ao4KlpJ0NOigt087H5zAP2zTX+CE3CozQc5WeCTL2tqsic8sA3K4Mz40BOYueWD6wHtsvqkzkQDmwCAgkaZjnayWRyXbeO0flg5Y3M3jTGl9Feggv7ILNKiFfzOi+Fc7a7Xg8PNkTYsYLvAT0tTs0fB7gM0xFbl97NFxCEIkB3mxjyl2oKS31PznyzOKbgSS+uiJtEaESpMuI9A8Kp1zMgKIoHHqGgctRAkLPkHWB8jQRdBkOT58fLfRlNkFFAHVjRDGsCiH10pz1qwo/aSf7KNtdc9UpWXk5D2M1aejyhrDKkSxv3ArC3nl1YTR0vDWVYXxLFlPwG5Sx9WhTtXmPNk8xnVBSCj/oaFZDBwKKGluWAqOqoJoYVVaGl7d+BKfZJyGO15XsKTUKaCpqOCgXMrIsG+eOxpejynJIrUdRtVrXxxdCM4YQspwXqg5zTarXIrKlWsROigVpPomTYtNJrDPr1AqdEt+o9jvV5yFYDLUzgalXDesTc1hx5t04tGHTE6HYHmiwnY2+Md4l+worqLcI+YVxpBlnkNVYZ6I/Nrwe5gmqcFBw4AHKv9yc4hqK1Bc32pMZWdyJu7zDD6awxFTtq33j0SJR08+rhpi8JIa2BmFXeWZX2fRd+gvKtK39Zcsn3qvnxyGEbuGyUxz1oY74cKPxapShXtxcZQPzqi+AOtE9secpjLbzRGKSc9B3jCVXbXvGbPT0bKwmxPEd1rm5pD1qKXDPaOURfBK+KQ+bAOjykdipcIpo+2mPPBrCsrdQOT+cFL/x5WFvdzTEMMxibnPkIj2c4DVXt7BdTew90Yf5Qf8QZx1iN27G0MCpFHJfWIw934si69KJHHTeNNL5CbwQxdAzmcxg9MwRtAF6Jvx5z2g1QPgm6aUTxm+ipAmRWjMhrMp6/8gsuEOpxSS9L8LgctKs3PP2c9I5A2qWpkcJzLl3Iju1dcjRRwH55ZmEPDtxItGo/qF8GFxdKRAcZ1C3Dz+wO6rXzMcidB7YIwXtAzRBobR8NehubGCIFdI7rG2aqPOHXqtFxv0heTSlbb9Yt++JEwrWQABl9XSN1HQ1R+WdOV+Nr4eTU7tvgY5G2U7LseSz5gyFgfLVXRP2u9ynSXU7Fwre2OkZfAFXnV7KLtnaKmv9mBndfqhfwa4TjmRqoIsMVotAR+mXWIjOuYyVtb1M5RAfi7dFuhogmHQKjtWAGdiAd9EpeDdl1pQFSLxE5DJ12qX0ANPoMXUKHI61ZCnmmFGOZZfSA0xjjuVexk6tzKkcL0y30fl0yMYW4uwGinpGjN1AEs3ofMRCjN1UvUd83VQR1eqk3VCfos7asPapnvmp16U8AQgiTgCaBDhUrcfguZhF2dpZJO685QzKagfdygyqBIdq5eIM2tqqkxI4qdYd+9X0p7AQIYkXQzthJd55e3q6ebXplpjTTQZiUTlGnp5wXm3CJbUJVy8lXOrpghtVxQraZ+q10yhq62baXjUyrGV/8qphFITVPaqVjkFniN4IaeMgv/ew8hK56EwfqDgtyaEqsX/kSHd/KTfjCdN7/CoPDXvr1takfS+/vlZ3NMaxsCIVrAgjbZB2aDxb9qjYC9tFAU6xwVh4WHGLo7AKd2UJVVTrbuyiwWXczCvV8YziikO8dhbSod+qrBw+Vhr9ohdJa1VKYw4vnOZ3bAPMeE6BpnQtrS3Qg9Fog+Bg13jCR5uFOrmiudbiZ1xro6EiRINJutztO7WXbCJsMk3Y4KZkdAF9JsXRbR+Idd2gsZuDoZHdcUzaptENPWOvC0QgPk2o3Na/rmWQHe+fD7PXYDRVVLB1w5wdriHlRlk1Tm8vjA4slZxChSP3euf2zzrYXdfD7poudtf1scv1TMGOunbe4u5SJKTw+4M2hFHLDRoRZk05QCEIxmsR3WC0OokGjHW7hjBBITEoELwBpjYKecI81DJTW2HHbCNzkOv7BfErW1uSX4M9UbdVc+exWm4GGI4LJauQp5I8700M1clTR1EdOSaOwXocgzU4BiaOqleUDEb0hzhrZG/ARtvS033GXLfe0yqW2mqHm7hJIK1xA6g2+oKNlicgYSErinJu2XszwfQUVePJzcIlyqN+GNNk1Jw3johXMFo4OOmQoVNLddRsrBOEeYpBz0YzXP9o1LYQQo3nPCq8f3nzPb+gu94F3XwvpDT8X1rwAk7kZBBpRhsVjjLa1P/Lu3QDb4l4+aoXkBtcaa1HOh4rKbWj5NInzljJqx0loT45oapDfbi2eCFZf4uP/IdQIUEJndQiAXRjX8FOapv6XZBPpKxOf8ZENJ3pb5hIuZ36PpFDtUM1ZTzR5VUvTDQC2QfYSLrKzG7tXgYjOi5Ia2Sh5Qi3K5ljqCIommNRI7jp7UpHot4IC7cFv5oBVB4RM+N8UIdWAYTz7HCBmjqLHlG8z0P09OPfsnrgCMmtVodaYXB14vTGK/a7oFvKvlhCaXV7p30Fv72QEB0kmH26QIXX/+//ABA65hGaRAQA"
-)};
-const _e33cgv = function _d3(d3_part_1,d3_part_2)
+)}
+
+function _d3(d3_part_1,d3_part_2)
 {
   // We push the source into a DOM element so es-module-shims picks it up
   const script = document.createElement("script");
@@ -30065,65 +29691,38 @@ const _e33cgv = function _d3(d3_part_1,d3_part_2)
   script.setAttribute("data-mime", "application/javascript");
   script.textContent = d3_part_1 + d3_part_2;
   document.body.appendChild(script);
-};
+}
+
 
 export default function define(runtime, observer) {
   const main = runtime.module();
-  const $def = (pid, name, deps, fn) => {
-    main.variable(observer(name)).define(name, deps, fn).pid = pid;
-  };
-
-  $def("_1lvaqpj", "title", [], _1lvaqpj);  
-  $def("_5vw2f8", "conf", [], _5vw2f8);  
-  $def("_1kn6xro", "library", ["highlight","marked","stdlib"], _1kn6xro);  
-  $def("_1d3syxm", "define_builtins", ["__ojs_runtime","stdlib","library","inputs"], _1d3syxm);  
-  $def("_liwyd1", "boot", ["define_builtins","conf","__ojs_runtime","location","__ojs_observer"], _liwyd1);  
-  $def("_1o3uuqr", "stdlib_5_8_9", [], _1o3uuqr);  
-  $def("_wlval9", "stdlib", ["stdlib_5_8_9"], _wlval9);  
-  $def("_1g34bkz", "marked_0_3_12", [], _1g34bkz);  
-  $def("_1xdoc65", "marked", ["marked_0_3_12"], _1xdoc65);  
-  $def("_hpy1m5", "highlight_2_0_0", [], _hpy1m5);  
-  $def("_1vi6m4j", "highlight", ["highlight_2_0_0"], _1vi6m4j);  
-  $def("_1mc6dpp", "lodash_min_4_17_21", [], _1mc6dpp);  
-  $def("_a2navy", "lodash", ["lodash_min_4_17_21"], _a2navy);  
-  $def("_10o0pg6", "htl_0_3_1", [], _10o0pg6);  
-  $def("_1i4ixrk", "htl", ["htl_0_3_1"], _1i4ixrk);  
-  $def("_nkuke7", "inputs_0_12_0", [], _nkuke7);  
-  $def("_yk2xgb", "inputs", ["inputs_0_12_0"], _yk2xgb);  
-  $def("_1afrmer", "plot_part_1", [], _1afrmer);  
-  $def("_1pipeyl", "plot_part_2", [], _1pipeyl);  
-  $def("_132otk7", "plot", ["plot_part_1","plot_part_2"], _132otk7);  
-  $def("_1kd2cgd", "d3_part_1", [], _1kd2cgd);  
-  $def("_1uqcalu", "d3_part_2", [], _1uqcalu);  
-  $def("_e33cgv", "d3", ["d3_part_1","d3_part_2"], _e33cgv);
+  main.variable(observer("title")).define("title", _title);
+  main.variable(observer("conf")).define("conf", _conf);
+  main.variable(observer("library")).define("library", ["highlight","marked","stdlib"], _library);
+  main.variable(observer("define_builtins")).define("define_builtins", ["__ojs_runtime","stdlib","library","inputs"], _define_builtins);
+  main.variable(observer("boot")).define("boot", ["define_builtins","conf","__ojs_runtime","location","__ojs_observer"], _boot);
+  main.variable(observer("stdlib_5_8_9")).define("stdlib_5_8_9", _stdlib_5_8_9);
+  main.variable(observer("stdlib")).define("stdlib", ["stdlib_5_8_9"], _stdlib);
+  main.variable(observer("marked_0_3_12")).define("marked_0_3_12", _marked_0_3_12);
+  main.variable(observer("marked")).define("marked", ["marked_0_3_12"], _marked);
+  main.variable(observer("highlight_2_0_0")).define("highlight_2_0_0", _highlight_2_0_0);
+  main.variable(observer("highlight")).define("highlight", ["highlight_2_0_0"], _highlight);
+  main.variable(observer("lodash_min_4_17_21")).define("lodash_min_4_17_21", _lodash_min_4_17_21);
+  main.variable(observer("lodash")).define("lodash", ["lodash_min_4_17_21"], _lodash);
+  main.variable(observer("htl_0_3_1")).define("htl_0_3_1", _htl_0_3_1);
+  main.variable(observer("htl")).define("htl", ["htl_0_3_1"], _htl);
+  main.variable(observer("inputs_0_12_0")).define("inputs_0_12_0", _inputs_0_12_0);
+  main.variable(observer("inputs")).define("inputs", ["inputs_0_12_0"], _inputs);
+  main.variable(observer("plot_part_1")).define("plot_part_1", _plot_part_1);
+  main.variable(observer("plot_part_2")).define("plot_part_2", _plot_part_2);
+  main.variable(observer("plot")).define("plot", ["plot_part_1","plot_part_2"], _plot);
+  main.variable(observer("d3_part_1")).define("d3_part_1", _d3_part_1);
+  main.variable(observer("d3_part_2")).define("d3_part_2", _d3_part_2);
+  main.variable(observer("d3")).define("d3", ["d3_part_1","d3_part_2"], _d3);
   return main;
-}</script>
-
-<script type="module" id="main">
-  await window.esmsInitOptions.fetch("file://es-module-shims@2.6.2").text().then(src => {
-    const script = document.createElement('script');
-    script.textContent = src;
-    document.head.appendChild(script);
-  });
-
-  const style0 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/global.css", { with: { type: 'css' } });
-  const style1 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/inspector.css", { with: { type: 'css' } });
-  const style2 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/highlight.css", { with: { type: 'css' } });
-  const style3 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/plot.css", { with: { type: 'css' } });
-  const style4 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/index.css", { with: { type: 'css' } });
-  const style5 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/theme-ocean-floor.css", { with: { type: 'css' } });
-  const style6 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/abstract-dark.css", { with: { type: 'css' } });
-  const style7 = await importShim("https://raw.githubusercontent.com/observablehq/notebook-kit/6c2ec69e1ac30dd329789524a849578b2df17945/src/styles/syntax-dark.css", { with: { type: 'css' } });
-  const style8 = await importShim("file://syntax.css", { with: { type: 'css' } });
-  document.adoptedStyleSheets = [style0.default,style1.default,style2.default,style3.default,style4.default,style5.default,style6.default,style7.default,style8.default];
-
-  const { Runtime } = await importShim("@observablehq/runtime@6.0.0");
-  const { Inspector } = await importShim("@observablehq/inspector@5.0.1");
-  const notebook = document.querySelector("notebook");
-  const runtime = new Runtime({__ojs_runtime: () => runtime, __ojs_observer: () => observer});
-  const observer = Inspector.into(document.body);
-  const {default: define} = await importShim("@tomlarkworthy/bootloader");
-  runtime.bootloader = runtime.module(define, () => ({}));
+}
 </script>
+
+<script id="streaming_sentinel">window.__lopeStreaming = false;</script>
 </body>
 </html>

--- a/notebooks/@tomlarkworthy_claude-code-pairing.json
+++ b/notebooks/@tomlarkworthy_claude-code-pairing.json
@@ -8,6 +8,7 @@
     ],
     "hash": "#view=S100(@tomlarkworthy/claude-code-pairing,@tomlarkworthy/module-selection)",
     "headless": true,
+    "prerender": true,
     "theme": "ocean-floor"
   },
   "files": [
@@ -22,6 +23,37 @@
     },
     "@observablehq/inspector@5.0.1": {
       "hash": "5658858e85affa2e1e5cd1052924c622"
+    },
+    "@tomlarkworthy/claude-code-pairing": {
+      "hash": "644fee3df532e77e7e18991bb824720a",
+      "dependsOn": [
+        "@tomlarkworthy/module-map",
+        "@tomlarkworthy/exporter-3",
+        "@tomlarkworthy/observablejs-toolchain",
+        "@tomlarkworthy/local-change-history",
+        "@tomlarkworthy/runtime-sdk",
+        "d/57d79353bac56631@44",
+        "@tomlarkworthy/summarizejs",
+        "@tomlarkworthy/file-sync"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/lopepage"
+      ]
+    },
+    "@tomlarkworthy/lopepage": {
+      "hash": "ea085755ec5e24f0b29c4cc5f06a7a08",
+      "dependsOn": [
+        "@tomlarkworthy/golden-layout-2-6-0",
+        "@tomlarkworthy/visualizer",
+        "@tomlarkworthy/module-selection",
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/editor-5",
+        "@tomlarkworthy/exporter-3",
+        "d/57d79353bac56631@44",
+        "@tomlarkworthy/local-change-history",
+        "@tomlarkworthy/claude-code-pairing",
+        "@tomlarkworthy/command-palette"
+      ]
     },
     "@mbostock/safe-local-storage": {
       "hash": "937d252019887842c8c48c634b76179a",
@@ -46,7 +78,7 @@
       ]
     },
     "@tomlarkworthy/cell-map": {
-      "hash": "434c65227b7b0457fdb8b2baf7580d25",
+      "hash": "92d3ea87805ffd4a9dc0b0a0e3d7127d",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
@@ -70,24 +102,8 @@
         "@tomlarkworthy/editor-5"
       ]
     },
-    "@tomlarkworthy/claude-code-pairing": {
-      "hash": "9ef62cada1525cf5d4987907f0362236",
-      "dependsOn": [
-        "@tomlarkworthy/module-map",
-        "@tomlarkworthy/exporter-3",
-        "@tomlarkworthy/observablejs-toolchain",
-        "@tomlarkworthy/local-change-history",
-        "@tomlarkworthy/runtime-sdk",
-        "d/57d79353bac56631@44",
-        "@tomlarkworthy/summarizejs",
-        "@tomlarkworthy/file-sync"
-      ],
-      "dependedBy": [
-        "@tomlarkworthy/lopepage-2"
-      ]
-    },
     "@tomlarkworthy/codemirror-6-v2": {
-      "hash": "80378ba570b5e43e8f978aa58a7aff02",
+      "hash": "4c719107756989ca8470b2b034bf7511",
       "files": [
         "codemirror_javascript%405.js.gz"
       ],
@@ -96,7 +112,7 @@
       ]
     },
     "@tomlarkworthy/command-palette": {
-      "hash": "a3617c1f57904cbab42a34b069bf092a",
+      "hash": "0b2390646b85056b6ee404d38db39c08",
       "dependsOn": [
         "@tomlarkworthy/cell-map",
         "@tomlarkworthy/lopepage-urls",
@@ -105,7 +121,7 @@
         "@tomlarkworthy/plugin-registry"
       ],
       "dependedBy": [
-        "@tomlarkworthy/lopepage-2"
+        "@tomlarkworthy/lopepage"
       ]
     },
     "@tomlarkworthy/dataflow-templating": {
@@ -128,7 +144,7 @@
       ]
     },
     "@tomlarkworthy/editor-5": {
-      "hash": "ce407d44e9550760a7882c2c7192658d",
+      "hash": "1d979f7d4603fc31da3ad066fc11813b",
       "files": [
         "cell_options.json"
       ],
@@ -150,17 +166,11 @@
         "@tomlarkworthy/module-map"
       ],
       "dependedBy": [
-        "@tomlarkworthy/lopepage-2"
-      ]
-    },
-    "@tomlarkworthy/escodegen": {
-      "hash": "d5e793114a390617e9a70bfdd61a42ec",
-      "files": [
-        "escodegen.browser.min.js.gz"
+        "@tomlarkworthy/lopepage"
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "9e5fcccf1ed23acb071ad881f1f2e1e0",
+      "hash": "f8f7f0bddbe0f4c99d8bcee5e5660338",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",
@@ -180,12 +190,11 @@
         "@tomlarkworthy/claude-code-pairing",
         "@tomlarkworthy/file-sync",
         "@tomlarkworthy/local-change-history",
-        "@tomlarkworthy/lopepage-2",
-        "@tomlarkworthy/save-in-place"
+        "@tomlarkworthy/lopepage"
       ]
     },
     "@tomlarkworthy/file-sync": {
-      "hash": "6c9f6c33ec72bb08443d18ae7e649237",
+      "hash": "53e231a7c5dddfb040d8b7325351936d",
       "dependsOn": [
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/exporter-3",
@@ -198,7 +207,7 @@
       ]
     },
     "@tomlarkworthy/fileattachments": {
-      "hash": "75679a4f3f2047d045c1e27372816a3b",
+      "hash": "909e72463d7da8f0d2fcd01e74ddc364",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk"
       ],
@@ -209,7 +218,7 @@
       ]
     },
     "@tomlarkworthy/flow-queue": {
-      "hash": "97db7ca44c394ea3f73a3f60f0d2ef6c",
+      "hash": "dd7a035f809162d101be55d55be97880",
       "files": [
         "flowQuery%401.svg"
       ],
@@ -220,7 +229,7 @@
       ]
     },
     "@tomlarkworthy/golden-layout-2-6-0": {
-      "hash": "24f5fad01bd508dd1bc3a49a99002770",
+      "hash": "3331ddc9fc7e65a246bfc1137961c766",
       "files": [
         "golden-layout-2.6.0.js.gz",
         "lm_popout_black.png",
@@ -228,6 +237,9 @@
         "lm_minimize_black.png",
         "lm_popin_black.png",
         "lm_maximise_black.png"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/lopepage"
       ]
     },
     "@tomlarkworthy/import-notebook": {
@@ -252,8 +264,17 @@
         "@tomlarkworthy/visualizer"
       ]
     },
+    "@tomlarkworthy/invoke-variable": {
+      "hash": "eb72dd569c9e7f0de6e0b518cbe12fb4",
+      "dependsOn": [
+        "@tomlarkworthy/runtime-sdk"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/module-map"
+      ]
+    },
     "@tomlarkworthy/isomorphic-git-1-30-1": {
-      "hash": "16fa79b79fb4e9e1a2d03cfc9221147c",
+      "hash": "0cb9679e97bac6b63cba20a792de5389",
       "files": [
         "isomorphic-git-1%401.30.1.bundle.js.gz",
         "isomorphic-git-http-1.0.0-beta.36.js.gz"
@@ -263,7 +284,7 @@
       ]
     },
     "@tomlarkworthy/jest-expect-standalone": {
-      "hash": "418ef3328580c7b2416be5b9fc940db4",
+      "hash": "bd4d80b0911cd2fc3cc10c4f007f447f",
       "files": [
         "jest-expect-standalone-24.0.2.js.gz"
       ],
@@ -274,7 +295,7 @@
       ]
     },
     "@tomlarkworthy/jszip-3-10-1": {
-      "hash": "2b119c57e9c2ce093b3a9c7d2932d010",
+      "hash": "b171464c98410d02c097e34a8f4d2b71",
       "files": [
         "jszip-3.10.1.min.js.gz"
       ],
@@ -283,7 +304,7 @@
       ]
     },
     "@tomlarkworthy/lightning-fs-4-6-0": {
-      "hash": "1f60955582df75104615d8061957d237",
+      "hash": "6eb7adeb763a8295f1bfab78e46f11af",
       "files": [
         "lightning-fs-4.6.0.js.gz"
       ],
@@ -292,7 +313,7 @@
       ]
     },
     "@tomlarkworthy/local-change-history": {
-      "hash": "4764f3d18c8f776aabdc6acb92d38a6f",
+      "hash": "052efa3aa9b37e17ea391c4a4dbde687",
       "dependsOn": [
         "@tomlarkworthy/runtime-sdk",
         "@tomlarkworthy/lightning-fs-4-6-0",
@@ -304,7 +325,7 @@
       "dependedBy": [
         "@tomlarkworthy/claude-code-pairing",
         "@tomlarkworthy/file-sync",
-        "@tomlarkworthy/lopepage-2"
+        "@tomlarkworthy/lopepage"
       ]
     },
     "@tomlarkworthy/local-storage-view": {
@@ -328,7 +349,6 @@
         "@tomlarkworthy/command-palette",
         "@tomlarkworthy/editor-5",
         "@tomlarkworthy/exporter-3",
-        "@tomlarkworthy/lopepage-2",
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/module-selection",
         "@tomlarkworthy/tests",
@@ -336,7 +356,7 @@
       ]
     },
     "@tomlarkworthy/module-map": {
-      "hash": "9eb3066d1ac81214f0d08efdf493f395",
+      "hash": "18f327c993e00ae2ab3ab0cb21a27492",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/flow-queue",
@@ -368,10 +388,24 @@
         "d/57d79353bac56631@44",
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/runtime-sdk"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/lopepage"
+      ]
+    },
+    "@tomlarkworthy/modules": {
+      "hash": "1a8195ade0cf1a14d350785eeec762cd",
+      "dependsOn": [
+        "@tomlarkworthy/runtime-sdk",
+        "@tomlarkworthy/tests",
+        "@tomlarkworthy/observable-runtime-v6"
+      ],
+      "dependedBy": [
+        "@tomlarkworthy/editor-5"
       ]
     },
     "@tomlarkworthy/observable-runtime": {
-      "hash": "4b60a23333fcadbc20650feae24d4039",
+      "hash": "e2e4c27c06b124cf3f3f880370d8755f",
       "files": [
         "runtime.js.gz"
       ],
@@ -380,14 +414,14 @@
       ]
     },
     "@tomlarkworthy/observable-runtime-v6": {
-      "hash": "6bc9db7b1881559c4d30c39f692e3969",
+      "hash": "cd421b0b3a2155578f1ef6d603b43258",
       "dependedBy": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/modules"
       ]
     },
     "@tomlarkworthy/observablehq-lezer": {
-      "hash": "f827692f8b66b9b0f0cb8b9529f40815",
+      "hash": "49b46bb0bfedf68aea06e8d8a61d39d7",
       "files": [
         "lezer-lr-bundled.js.gz",
         "lezer-highlight-bundled.js.gz"
@@ -399,7 +433,6 @@
     "@tomlarkworthy/observablejs-toolchain": {
       "hash": "ee645d9c91a19f749128621e7ec3f99f",
       "files": [
-        "acorn-walk-8.3.2.js.gz",
         "parser-6.1.0.js.gz"
       ],
       "dependsOn": [
@@ -418,6 +451,12 @@
         "@tomlarkworthy/module-selection"
       ]
     },
+    "@tomlarkworthy/plugin-registry": {
+      "hash": "428298afcf9c9c8bb13c412d7c23b191",
+      "dependedBy": [
+        "@tomlarkworthy/command-palette"
+      ]
+    },
     "@tomlarkworthy/reversible-attachment": {
       "hash": "bd5c80a260b0ab92fd01205320224d30",
       "dependsOn": [
@@ -429,7 +468,7 @@
       ]
     },
     "@tomlarkworthy/runtime-sdk": {
-      "hash": "fe93b58bba8bad16ebe793c3c4b44eb6",
+      "hash": "3241057be6a447812dc7e7106e9d26a4",
       "dependsOn": [
         "@mootari/access-runtime"
       ],
@@ -444,12 +483,11 @@
         "@tomlarkworthy/import-notebook",
         "@tomlarkworthy/invoke-variable",
         "@tomlarkworthy/local-change-history",
-        "@tomlarkworthy/lopepage-2",
+        "@tomlarkworthy/lopepage",
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/module-map",
         "@tomlarkworthy/module-selection",
         "@tomlarkworthy/modules",
-        "@tomlarkworthy/save-in-place",
         "@tomlarkworthy/tests",
         "@tomlarkworthy/visualizer"
       ]
@@ -495,22 +533,21 @@
       ]
     },
     "@tomlarkworthy/themes": {
-      "hash": "2320f0d9d51c50a2272d57b672b66f59",
+      "hash": "e805ad68c19cf214655218d6cb106d70",
       "dependedBy": [
         "@tomlarkworthy/command-palette",
-        "@tomlarkworthy/exporter-3",
-        "@tomlarkworthy/lopepage-2"
+        "@tomlarkworthy/exporter-3"
       ]
     },
     "@tomlarkworthy/view": {
-      "hash": "970bf1f386002336660773d1215dd61f",
+      "hash": "c8bc708ea9f194c66bc203be5ed9bde5",
       "dependedBy": [
         "@tomlarkworthy/exporter-3",
         "@tomlarkworthy/reversible-attachment"
       ]
     },
     "@tomlarkworthy/visualizer": {
-      "hash": "c2964fd9bd642d209f8bbd5a3675b7b3",
+      "hash": "72308ea706602b6b9d1d4836c0c3eea6",
       "dependsOn": [
         "@tomlarkworthy/inspector",
         "@tomlarkworthy/runtime-sdk",
@@ -519,67 +556,14 @@
       ],
       "dependedBy": [
         "@tomlarkworthy/editor-5",
-        "@tomlarkworthy/lopepage-2"
+        "@tomlarkworthy/lopepage"
       ]
     },
     "d/57d79353bac56631": {
       "hash": "913f1f6b56a3bbdfca30148905419a98"
     },
-    "@tomlarkworthy/invoke-variable": {
-      "hash": "ae3d268aca489da6f10ef0ac2ebf5da2",
-      "dependsOn": [
-        "@tomlarkworthy/runtime-sdk"
-      ],
-      "dependedBy": [
-        "@tomlarkworthy/module-map"
-      ]
-    },
-    "@tomlarkworthy/plugin-registry": {
-      "hash": "428298afcf9c9c8bb13c412d7c23b191",
-      "dependedBy": [
-        "@tomlarkworthy/command-palette",
-        "@tomlarkworthy/lopepage-2",
-        "@tomlarkworthy/save-in-place"
-      ]
-    },
-    "@tomlarkworthy/modules": {
-      "hash": "1a8195ade0cf1a14d350785eeec762cd",
-      "dependsOn": [
-        "@tomlarkworthy/runtime-sdk",
-        "@tomlarkworthy/tests",
-        "@tomlarkworthy/observable-runtime-v6"
-      ],
-      "dependedBy": [
-        "@tomlarkworthy/editor-5",
-        "@tomlarkworthy/lopepage-2"
-      ]
-    },
-    "@tomlarkworthy/lopepage-2": {
-      "hash": "0598b5ecce2336d3dd3c3fc59cc0508d",
-      "dependsOn": [
-        "@tomlarkworthy/plugin-registry",
-        "@tomlarkworthy/runtime-sdk",
-        "@tomlarkworthy/visualizer",
-        "@tomlarkworthy/modules",
-        "@tomlarkworthy/claude-code-pairing",
-        "@tomlarkworthy/command-palette",
-        "@tomlarkworthy/themes",
-        "@tomlarkworthy/local-change-history",
-        "@tomlarkworthy/lopepage-urls",
-        "@tomlarkworthy/editor-5",
-        "@tomlarkworthy/exporter-3"
-      ]
-    },
-    "@tomlarkworthy/save-in-place": {
-      "hash": "aea6b315755118e76e8021177e76e917",
-      "dependsOn": [
-        "@tomlarkworthy/exporter-3",
-        "@tomlarkworthy/plugin-registry",
-        "@tomlarkworthy/runtime-sdk"
-      ]
-    },
     "@tomlarkworthy/bootloader": {
-      "hash": "f687ddbbf19b8758d061a3cf72779a66"
+      "hash": "8f696c43527a8ceadc35bd1192292b4e"
     }
   },
   "upstreams": {
@@ -587,6 +571,6 @@
       "@tomlarkworthy/claude-code-pairing": "https://observablehq.com/@tomlarkworthy/claude-code-pairing"
     }
   },
-  "observable_version": 1881,
-  "observable_update_time": "2026-05-13T08:16:14.556Z"
+  "observable_version": 1883,
+  "observable_update_time": "2026-08-06T06:29:37.917Z"
 }

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.html
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_command-palette.html
+++ b/notebooks/@tomlarkworthy_command-palette.html
@@ -6240,9 +6240,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -6253,7 +6252,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -6419,7 +6418,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -6445,8 +6444,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -6915,7 +6914,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -12376,247 +12375,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -12834,12 +12842,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -12982,341 +12993,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -13365,7 +13377,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -13613,9 +13624,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -13629,10 +13640,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -13642,8 +13653,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_dataflow-templating.html
+++ b/notebooks/@tomlarkworthy_dataflow-templating.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_debugger-2.html
+++ b/notebooks/@tomlarkworthy_debugger-2.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -11381,247 +11380,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -11839,12 +11847,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -11987,341 +11998,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -12370,7 +12382,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -12618,9 +12629,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -12634,10 +12645,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -12647,8 +12658,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_debugger.html
+++ b/notebooks/@tomlarkworthy_debugger.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10640,247 +10639,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -11098,12 +11106,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -11246,341 +11257,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11629,7 +11641,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11877,9 +11888,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11893,10 +11904,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11906,8 +11917,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_dom-view.html
+++ b/notebooks/@tomlarkworthy_dom-view.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_editor-5.html
+++ b/notebooks/@tomlarkworthy_editor-5.html
@@ -7990,9 +7990,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -8003,7 +8002,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -8169,7 +8168,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -8195,8 +8194,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -8665,7 +8664,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -12324,247 +12323,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -12782,12 +12790,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -12930,341 +12941,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -13313,7 +13325,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -13561,9 +13572,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -13577,10 +13588,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -13590,8 +13601,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_exporter-2.html
+++ b/notebooks/@tomlarkworthy_exporter-2.html
@@ -5701,9 +5701,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -5714,7 +5713,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -5880,7 +5879,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -5906,8 +5905,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -6376,7 +6375,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -12317,247 +12316,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -12775,12 +12783,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -12923,341 +12934,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -13306,7 +13318,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -13554,9 +13565,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -13570,10 +13581,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -13583,8 +13594,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -5941,9 +5941,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -5954,7 +5953,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -6120,7 +6119,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -6146,8 +6145,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -6616,7 +6615,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10253,247 +10252,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10711,12 +10719,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10859,341 +10870,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11242,7 +11254,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11490,9 +11501,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11506,10 +11517,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11519,8 +11530,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_fileattachments.html
+++ b/notebooks/@tomlarkworthy_fileattachments.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_flow-queue.html
+++ b/notebooks/@tomlarkworthy_flow-queue.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_import-notebook.html
+++ b/notebooks/@tomlarkworthy_import-notebook.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.html
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_local-change-history.html
+++ b/notebooks/@tomlarkworthy_local-change-history.html
@@ -8009,9 +8009,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -8022,7 +8021,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -8188,7 +8187,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -8214,8 +8213,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -8684,7 +8683,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -14674,247 +14673,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -15132,12 +15140,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -15280,341 +15291,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -15663,7 +15675,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -15911,9 +15922,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -15927,10 +15938,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -15940,8 +15951,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_local-storage-view.html
+++ b/notebooks/@tomlarkworthy_local-storage-view.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_lopecode-tour.html
+++ b/notebooks/@tomlarkworthy_lopecode-tour.html
@@ -6787,9 +6787,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -6800,7 +6799,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -6966,7 +6965,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -6992,8 +6991,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -7462,7 +7461,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -14654,247 +14653,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -15112,12 +15120,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -15260,341 +15271,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -15643,7 +15655,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -15891,9 +15902,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -15907,10 +15918,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -15920,8 +15931,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_lopecode-vision.html
+++ b/notebooks/@tomlarkworthy_lopecode-vision.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -11421,247 +11420,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -11879,12 +11887,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -12027,341 +12038,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -12410,7 +12422,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -12658,9 +12669,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -12674,10 +12685,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -12687,8 +12698,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_lopepage-2.html
+++ b/notebooks/@tomlarkworthy_lopepage-2.html
@@ -7369,9 +7369,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -7382,7 +7381,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -7548,7 +7547,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -7574,8 +7573,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -8044,7 +8043,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -13985,247 +13984,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -14443,12 +14451,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -14591,341 +14602,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -14974,7 +14986,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -15222,9 +15233,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -15238,10 +15249,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -15251,8 +15262,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_lopepage-urls.html
+++ b/notebooks/@tomlarkworthy_lopepage-urls.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_lopepage.html
+++ b/notebooks/@tomlarkworthy_lopepage.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_modern-screenshot.html
+++ b/notebooks/@tomlarkworthy_modern-screenshot.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_module-selection.html
+++ b/notebooks/@tomlarkworthy_module-selection.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_modules.html
+++ b/notebooks/@tomlarkworthy_modules.html
@@ -6140,9 +6140,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -6153,7 +6152,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -6319,7 +6318,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -6345,8 +6344,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -6815,7 +6814,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -12756,247 +12755,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -13214,12 +13222,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -13362,341 +13373,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -13745,7 +13757,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -13993,9 +14004,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -14009,10 +14020,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -14022,8 +14033,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_notes.html
+++ b/notebooks/@tomlarkworthy_notes.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10265,247 +10264,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10723,12 +10731,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10871,341 +10882,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11254,7 +11266,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11502,9 +11513,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11518,10 +11529,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11531,8 +11542,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_observablehq-lezer.html
+++ b/notebooks/@tomlarkworthy_observablehq-lezer.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.html
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.html
@@ -7005,9 +7005,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -7018,7 +7017,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -7184,7 +7183,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -7210,8 +7209,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -7680,7 +7679,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -13621,247 +13620,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -14079,12 +14087,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -14227,341 +14238,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -14610,7 +14622,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -14858,9 +14869,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -14874,10 +14885,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -14887,8 +14898,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_openai-responses-api.html
+++ b/notebooks/@tomlarkworthy_openai-responses-api.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_reversible-attachment.html
+++ b/notebooks/@tomlarkworthy_reversible-attachment.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_robocoop-2.html
+++ b/notebooks/@tomlarkworthy_robocoop-2.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_robocoop-3.html
+++ b/notebooks/@tomlarkworthy_robocoop-3.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_robocoop-4.html
+++ b/notebooks/@tomlarkworthy_robocoop-4.html
@@ -3601,9 +3601,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3614,7 +3613,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3780,7 +3779,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3806,8 +3805,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4276,7 +4275,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10266,247 +10265,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10724,12 +10732,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10872,341 +10883,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11255,7 +11267,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11503,9 +11514,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11519,10 +11530,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11532,8 +11543,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_runtime-sdk.html
+++ b/notebooks/@tomlarkworthy_runtime-sdk.html
@@ -4681,9 +4681,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -4694,7 +4693,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -4860,7 +4859,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -4886,8 +4885,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -5356,7 +5355,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -11297,247 +11296,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -11755,12 +11763,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -11903,341 +11914,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -12286,7 +12298,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -12534,9 +12545,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -12550,10 +12561,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -12563,8 +12574,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_save-in-place.html
+++ b/notebooks/@tomlarkworthy_save-in-place.html
@@ -5705,9 +5705,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -5718,7 +5717,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -5884,7 +5883,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -5910,8 +5909,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -6380,7 +6379,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -12321,247 +12320,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -12779,12 +12787,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -12927,341 +12938,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -13310,7 +13322,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -13558,9 +13569,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -13574,10 +13585,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -13587,8 +13598,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_secrets.html
+++ b/notebooks/@tomlarkworthy_secrets.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_tests.html
+++ b/notebooks/@tomlarkworthy_tests.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_themes.html
+++ b/notebooks/@tomlarkworthy_themes.html
@@ -3554,9 +3554,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -3567,7 +3566,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -3733,7 +3732,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -3759,8 +3758,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4229,7 +4228,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10219,247 +10218,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -10677,12 +10685,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -10825,341 +10836,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11208,7 +11220,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -11456,9 +11467,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -11472,10 +11483,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -11485,8 +11496,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/@tomlarkworthy_visualizer.html
+++ b/notebooks/@tomlarkworthy_visualizer.html
@@ -4184,9 +4184,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -4197,7 +4196,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -4363,7 +4362,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -4389,8 +4388,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -4859,7 +4858,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -10849,247 +10848,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -11307,12 +11315,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -11455,341 +11466,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -11838,7 +11850,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -12086,9 +12097,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -12102,10 +12113,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -12115,8 +12126,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/atproto.html
+++ b/notebooks/atproto.html
@@ -6565,9 +6565,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -6578,7 +6577,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -6744,7 +6743,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -6770,8 +6769,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -7240,7 +7239,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -13230,247 +13229,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -13688,12 +13696,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -13836,341 +13847,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -14219,7 +14231,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -14467,9 +14478,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -14483,10 +14494,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -14496,8 +14507,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/import_wizards.html
+++ b/notebooks/import_wizards.html
@@ -6223,9 +6223,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -6236,7 +6235,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -6402,7 +6401,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -6428,8 +6427,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -6898,7 +6897,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -12888,247 +12887,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -13346,12 +13354,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -13494,341 +13505,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -13877,7 +13889,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -14125,9 +14136,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -14141,10 +14152,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -14154,8 +14165,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/jumpgates.html
+++ b/notebooks/jumpgates.html
@@ -6847,9 +6847,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -6860,7 +6859,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -7026,7 +7025,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -7052,8 +7051,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -7522,7 +7521,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -13463,247 +13462,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -13921,12 +13929,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -14069,341 +14080,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -14452,7 +14464,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -14700,9 +14711,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -14716,10 +14727,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -14729,8 +14740,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/ledger.html
+++ b/notebooks/ledger.html
@@ -6364,9 +6364,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -6377,7 +6376,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -6543,7 +6542,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -6569,8 +6568,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -7039,7 +7038,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -13029,247 +13028,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -13487,12 +13495,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -13635,341 +13646,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -14018,7 +14030,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -14266,9 +14277,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -14282,10 +14293,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -14295,8 +14306,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/lopefeed.html
+++ b/notebooks/lopefeed.html
@@ -6364,9 +6364,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -6377,7 +6376,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -6543,7 +6542,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -6569,8 +6568,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -7039,7 +7038,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -13029,247 +13028,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -13487,12 +13495,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -13635,341 +13646,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -14018,7 +14030,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -14266,9 +14277,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -14282,10 +14293,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -14295,8 +14306,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 

--- a/notebooks/quick_start.html
+++ b/notebooks/quick_start.html
@@ -13856,9 +13856,8 @@ function handleCommand(cmd) {
     return handler(cmd, rt);
 }
 )};
-const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation)
-{
-    return function () {
+const _1g08tci = function _cc_ws(cc_config,location,cc_status,Event,$0,cc_notebook_id,cc_watchers,$1,cc_messages,cc_activity,cc_command_handlers,invalidation){return(
+function () {
         var port = cc_config.port, host = cc_config.host;
         var ws = null;
         var paired = false;
@@ -13869,7 +13868,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (token) {
                 try {
-                    sessionStorage.setItem('lopecode_cc_token', token);
+                    window.sessionStorage.setItem('lopecode_cc_token', token);
                 } catch (e) {
                 }
                 var hash = location.hash || '#';
@@ -14035,7 +14034,7 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
             }
             if (!token) {
                 try {
-                    token = sessionStorage.getItem('lopecode_cc_token');
+                    token = window.sessionStorage.getItem('lopecode_cc_token');
                 } catch (e) {
                 }
             }
@@ -14061,8 +14060,8 @@ const _1s8ywlt = function _cc_ws(cc_config,sessionStorage,location,cc_status,Eve
                 return ws;
             }
         };
-    }();
-};
+    }()
+)};
 const _agu8h7 = function _cc_doc_side_effects(md){return(
 md`---
 ### Side effects
@@ -14531,7 +14530,7 @@ export default function define(runtime, observer) {
   $def("_bzq7u5", null, ["viewof mcpTools","fileSyncTools","Event"], _bzq7u5);  
   $def("_npplqm", "cc_handle_call_tool", ["viewof mcpTools","cc_watchers","runtime"], _npplqm);  
   $def("_ptgn2x", "cc_command_handlers", ["runtime","cc_handle_get_variable","cc_handle_define_variable","cc_handle_define_cell","cc_handle_delete_variable","cc_handle_delete_cell","cc_handle_update_cell","cc_handle_list_variables","cc_handle_list_cells","cc_handle_run_tests","cc_handle_create_module","cc_handle_delete_module","cc_handle_eval","cc_handle_fork","cc_handle_export_module","cc_handle_watch","cc_handle_unwatch","cc_handle_call_tool"], _ptgn2x);  
-  $def("_1s8ywlt", "cc_ws", ["cc_config","sessionStorage","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1s8ywlt);  
+  $def("_1g08tci", "cc_ws", ["cc_config","location","cc_status","Event","viewof mcpTools","cc_notebook_id","cc_watchers","viewof cc_watches","cc_messages","cc_activity","cc_command_handlers","invalidation"], _1g08tci);  
   $def("_agu8h7", "cc_doc_side_effects", ["md"], _agu8h7);  
   $def("_d9cyj2", "cc_change_forwarder", ["cc_ws","history","invalidation"], _d9cyj2);  
   $def("_56tjlo", "cc_voice", ["voiceEnabled","KeyboardEvent","SpeechSynthesisUtterance","invalidation"], _56tjlo);  
@@ -20521,247 +20520,256 @@ const _1t1i3ml = function _directory(notebookId,htl,hashParam,location,history)
     return container;
 };
 const _jnt0bt = (G, _) => G.input(_);
-const _yqx7l8 = function _syncEnabled(notebookId,htl)
+const _1rbt7m0 = function _syncEnabled(notebookId,htl)
 {
     const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-    const initial = window.localStorage.getItem(KEY) === '1';
+    // blob: forks are an opaque origin, where reading window.localStorage throws
+    const store = (fn, fallback) => {
+        try {
+            return fn(window.localStorage);
+        } catch (e) {
+            return fallback;
+        }
+    };
+    const initial = store(s => s.getItem(KEY), null) === '1';
     const container = htl.html`<label style="display:inline-flex;align-items:center;gap:6px;padding:8px 12px;font-size:13px;cursor:pointer;"><input type="checkbox"> Sync enabled</label>`;
     const cb = container.querySelector('input');
     cb.checked = initial;
     container.value = initial;
     cb.onchange = () => {
         container.value = cb.checked;
-        window.localStorage.setItem(KEY, cb.checked ? '1' : '0');
+        store(s => s.setItem(KEY, cb.checked ? '1' : '0'));
         container.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
     return container;
 };
 const _xltqf6 = (G, _) => G.input(_);
-const _1mb10vh = function _disassemble(htl, directory, notebookId, manifestWriter, readFile, writeFile, syncableModules, exportModuleJS, hashSource, currentModules, runtime, probeDefine, tag, importShim, $0) {
-    const container = htl.html`<div>
+const _1nuhj4u = function _disassemble(htl,directory,notebookId,manifestWriter,readFile,writeFile,syncableModules,exportModuleJS,hashSource,currentModules,runtime,probeDefine,tag,$0)
+{
+  const container = htl.html`<div>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
       <button class="disassemble" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Disassemble to disk</button>
       <button class="sync" style="padding: 8px 16px; font-size: 14px; cursor: pointer;" disabled>Sync from disk</button>
     </div>
     <pre style="font-size: 12px; max-height: 300px; overflow-y: auto; margin-top: 8px;"></pre>
   </div>`;
-    const disBtn = container.querySelector('.disassemble');
-    const syncBtn = container.querySelector('.sync');
-    const status = container.querySelector('pre');
-    if (directory) {
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
+  const disBtn = container.querySelector('.disassemble');
+  const syncBtn = container.querySelector('.sync');
+  const status = container.querySelector('pre');
+  if (directory) {
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  }
+  const log = msg => {
+    status.textContent += msg + '\n';
+    status.scrollTop = status.scrollHeight;
+  };
+  const prefix = notebookId + '/';
+  disBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    disBtn.textContent = 'Disassembling...';
+    let ok = 0, fail = 0;
+    const manifestUpdates = {};
+    await manifestWriter(directory, prefix, null, readFile, writeFile);
+    log('cleared manifest');
+    for (const moduleId of syncableModules) {
+      try {
+        log('Exporting ' + moduleId + '...');
+        const result = await exportModuleJS(moduleId);
+        const path = prefix + moduleId + '.js';
+        await writeFile(directory, path, result.source);
+        manifestUpdates[moduleId] = hashSource(result.source);
+        log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
+        if (result.fileAttachments && result.fileAttachments.size) {
+          for (const [name, entry] of result.fileAttachments) {
+            try {
+              const resp = await fetch(entry.url);
+              const bytes = await resp.arrayBuffer();
+              await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
+              log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
+            } catch (e) {
+              log('  attachment FAILED: ' + name + ' - ' + e.message);
+            }
+          }
+        }
+        ok++;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
     }
-    const log = msg => {
-        status.textContent += msg + '\n';
-        status.scrollTop = status.scrollHeight;
+    try {
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const bootconf = document.querySelector('script[id="bootconf.json"]');
+      if (bootconf) {
+        await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
+        log('wrote ' + prefix + 'bootconf.json');
+      }
+    } catch (e) {
+      log('bootconf.json FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
+    disBtn.textContent = 'Disassembled ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  syncBtn.onclick = async () => {
+    if (!directory)
+      return;
+    disBtn.disabled = true;
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing from disk...';
+    status.textContent = '';
+    const nameToModule = new window.Map();
+    const nameToVars = new window.Map();
+    for (const [mod, info] of currentModules) {
+      if (info.name === 'bootloader' || info.name === 'builtin')
+        continue;
+      if (!info.name.includes('/') && !info.name.startsWith('d/'))
+        continue;
+      nameToModule.set(info.name, info.module);
+      const vars = new window.Map();
+      for (const v of runtime._variables) {
+        if (v._module !== info.module)
+          continue;
+        if (v._name)
+          vars.set(v._name, v);
+        if (v.pid)
+          vars.set('__pid__' + v.pid, v);
+      }
+      nameToVars.set(info.name, vars);
+    }
+    const applyModule = (moduleId, defineFn) => {
+      const mod = nameToModule.get(moduleId);
+      if (!mod)
+        return;
+      const existingVars = nameToVars.get(moduleId) || new window.Map();
+      const cells = probeDefine(defineFn);
+      const seenPids = new Set();
+      for (const cell of cells) {
+        if (cell.type === 'import')
+          continue;
+        if (!cell.pid)
+          continue;
+        seenPids.add(cell.pid);
+        const existing = existingVars.get('__pid__' + cell.pid);
+        if (!existing) {
+          const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+          const v = mod.variable();
+          v.define(cell.name, cell.inputs, taggedDefn);
+          v.pid = cell.pid;
+          existingVars.set('__pid__' + cell.pid, v);
+          if (cell.name)
+            existingVars.set(cell.name, v);
+          continue;
+        }
+        if (existing._definition) {
+          const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
+          const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+          const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+          if (inputsMatch && defnMatch)
+            continue;
+        }
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      }
+      const ordered = [];
+      for (const cell of cells) {
+        if (!cell.pid)
+          continue;
+        const v = existingVars.get('__pid__' + cell.pid);
+        if (v)
+          ordered.push(v);
+      }
+      if (ordered.length) {
+        const orderedSet = new Set(ordered);
+        const arr = [...runtime._variables];
+        let oi = 0;
+        for (let i = 0; i < arr.length; i++) {
+          if (orderedSet.has(arr[i]))
+            arr[i] = ordered[oi++];
+        }
+        while (oi < ordered.length)
+          arr.push(ordered[oi++]);
+        runtime._variables.clear();
+        for (const v of arr)
+          runtime._variables.add(v);
+      }
     };
-    const prefix = notebookId + '/';
-    disBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        disBtn.textContent = 'Disassembling...';
-        let ok = 0, fail = 0;
-        const manifestUpdates = {};
-        await manifestWriter(directory, prefix, null, readFile, writeFile);
-        log('cleared manifest');
-        for (const moduleId of syncableModules) {
+    const manifestUpdates = {};
+    let ok = 0, fail = 0;
+    for (const moduleId of syncableModules) {
+      try {
+        let file;
+        try {
+          file = await readFile(directory, prefix + moduleId + '.js');
+        } catch (e) {
+          file = null;
+        }
+        if (!file) {
+          log('  skip ' + moduleId + ' (no .js on disk)');
+          continue;
+        }
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const mod = await import(url);
+          if (typeof mod.default === 'function') {
+            applyModule(moduleId, mod.default);
+            log('  applied ' + moduleId);
             try {
-                log('Exporting ' + moduleId + '...');
-                const result = await exportModuleJS(moduleId);
-                const path = prefix + moduleId + '.js';
-                await writeFile(directory, path, result.source);
-                manifestUpdates[moduleId] = hashSource(result.source);
-                log('  wrote ' + path + ' (' + result.source.length + ' bytes)');
-                if (result.fileAttachments && result.fileAttachments.size) {
-                    for (const [name, entry] of result.fileAttachments) {
-                        try {
-                            const resp = await fetch(entry.url);
-                            const bytes = await resp.arrayBuffer();
-                            await writeFile(directory, prefix + moduleId + '/' + name, new Uint8Array(bytes));
-                            log('  attachment: ' + moduleId + '/' + name + ' (' + bytes.byteLength + ' bytes)');
-                        } catch (e) {
-                            log('  attachment FAILED: ' + name + ' - ' + e.message);
-                        }
-                    }
-                }
-                ok++;
+              const after = await exportModuleJS(moduleId);
+              manifestUpdates[moduleId] = hashSource(after.source);
             } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
+              manifestUpdates[moduleId] = hashSource(diskText);
             }
+            ok++;
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
         }
-        try {
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const bootconf = document.querySelector('script[id="bootconf.json"]');
-            if (bootconf) {
-                await writeFile(directory, prefix + 'bootconf.json', bootconf.textContent.trim());
-                log('wrote ' + prefix + 'bootconf.json');
-            }
-        } catch (e) {
-            log('bootconf.json FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules exported, ' + fail + ' failed');
-        disBtn.textContent = 'Disassembled ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    syncBtn.onclick = async () => {
-        if (!directory)
-            return;
-        disBtn.disabled = true;
-        syncBtn.disabled = true;
-        syncBtn.textContent = 'Syncing from disk...';
-        status.textContent = '';
-        const nameToModule = new window.Map();
-        const nameToVars = new window.Map();
-        for (const [mod, info] of currentModules) {
-            if (info.name === 'bootloader' || info.name === 'builtin')
-                continue;
-            if (!info.name.includes('/') && !info.name.startsWith('d/'))
-                continue;
-            nameToModule.set(info.name, info.module);
-            const vars = new window.Map();
-            for (const v of runtime._variables) {
-                if (v._module !== info.module)
-                    continue;
-                if (v._name)
-                    vars.set(v._name, v);
-                if (v.pid)
-                    vars.set('__pid__' + v.pid, v);
-            }
-            nameToVars.set(info.name, vars);
-        }
-        const applyModule = (moduleId, defineFn) => {
-            const mod = nameToModule.get(moduleId);
-            if (!mod)
-                return;
-            const existingVars = nameToVars.get(moduleId) || new window.Map();
-            const cells = probeDefine(defineFn);
-            const seenPids = new Set();
-            for (const cell of cells) {
-                if (cell.type === 'import')
-                    continue;
-                if (!cell.pid)
-                    continue;
-                seenPids.add(cell.pid);
-                const existing = existingVars.get('__pid__' + cell.pid);
-                if (!existing) {
-                    const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                    const v = mod.variable();
-                    v.define(cell.name, cell.inputs, taggedDefn);
-                    v.pid = cell.pid;
-                    existingVars.set('__pid__' + cell.pid, v);
-                    if (cell.name)
-                        existingVars.set(cell.name, v);
-                    continue;
-                }
-                if (existing._definition) {
-                    const existingInputNames = existing._inputs.map(v => typeof v === 'string' ? v : v._name);
-                    const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                    const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                    if (inputsMatch && defnMatch)
-                        continue;
-                }
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            }
-            const ordered = [];
-            for (const cell of cells) {
-                if (!cell.pid)
-                    continue;
-                const v = existingVars.get('__pid__' + cell.pid);
-                if (v)
-                    ordered.push(v);
-            }
-            if (ordered.length) {
-                const orderedSet = new Set(ordered);
-                const arr = [...runtime._variables];
-                let oi = 0;
-                for (let i = 0; i < arr.length; i++) {
-                    if (orderedSet.has(arr[i]))
-                        arr[i] = ordered[oi++];
-                }
-                while (oi < ordered.length)
-                    arr.push(ordered[oi++]);
-                runtime._variables.clear();
-                for (const v of arr)
-                    runtime._variables.add(v);
-            }
-        };
-        const manifestUpdates = {};
-        let ok = 0, fail = 0;
-        for (const moduleId of syncableModules) {
-            try {
-                let file;
-                try {
-                    file = await readFile(directory, prefix + moduleId + '.js');
-                } catch (e) {
-                    file = null;
-                }
-                if (!file) {
-                    log('  skip ' + moduleId + ' (no .js on disk)');
-                    continue;
-                }
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
-                try {
-                    const mod = await window.importShim(url);
-                    if (typeof mod.default === 'function') {
-                        applyModule(moduleId, mod.default);
-                        log('  applied ' + moduleId);
-                        try {
-                            const after = await exportModuleJS(moduleId);
-                            manifestUpdates[moduleId] = hashSource(after.source);
-                        } catch (e) {
-                            manifestUpdates[moduleId] = hashSource(diskText);
-                        }
-                        ok++;
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                log('  FAILED: ' + moduleId + ' - ' + e.message);
-                fail++;
-            }
-        }
-        try {
-            await manifestWriter(directory, prefix, null, readFile, writeFile);
-            await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
-            log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
-        } catch (e) {
-            log('manifest write FAILED: ' + e.message);
-        }
-        try {
-            const view = $0;
-            const cb = view && view.querySelector ? view.querySelector('input') : null;
-            if (cb && !cb.checked) {
-                cb.checked = true;
-                view.value = true;
-                view.dispatchEvent(new window.Event('input', { bubbles: true }));
-                log('enabled Sync toggle');
-            } else if (cb && cb.checked) {
-                log('Sync toggle already enabled');
-            }
-        } catch (e) {
-            log('toggle enable FAILED: ' + e.message);
-        }
-        log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
-        syncBtn.textContent = 'Synced ' + ok + ' modules';
-        disBtn.disabled = false;
-        syncBtn.disabled = false;
-    };
-    container.value = undefined;
-    return container;
+      } catch (e) {
+        log('  FAILED: ' + moduleId + ' - ' + e.message);
+        fail++;
+      }
+    }
+    try {
+      await manifestWriter(directory, prefix, null, readFile, writeFile);
+      await manifestWriter(directory, prefix, manifestUpdates, readFile, writeFile);
+      log('wrote manifest (' + Object.keys(manifestUpdates).length + ' modules)');
+    } catch (e) {
+      log('manifest write FAILED: ' + e.message);
+    }
+    try {
+      const view = $0;
+      const cb = view && view.querySelector ? view.querySelector('input') : null;
+      if (cb && !cb.checked) {
+        cb.checked = true;
+        view.value = true;
+        view.dispatchEvent(new window.Event('input', { bubbles: true }));
+        log('enabled Sync toggle');
+      } else if (cb && cb.checked) {
+        log('Sync toggle already enabled');
+      }
+    } catch (e) {
+      log('toggle enable FAILED: ' + e.message);
+    }
+    log('\nDone: ' + ok + ' modules synced, ' + fail + ' failed');
+    syncBtn.textContent = 'Synced ' + ok + ' modules';
+    disBtn.disabled = false;
+    syncBtn.disabled = false;
+  };
+  container.value = undefined;
+  return container;
 };
 const _eoa5ga = (G, _) => G.input(_);
 const _1jyon1g = function _syncStatus(htl,directory,syncableModules,notebookToFiles,filesToNotebook){return(
@@ -20979,12 +20987,15 @@ const _ujgc0c = function _manifestWriter(){return(
     };
 })()
 )};
-const _1cy7bqk = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
+const _1wi1ddm = function _syncArmed(notebookId,$0,directory,syncEnabled,readFile,exportModuleJS,hashSource)
 {
     const disableToggle = reason => {
         console.warn('[file-sync] auto-disabled: ' + reason);
         const KEY = 'lopecode-file-sync:syncEnabled:' + notebookId;
-        window.localStorage.setItem(KEY, '0');
+        try {
+            window.localStorage.setItem(KEY, '0');   // throws on an opaque origin (blob: fork)
+        } catch (e) {
+        }
         if ($0 && $0.querySelector) {
             const cb = $0.querySelector('input');
             if (cb && cb.checked) {
@@ -21127,341 +21138,342 @@ const _1bf1rb4 = function _fileSyncLastSeen(directory)
     void directory;
     return new window.Map();
 };
-const _43mwl9 = function _filesToNotebook(directory, syncArmed, currentModules, fileSyncLastSeen, notebookId, runtime, probeDefine, tag, readFile, exportModuleJS, importShim, manifestWriter, hashSource, writeFile, getFileAttachmentsMap, invalidation) {
-    if (!directory)
-        return 'Waiting for directory...';
-    if (!syncArmed || !syncArmed.armed)
-        return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
-    const SKIP = new Set([
-        'bootloader',
-        'builtin'
-    ]);
-    const syncableModules = [];
-    for (const [mod, info] of currentModules) {
-        if (SKIP.has(info.name))
-            continue;
-        if (!info.name.includes('/') && !info.name.startsWith('d/'))
-            continue;
-        syncableModules.push(info.name);
+const _7bljmk = function _filesToNotebook(directory,syncArmed,currentModules,fileSyncLastSeen,notebookId,runtime,probeDefine,tag,readFile,exportModuleJS,manifestWriter,hashSource,writeFile,getFileAttachmentsMap,invalidation)
+{
+  if (!directory)
+    return 'Waiting for directory...';
+  if (!syncArmed || !syncArmed.armed)
+    return 'Sync inactive: ' + (syncArmed && syncArmed.reason || 'unknown');
+  const SKIP = new Set([
+    'bootloader',
+    'builtin'
+  ]);
+  const syncableModules = [];
+  for (const [mod, info] of currentModules) {
+    if (SKIP.has(info.name))
+      continue;
+    if (!info.name.includes('/') && !info.name.startsWith('d/'))
+      continue;
+    syncableModules.push(info.name);
+  }
+  const syncableSet = new Set(syncableModules);
+  const lastSeen = fileSyncLastSeen;
+  const POLL_MS = 1000;
+  const prefix = notebookId + '/';
+  const nameToModule = new window.Map();
+  const nameToVars = new window.Map();
+  for (const [mod, info] of currentModules) {
+    if (!syncableSet.has(info.name))
+      continue;
+    nameToModule.set(info.name, info.module);
+    const vars = new window.Map();
+    for (const v of runtime._variables) {
+      if (v._module !== info.module)
+        continue;
+      if (v._name)
+        vars.set(v._name, v);
+      if (v.pid)
+        vars.set('__pid__' + v.pid, v);
     }
-    const syncableSet = new Set(syncableModules);
-    const lastSeen = fileSyncLastSeen;
-    const POLL_MS = 1000;
-    const prefix = notebookId + '/';
-    const nameToModule = new window.Map();
-    const nameToVars = new window.Map();
-    for (const [mod, info] of currentModules) {
-        if (!syncableSet.has(info.name))
-            continue;
-        nameToModule.set(info.name, info.module);
-        const vars = new window.Map();
-        for (const v of runtime._variables) {
-            if (v._module !== info.module)
-                continue;
-            if (v._name)
-                vars.set(v._name, v);
-            if (v.pid)
-                vars.set('__pid__' + v.pid, v);
-        }
-        nameToVars.set(info.name, vars);
+    nameToVars.set(info.name, vars);
+  }
+  let pollTimer;
+  const knownFilePids = new window.Map();
+  let knownDiskModules = null;
+  const getModuleFA = mod => {
+    for (const v of runtime._variables) {
+      if (v._module === mod && v._name === 'FileAttachment' && v._value)
+        return v._value;
     }
-    let pollTimer;
-    const knownFilePids = new window.Map();
-    let knownDiskModules = null;
-    const getModuleFA = mod => {
-        for (const v of runtime._variables) {
-            if (v._module === mod && v._name === 'FileAttachment' && v._value)
-                return v._value;
-        }
-        return null;
-    };
-    const getSubDir = async (dirHandle, path) => {
-        let current = dirHandle;
-        for (const part of path.split('/').filter(Boolean)) {
-            current = await current.getDirectoryHandle(part);
-        }
-        return current;
-    };
-    const applyModule = (moduleId, defineFn) => {
-        const mod = nameToModule.get(moduleId);
-        if (!mod)
-            return;
-        const existingVars = nameToVars.get(moduleId) || new window.Map();
-        const cells = probeDefine(defineFn);
-        let redefinedSelf = false;
-        const seenPids = new Set();
-        for (const cell of cells) {
-            if (cell.type === 'import')
-                continue;
-            if (!cell.pid)
-                continue;
-            seenPids.add(cell.pid);
-            const existing = existingVars.get('__pid__' + cell.pid);
-            if (!existing) {
-                const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-                const v = mod.variable();
-                v.define(cell.name, cell.inputs, taggedDefn);
-                v.pid = cell.pid;
-                existingVars.set('__pid__' + cell.pid, v);
-                if (cell.name)
-                    existingVars.set(cell.name, v);
-                console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
-                continue;
-            }
-            if (existing._definition) {
-                const existingInputNames = existing._inputs.map(function (v) {
-                    return typeof v === 'string' ? v : v._name;
-                });
-                const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
-                const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
-                if (inputsMatch && defnMatch)
-                    continue;
-            }
-            const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
-            existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
-            if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
-                redefinedSelf = true;
-            }
-        }
-        const prevKnown = knownFilePids.get(moduleId);
-        if (prevKnown) {
-            for (const pid of prevKnown) {
-                if (seenPids.has(pid))
-                    continue;
-                const v = existingVars.get('__pid__' + pid);
-                if (!v)
-                    continue;
-                console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
-                v.delete();
-                existingVars.delete('__pid__' + pid);
-                if (v._name)
-                    existingVars.delete(v._name);
-            }
-        }
-        knownFilePids.set(moduleId, seenPids);
-        const ordered = [];
-        for (const cell of cells) {
-            if (!cell.pid)
-                continue;
-            const v = existingVars.get('__pid__' + cell.pid);
-            if (v)
-                ordered.push(v);
-        }
-        if (ordered.length) {
-            const orderedSet = new Set(ordered);
-            const arr = [...runtime._variables];
-            let oi = 0;
-            for (let i = 0; i < arr.length; i++) {
-                if (orderedSet.has(arr[i]))
-                    arr[i] = ordered[oi++];
-            }
-            while (oi < ordered.length)
-                arr.push(ordered[oi++]);
-            runtime._variables.clear();
-            for (const v of arr)
-                runtime._variables.add(v);
-        }
-        if (redefinedSelf) {
-            clearInterval(pollTimer);
-            console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
-        }
-    };
-    const pollModule = async moduleId => {
-        try {
-            let file;
+    return null;
+  };
+  const getSubDir = async (dirHandle, path) => {
+    let current = dirHandle;
+    for (const part of path.split('/').filter(Boolean)) {
+      current = await current.getDirectoryHandle(part);
+    }
+    return current;
+  };
+  const applyModule = (moduleId, defineFn) => {
+    const mod = nameToModule.get(moduleId);
+    if (!mod)
+      return;
+    const existingVars = nameToVars.get(moduleId) || new window.Map();
+    const cells = probeDefine(defineFn);
+    let redefinedSelf = false;
+    const seenPids = new Set();
+    for (const cell of cells) {
+      if (cell.type === 'import')
+        continue;
+      if (!cell.pid)
+        continue;
+      seenPids.add(cell.pid);
+      const existing = existingVars.get('__pid__' + cell.pid);
+      if (!existing) {
+        const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+        const v = mod.variable();
+        v.define(cell.name, cell.inputs, taggedDefn);
+        v.pid = cell.pid;
+        existingVars.set('__pid__' + cell.pid, v);
+        if (cell.name)
+          existingVars.set(cell.name, v);
+        console.log('[file-sync] created cell', cell.pid, cell.name || '(anonymous)');
+        continue;
+      }
+      if (existing._definition) {
+        const existingInputNames = existing._inputs.map(function (v) {
+          return typeof v === 'string' ? v : v._name;
+        });
+        const inputsMatch = JSON.stringify(existingInputNames) === JSON.stringify(cell.inputs);
+        const defnMatch = existing._definition.toString() === (cell.definition ? cell.definition.toString() : '');
+        if (inputsMatch && defnMatch)
+          continue;
+      }
+      const taggedDefn = cell.definition ? tag(cell.definition, { source: 'file-sync' }) : cell.definition;
+      existing.define(cell.name, cell.inputs, taggedDefn).pid = cell.pid;
+      if (moduleId === '@tomlarkworthy/file-sync' && cell.name === 'filesToNotebook') {
+        redefinedSelf = true;
+      }
+    }
+    const prevKnown = knownFilePids.get(moduleId);
+    if (prevKnown) {
+      for (const pid of prevKnown) {
+        if (seenPids.has(pid))
+          continue;
+        const v = existingVars.get('__pid__' + pid);
+        if (!v)
+          continue;
+        console.log('[file-sync] deleting cell', pid, v._name || '(anonymous)');
+        v.delete();
+        existingVars.delete('__pid__' + pid);
+        if (v._name)
+          existingVars.delete(v._name);
+      }
+    }
+    knownFilePids.set(moduleId, seenPids);
+    const ordered = [];
+    for (const cell of cells) {
+      if (!cell.pid)
+        continue;
+      const v = existingVars.get('__pid__' + cell.pid);
+      if (v)
+        ordered.push(v);
+    }
+    if (ordered.length) {
+      const orderedSet = new Set(ordered);
+      const arr = [...runtime._variables];
+      let oi = 0;
+      for (let i = 0; i < arr.length; i++) {
+        if (orderedSet.has(arr[i]))
+          arr[i] = ordered[oi++];
+      }
+      while (oi < ordered.length)
+        arr.push(ordered[oi++]);
+      runtime._variables.clear();
+      for (const v of arr)
+        runtime._variables.add(v);
+    }
+    if (redefinedSelf) {
+      clearInterval(pollTimer);
+      console.log('[file-sync] filesToNotebook redefined \u2014 stopping old poll timer');
+    }
+  };
+  const pollModule = async moduleId => {
+    try {
+      let file;
+      try {
+        file = await readFile(directory, prefix + moduleId + '.js');
+      } catch (e) {
+        file = null;
+      }
+      if (file) {
+        const prev = lastSeen.get(moduleId);
+        const changed = !prev || file.lastModified !== prev.lastModified;
+        if (changed) {
+          lastSeen.set(moduleId, { lastModified: file.lastModified });
+          const diskText = await file.text();
+          let needsApply = true;
+          try {
+            const runtimeResult = await exportModuleJS(moduleId);
+            if (runtimeResult.source === diskText)
+              needsApply = false;
+          } catch (e) {
+          }
+          if (needsApply) {
+            const blob = new window.Blob([diskText], { type: 'text/javascript' });
+            const url = window.URL.createObjectURL(blob);
             try {
-                file = await readFile(directory, prefix + moduleId + '.js');
-            } catch (e) {
-                file = null;
-            }
-            if (file) {
-                const prev = lastSeen.get(moduleId);
-                const changed = !prev || file.lastModified !== prev.lastModified;
-                if (changed) {
-                    lastSeen.set(moduleId, { lastModified: file.lastModified });
-                    const diskText = await file.text();
-                    let needsApply = true;
-                    try {
-                        const runtimeResult = await exportModuleJS(moduleId);
-                        if (runtimeResult.source === diskText)
-                            needsApply = false;
-                    } catch (e) {
-                    }
-                    if (needsApply) {
-                        const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                        const url = window.URL.createObjectURL(blob);
-                        try {
-                            const mod = await window.importShim(url);
-                            if (typeof mod.default === 'function') {
-                                applyModule(moduleId, mod.default);
-                                console.log('[file-sync] applied ' + moduleId + ' from disk');
-                                try {
-                                    const after = await exportModuleJS(moduleId);
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
-                                } catch (e) {
-                                    await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                                }
-                            }
-                        } finally {
-                            window.URL.revokeObjectURL(url);
-                        }
-                    }
-                }
-            }
-        } catch (e) {
-            console.error('[file-sync] poll error for ' + moduleId + ':', e);
-        }
-        try {
-            const attachDir = await getSubDir(directory, prefix + moduleId);
-            const mod = nameToModule.get(moduleId);
-            const FA = mod ? getModuleFA(mod) : null;
-            const faMap = FA ? getFileAttachmentsMap(FA) : null;
-            if (faMap) {
-                for (const key of [...faMap.keys()]) {
-                    if (key.endsWith('.crswap') || key.startsWith('.'))
-                        faMap.delete(key);
-                }
-            }
-            for await (const [name, handle] of attachDir) {
-                if (handle.kind !== 'file')
-                    continue;
-                if (name.endsWith('.crswap') || name.startsWith('.'))
-                    continue;
-                const file = await handle.getFile();
-                const attKey = '__att__' + moduleId + '/' + name;
-                const prevA = lastSeen.get(attKey);
-                if (prevA && file.lastModified === prevA.lastModified)
-                    continue;
-                lastSeen.set(attKey, { lastModified: file.lastModified });
-                const bytes = new Uint8Array(await file.arrayBuffer());
-                const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
-                const blobUrl = window.URL.createObjectURL(blob);
-                if (faMap) {
-                    faMap.set(name, {
-                        url: blobUrl,
-                        mimeType: file.type || 'application/octet-stream'
-                    });
-                    console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
-                }
-                const scriptId = moduleId + '/' + encodeURIComponent(name);
-                const script = document.getElementById(scriptId);
-                if (script) {
-                    const b64 = btoa(String.fromCharCode.apply(null, bytes));
-                    script.textContent = b64;
-                    script.setAttribute('data-encoding', 'base64');
-                    script.setAttribute('data-mime', file.type || 'application/octet-stream');
-                }
-            }
-        } catch (e) {
-            if (e.name !== 'NotFoundError')
-                console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
-        }
-    };
-    const scanDiskModules = async () => {
-        const diskModules = new Set();
-        try {
-            const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
-            for await (const [orgName, orgHandle] of notebookDir) {
-                if (orgHandle.kind !== 'directory')
-                    continue;
-                if (orgName.startsWith('@')) {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add(orgName + '/' + fname.slice(0, -3));
-                    }
-                } else if (orgName === 'd') {
-                    for await (const [fname, fhandle] of orgHandle) {
-                        if (fhandle.kind === 'file' && fname.endsWith('.js'))
-                            diskModules.add('d/' + fname.slice(0, -3));
-                    }
-                }
-            }
-        } catch (e) {
-        }
-        return diskModules;
-    };
-    const poll = async () => {
-        for (const moduleId of syncableModules)
-            await pollModule(moduleId);
-        const diskModules = await scanDiskModules();
-        const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
-        if (newOnDisk.length)
-            console.log('[file-sync] new modules on disk:', newOnDisk);
-        for (const moduleId of diskModules) {
-            if (syncableSet.has(moduleId))
-                continue;
-            if (nameToModule.has(moduleId))
-                continue;
-            try {
-                const file = await readFile(directory, prefix + moduleId + '.js');
-                const diskText = await file.text();
-                const blob = new window.Blob([diskText], { type: 'text/javascript' });
-                const url = window.URL.createObjectURL(blob);
+              const mod = await import(url);
+              if (typeof mod.default === 'function') {
+                applyModule(moduleId, mod.default);
+                console.log('[file-sync] applied ' + moduleId + ' from disk');
                 try {
-                    const imported = await window.importShim(url);
-                    if (typeof imported.default === 'function') {
-                        const newMod = runtime.module(imported.default, () => null);
-                        runtime.mains.set(moduleId, newMod);
-                        nameToModule.set(moduleId, newMod);
-                        syncableModules.push(moduleId);
-                        syncableSet.add(moduleId);
-                        const vars = new window.Map();
-                        for (const v of runtime._variables) {
-                            if (v._module !== newMod)
-                                continue;
-                            if (v._name)
-                                vars.set(v._name, v);
-                            if (v.pid)
-                                vars.set('__pid__' + v.pid, v);
-                        }
-                        nameToVars.set(moduleId, vars);
-                        console.log('[file-sync] added new module from disk: ' + moduleId);
-                        try {
-                            await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
-                        } catch (e) {
-                            console.error('[file-sync] manifest update for new module failed:', e);
-                        }
-                    }
-                } finally {
-                    window.URL.revokeObjectURL(url);
-                }
-            } catch (e) {
-                console.error('[file-sync] failed to add module ' + moduleId + ':', e);
-            }
-        }
-        if (knownDiskModules) {
-            for (const moduleId of knownDiskModules) {
-                if (diskModules.has(moduleId))
-                    continue;
-                if (!nameToModule.has(moduleId))
-                    continue;
-                const mod = nameToModule.get(moduleId);
-                for (const v of [...runtime._variables]) {
-                    if (v._module === mod)
-                        v.delete();
-                }
-                runtime.mains.delete(moduleId);
-                nameToModule.delete(moduleId);
-                nameToVars.delete(moduleId);
-                knownFilePids.delete(moduleId);
-                const idx = syncableModules.indexOf(moduleId);
-                if (idx !== -1)
-                    syncableModules.splice(idx, 1);
-                syncableSet.delete(moduleId);
-                console.log('[file-sync] removed module: ' + moduleId);
-                try {
-                    await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+                  const after = await exportModuleJS(moduleId);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(after.source) }, readFile, writeFile);
                 } catch (e) {
-                    console.error('[file-sync] manifest remove failed:', e);
+                  await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
                 }
+              }
+            } finally {
+              window.URL.revokeObjectURL(url);
             }
+          }
         }
-        knownDiskModules = diskModules;
-    };
-    pollTimer = setInterval(poll, POLL_MS);
-    poll();
-    invalidation.then(() => clearInterval(pollTimer));
-    return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
+      }
+    } catch (e) {
+      console.error('[file-sync] poll error for ' + moduleId + ':', e);
+    }
+    try {
+      const attachDir = await getSubDir(directory, prefix + moduleId);
+      const mod = nameToModule.get(moduleId);
+      const FA = mod ? getModuleFA(mod) : null;
+      const faMap = FA ? getFileAttachmentsMap(FA) : null;
+      if (faMap) {
+        for (const key of [...faMap.keys()]) {
+          if (key.endsWith('.crswap') || key.startsWith('.'))
+            faMap.delete(key);
+        }
+      }
+      for await (const [name, handle] of attachDir) {
+        if (handle.kind !== 'file')
+          continue;
+        if (name.endsWith('.crswap') || name.startsWith('.'))
+          continue;
+        const file = await handle.getFile();
+        const attKey = '__att__' + moduleId + '/' + name;
+        const prevA = lastSeen.get(attKey);
+        if (prevA && file.lastModified === prevA.lastModified)
+          continue;
+        lastSeen.set(attKey, { lastModified: file.lastModified });
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const blob = new window.Blob([bytes], { type: file.type || 'application/octet-stream' });
+        const blobUrl = window.URL.createObjectURL(blob);
+        if (faMap) {
+          faMap.set(name, {
+            url: blobUrl,
+            mimeType: file.type || 'application/octet-stream'
+          });
+          console.log('[file-sync] updated attachment ' + moduleId + '/' + name);
+        }
+        const scriptId = moduleId + '/' + encodeURIComponent(name);
+        const script = document.getElementById(scriptId);
+        if (script) {
+          const b64 = btoa(String.fromCharCode.apply(null, bytes));
+          script.textContent = b64;
+          script.setAttribute('data-encoding', 'base64');
+          script.setAttribute('data-mime', file.type || 'application/octet-stream');
+        }
+      }
+    } catch (e) {
+      if (e.name !== 'NotFoundError')
+        console.error('[file-sync] attachment scan error for ' + moduleId + ':', e);
+    }
+  };
+  const scanDiskModules = async () => {
+    const diskModules = new Set();
+    try {
+      const notebookDir = await getSubDir(directory, prefix.slice(0, -1));
+      for await (const [orgName, orgHandle] of notebookDir) {
+        if (orgHandle.kind !== 'directory')
+          continue;
+        if (orgName.startsWith('@')) {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add(orgName + '/' + fname.slice(0, -3));
+          }
+        } else if (orgName === 'd') {
+          for await (const [fname, fhandle] of orgHandle) {
+            if (fhandle.kind === 'file' && fname.endsWith('.js'))
+              diskModules.add('d/' + fname.slice(0, -3));
+          }
+        }
+      }
+    } catch (e) {
+    }
+    return diskModules;
+  };
+  const poll = async () => {
+    for (const moduleId of syncableModules)
+      await pollModule(moduleId);
+    const diskModules = await scanDiskModules();
+    const newOnDisk = [...diskModules].filter(m => !syncableSet.has(m) && !nameToModule.has(m));
+    if (newOnDisk.length)
+      console.log('[file-sync] new modules on disk:', newOnDisk);
+    for (const moduleId of diskModules) {
+      if (syncableSet.has(moduleId))
+        continue;
+      if (nameToModule.has(moduleId))
+        continue;
+      try {
+        const file = await readFile(directory, prefix + moduleId + '.js');
+        const diskText = await file.text();
+        const blob = new window.Blob([diskText], { type: 'text/javascript' });
+        const url = window.URL.createObjectURL(blob);
+        try {
+          const imported = await import(url);
+          if (typeof imported.default === 'function') {
+            const newMod = runtime.module(imported.default, () => null);
+            runtime.mains.set(moduleId, newMod);
+            nameToModule.set(moduleId, newMod);
+            syncableModules.push(moduleId);
+            syncableSet.add(moduleId);
+            const vars = new window.Map();
+            for (const v of runtime._variables) {
+              if (v._module !== newMod)
+                continue;
+              if (v._name)
+                vars.set(v._name, v);
+              if (v.pid)
+                vars.set('__pid__' + v.pid, v);
+            }
+            nameToVars.set(moduleId, vars);
+            console.log('[file-sync] added new module from disk: ' + moduleId);
+            try {
+              await manifestWriter(directory, prefix, { [moduleId]: hashSource(diskText) }, readFile, writeFile);
+            } catch (e) {
+              console.error('[file-sync] manifest update for new module failed:', e);
+            }
+          }
+        } finally {
+          window.URL.revokeObjectURL(url);
+        }
+      } catch (e) {
+        console.error('[file-sync] failed to add module ' + moduleId + ':', e);
+      }
+    }
+    if (knownDiskModules) {
+      for (const moduleId of knownDiskModules) {
+        if (diskModules.has(moduleId))
+          continue;
+        if (!nameToModule.has(moduleId))
+          continue;
+        const mod = nameToModule.get(moduleId);
+        for (const v of [...runtime._variables]) {
+          if (v._module === mod)
+            v.delete();
+        }
+        runtime.mains.delete(moduleId);
+        nameToModule.delete(moduleId);
+        nameToVars.delete(moduleId);
+        knownFilePids.delete(moduleId);
+        const idx = syncableModules.indexOf(moduleId);
+        if (idx !== -1)
+          syncableModules.splice(idx, 1);
+        syncableSet.delete(moduleId);
+        console.log('[file-sync] removed module: ' + moduleId);
+        try {
+          await manifestWriter(directory, prefix, { [moduleId]: null }, readFile, writeFile);
+        } catch (e) {
+          console.error('[file-sync] manifest remove failed:', e);
+        }
+      }
+    }
+    knownDiskModules = diskModules;
+  };
+  pollTimer = setInterval(poll, POLL_MS);
+  poll();
+  invalidation.then(() => clearInterval(pollTimer));
+  return 'Polling ' + syncableModules.length + ' modules every ' + POLL_MS + 'ms...';
 };
 const _1b4kluo = function _21(md){return(
 md`## How It Works
@@ -21510,7 +21522,6 @@ md`## TODO
 - **Import cell validation**: verify import bridges survive round-trip correctly
 - **Conflict resolution**: when both disk and runtime edit the same cell simultaneously, detect and surface the conflict instead of last-write-wins`
 )};
-
 const _qq3v7b = function _jbApply(importShim)
 {
   // Pure factory so any notebook can reuse it over its own runtime/fs. Build with
@@ -21758,9 +21769,9 @@ export default function define(runtime, observer) {
   $def("_1th1rci", null, ["md"], _1th1rci);  
   $def("_1t1i3ml", "viewof directory", ["notebookId","htl","hashParam","location","history"], _1t1i3ml);  
   $def("_jnt0bt", "directory", ["Generators","viewof directory"], _jnt0bt);  
-  $def("_yqx7l8", "viewof syncEnabled", ["notebookId","htl"], _yqx7l8);  
+  $def("_1rbt7m0", "viewof syncEnabled", ["notebookId","htl"], _1rbt7m0);  
   $def("_xltqf6", "syncEnabled", ["Generators","viewof syncEnabled"], _xltqf6);  
-  $def("_1mb10vh", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","importShim","viewof syncEnabled"], _1mb10vh);  
+  $def("_1nuhj4u", "viewof disassemble", ["htl","directory","notebookId","manifestWriter","readFile","writeFile","syncableModules","exportModuleJS","hashSource","currentModules","runtime","probeDefine","tag","viewof syncEnabled"], _1nuhj4u);  
   $def("_eoa5ga", "disassemble", ["Generators","viewof disassemble"], _eoa5ga);  
   $def("_1jyon1g", "syncStatus", ["htl","directory","syncableModules","notebookToFiles","filesToNotebook"], _1jyon1g);  
   $def("_1dl3i63", null, ["md"], _1dl3i63);  
@@ -21774,10 +21785,10 @@ export default function define(runtime, observer) {
   $def("_vxwmfh", "probeDefine", [], _vxwmfh);  
   $def("_7ajapw", "hashSource", [], _7ajapw);  
   $def("_ujgc0c", "manifestWriter", [], _ujgc0c);  
-  $def("_1cy7bqk", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1cy7bqk);  
+  $def("_1wi1ddm", "syncArmed", ["notebookId","viewof syncEnabled","directory","syncEnabled","readFile","exportModuleJS","hashSource"], _1wi1ddm);  
   $def("_3zm0bx", "notebookToFiles", ["directory","syncArmed","currentModules","notebookId","exportModuleJS","writeFile","manifestWriter","hashSource","readFile","onCodeChange","invalidation"], _3zm0bx);  
   $def("_1bf1rb4", "fileSyncLastSeen", ["directory"], _1bf1rb4);  
-  $def("_43mwl9", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","importShim","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _43mwl9);  
+  $def("_7bljmk", "filesToNotebook", ["directory","syncArmed","currentModules","fileSyncLastSeen","notebookId","runtime","probeDefine","tag","readFile","exportModuleJS","manifestWriter","hashSource","writeFile","getFileAttachmentsMap","invalidation"], _7bljmk);  
   $def("_1b4kluo", null, ["md"], _1b4kluo);  
   $def("_1h2nj16", null, ["md"], _1h2nj16);  
   main.define("viewof currentModules", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("viewof currentModules", _));  
@@ -21787,8 +21798,8 @@ export default function define(runtime, observer) {
   main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
   main.define("tag", ["module @tomlarkworthy/local-change-history", "@variable"], (_, v) => v.import("tag", _));  
-  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));
-  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);  
+  main.define("getFileAttachmentsMap", ["module @tomlarkworthy/fileattachments", "@variable"], (_, v) => v.import("getFileAttachmentsMap", _));  
+  $def("_qq3v7b", "jbApply", ["importShim"], _qq3v7b);
   return main;
 }</script>
 


### PR DESCRIPTION
Companion PR (file-sync half): tomlarkworthy/lopebooks#121.

## Reported symptom

After forking a notebook to a tab, "claude code pairing" stops working:

```
cc_chat = RuntimeError: Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.
fileSyncPanel = RuntimeError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.
```

## Root cause

Fork-to-tab opens the notebook as `blob:null/<uuid>` — an **opaque origin**, because the parent is `file://`. There, merely *reading* the `window.sessionStorage` / `window.localStorage` property throws `SecurityError`.

Two independent origin cells:

1. **`cc_ws`** (this module) declared the `sessionStorage` stdlib builtin as a **cell input**. The throw therefore happens during *dependency resolution*, before the cell body — and the `try/catch` blocks already wrapping both call sites — ever run. A cell-level try/catch cannot guard an input.
2. **`syncEnabled`** (`@tomlarkworthy/file-sync`, companion PR) read `window.localStorage` unguarded in its body.

Everything downstream was collateral via Observable's error propagation:

```
cc_ws               = RuntimeError: ...sessionStorage...   <- origin
cc_chat             = RuntimeError: ...sessionStorage...   <- via cc_ws
cc_change_forwarder = RuntimeError: ...sessionStorage...   <- via cc_ws
fileSyncPanel       = RuntimeError: ...localStorage...     <- via syncEnabled
```

So the report understated it: the whole pairing websocket was down in every forked tab, not just the chat pane.

## Fix

Drop `sessionStorage` from `cc_ws`'s input list and read `window.sessionStorage` at the two call sites, which are already inside `try/catch`. The property read now happens lazily inside a guard instead of eagerly during dependency resolution. Using `window.sessionStorage` rather than a bare identifier also stops Observable re-capturing the builtin as an input on the next round-trip.

## Verification

`tools/probe-fork-storage.ts` boots the notebook, clicks exporter-3's **Fork**, attaches to the real `blob:null` popup, and reads back rendered errors plus a functional check. `tools/probe-fork-pairing-connect.ts` does the same with a live pairing token. Baseline vs patched:

| | baseline fork | patched fork |
|---|---|---|
| storage `RuntimeError`s | 5 | **0** |
| pairing status | `disconnected` | **`connected`** |
| channel-side registration | never arrived | **logged** (`blob:null/…` connected) |
| `Sync enabled` checkbox | ✗ absent | ✓ renders, toggles without throwing |
| `Pick sync directory` | ✗ absent | ✓ present |

No regression on the normal `file://` path (`tools/probe-fork-storage-regression.ts`): `syncEnabled` still persists to `localStorage`, `sessionStorage` still writable, parent rendered-error set byte-identical before and after.

Corpus gate: `lope-preflight.ts` differential against these worktrees at `origin/main` — **0 NEW, 0 resolved** across 227 notebooks.

## Chain

Cell pushed to ObservableHQ (v1883) → re-jumpgated the canonical → synced into 49 consumers (`updated=49 inserted=0`).

**Rebased onto `34046a9`.** Worth noting: the jumpgate bundle carried the *pre-sweep* `exporter-3` (the light-DOM prerender change is local, not yet on Observable), so merging the original branch would have silently reverted that sweep in these files. The rebase takes `exporter-3` from current `main` and re-applies only the two fixed module blocks. Verified swept `exporter-3` is intact across both repos.

## Out of scope (pre-existing, not fork-related)

- `RuntimeError: fileSyncTools is not defined` — `claude-code-pairing` imports `fileSyncTools` from `file-sync`, which has never defined it (not in the corpus, not on Observable, not in any commit). Present on `file://` too. Dead plumbing for the dynamic-MCP-tools mechanism; deliberately left alone.
- `IDBFactory ... denied in this context` in forks — already caught at every call site, so `directory` degrades gracefully.