### PR TITLE
Fix: order exporter-3 content modules by size, smallest first

### DIFF
--- a/notebooks/@tomlarkworthy_exporter-3.html
+++ b/notebooks/@tomlarkworthy_exporter-3.html
@@ -1979,15 +1979,20 @@ module => {
 )};
 const _g0wr2v = function _streamingModuleOrder()
 {
-  return (mainNames, specByName) => {
-    // Deterministic, churn-free order: bootconf-declared mains first so a notebook's own page/entry
-    // modules stream before anything else, then every other module — each group sorted alphabetically.
-    // Order depends only on the set of module names (not on the import graph), so re-exporting an
-    // unchanged notebook produces byte-identical block order. Each module's FileAttachment blocks
-    // already precede its source (see lopemodule), so define-time contentSync never misses.
+  return (mainNames, specByName, blockByName) => {
+    // Small blocks first, so each one unblocks the parser sooner: bootconf-declared mains lead (they
+    // boot the page), then every other module in ascending emitted-block size — the biggest module,
+    // which stalls the parser longest, lands last. `blockByName` holds each module's already-rendered
+    // block, which includes its FileAttachment blocks (they must stay adjacent to their module, see
+    // lopemodule), so an attachment-heavy module sorts by its real weight. Without it, fall back to
+    // the source length. Ties break alphabetically, so order depends only on content and re-exporting
+    // an unchanged notebook still produces byte-identical block order. The import graph is ignored:
+    // define-time contentSync only needs each module's own attachments to precede it.
+    const sizeOf = name => blockByName?.get(name)?.length ?? specByName.get(name)?.source?.length ?? 0;
+    const bySize = (a, b) => sizeOf(a) - sizeOf(b) || (a < b ? -1 : a > b ? 1 : 0);
     const mains = new Set(mainNames.filter(n => specByName.has(n)));
-    const lead = [...mains].sort();
-    const rest = [...specByName.keys()].filter(n => !mains.has(n)).sort();
+    const lead = [...mains].sort(bySize);
+    const rest = [...specByName.keys()].filter(n => !mains.has(n)).sort(bySize);
     return [
       ...lead,
       ...rest
@@ -2004,8 +2009,14 @@ const _e1usrg = function _book(task,inlineModule,inlineGzipModule,es_module_shim
       inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz),
       inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz)
     ].join('\n');
-    const orderedNames = streamingModuleOrder([...task.mains.keys()], module_specs);
-    const userBlocks = (await Promise.all(orderedNames.map(name => lopemodule(module_specs.get(name))))).join('');
+    // Render every block first (same total work — they already all rendered in parallel), so the
+    // order can be decided on the emitted byte size rather than an estimate.
+    const blockByName = new Map(await Promise.all([...module_specs.keys()].map(async name => [
+      name,
+      await lopemodule(module_specs.get(name))
+    ])));
+    const orderedNames = streamingModuleOrder([...task.mains.keys()], module_specs, blockByName);
+    const userBlocks = orderedNames.map(name => blockByName.get(name)).join('');
     const bootloader = task.options.bootloader || '@tomlarkworthy/bootloader';
     const tickLine = task.options.tick != null ? `,\n  "tick": ${ JSON.stringify(task.options.tick) }` : '';
     const tickDelayLine = task.options.tickDelayMs != null ? `,\n  "tickDelayMs": ${ JSON.stringify(task.options.tickDelayMs) }` : '';
@@ -2502,9 +2513,9 @@ const _13d3rb0 = function _test_streaming_order_prioritizes_mains(expect,streami
     '@u/lib',
     '@u/junk'
   ]);
-  // single main leads, then everything else alphabetically (imports are ignored)
+  // equal size (no blocks, no source) degrades to alphabetical; main still leads
   expect(streamingModuleOrder(['@u/app'], specByName).join(',')).toBe('@u/app,@u/junk,@u/lib');
-  // multiple mains are themselves alphabetical and still lead
+  // multiple mains lead, alphabetically among themselves at equal size
   expect(streamingModuleOrder([
     '@u/lib',
     '@u/app'
@@ -2517,6 +2528,80 @@ const _13d3rb0 = function _test_streaming_order_prioritizes_mains(expect,streami
   ])).join(',')).toBe('@u/app,@u/junk,@u/lib');
   // unknown main is ignored; every module still present exactly once
   expect(streamingModuleOrder(['@u/missing'], specByName).join(',')).toBe('@u/app,@u/junk,@u/lib');
+  return 'ok';
+};
+const _1pz36ta = function _test_streaming_order_smallest_first(expect,streamingModuleOrder)
+{
+  const specByName = new Map([
+    '@u/app',
+    '@u/big',
+    '@u/mid',
+    '@u/small'
+  ].map(n => [
+    n,
+    {
+      url: n,
+      imports: []
+    }
+  ]));
+  const blocks = new Map([
+    [
+      '@u/app',
+      'x'.repeat(10)
+    ],
+    [
+      '@u/big',
+      'x'.repeat(900)
+    ],
+    [
+      '@u/mid',
+      'x'.repeat(90)
+    ],
+    [
+      '@u/small',
+      'x'.repeat(9)
+    ]
+  ]);
+  // main leads regardless of size, then ascending block size — the biggest lands last
+  expect(streamingModuleOrder(['@u/app'], specByName, blocks).join(',')).toBe('@u/app,@u/small,@u/mid,@u/big');
+  // an attachment-heavy module sorts by the whole block, not by its source
+  const withFiles = new Map(blocks);
+  withFiles.set('@u/small', 'x'.repeat(5000));
+  expect(streamingModuleOrder(['@u/app'], specByName, withFiles).join(',')).toBe('@u/app,@u/mid,@u/big,@u/small');
+  // no blocks: fall back to source length
+  const sourced = new Map([
+    [
+      '@u/big',
+      {
+        url: '@u/big',
+        source: 'x'.repeat(900)
+      }
+    ],
+    [
+      '@u/small',
+      {
+        url: '@u/small',
+        source: 'x'.repeat(9)
+      }
+    ]
+  ]);
+  expect(streamingModuleOrder([], sourced).join(',')).toBe('@u/small,@u/big');
+  // equal sizes tie-break alphabetically, so the order stays deterministic
+  const tied = new Map([
+    [
+      '@u/b',
+      'x'.repeat(10)
+    ],
+    [
+      '@u/a',
+      'x'.repeat(10)
+    ]
+  ]);
+  const tiedSpecs = new Map([...tied.keys()].map(n => [
+    n,
+    { url: n }
+  ]));
+  expect(streamingModuleOrder([], tiedSpecs, tied).join(',')).toBe('@u/a,@u/b');
   return 'ok';
 };
 const _18z61zg = function _test_streaming_order_runtime(Runtime,streamingModuleOrder,expect)
@@ -2555,7 +2640,7 @@ const _18z61zg = function _test_streaming_order_runtime(Runtime,streamingModuleO
   }
   const order = streamingModuleOrder(['@u/app'], specByName);
   expect(order.join(',')).toBe('@u/app,@u/junk,@u/lib');
-  // main first, then the rest alphabetically
+  // main first, then the rest — no sizes available here, so alphabetical
   return 'ok';
 };
 const _1didxs7 = function _test_restoreCanonicalImports(restoreCanonicalImports,expect)
@@ -3159,6 +3244,7 @@ export default function define(runtime, observer) {
   $def("_1d9ux6v", "test_lopebook_main_at_top_with_sentinel", ["lopebook","expect"], _1d9ux6v);
   $def("_1c8v2ne", "test_lopebook_agent_orientation", ["lopebook","expect"], _1c8v2ne);
   $def("_13d3rb0", "test_streaming_order_prioritizes_mains", ["expect","streamingModuleOrder"], _13d3rb0);  
+  $def("_1pz36ta", "test_streaming_order_smallest_first", ["expect","streamingModuleOrder"], _1pz36ta);
   $def("_18z61zg", "test_streaming_order_runtime", ["Runtime","streamingModuleOrder","expect"], _18z61zg);  
   $def("_1didxs7", "test_restoreCanonicalImports", ["restoreCanonicalImports","expect"], _1didxs7);  
   $def("_ogm44p", "test_restoreCanonicalImports_preserves_source", ["expect","restoreCanonicalImports"], _ogm44p);  

--- a/notebooks/jumpgates.html
+++ b/notebooks/jumpgates.html
@@ -12792,15 +12792,20 @@ module => {
 )};
 const _g0wr2v = function _streamingModuleOrder()
 {
-  return (mainNames, specByName) => {
-    // Deterministic, churn-free order: bootconf-declared mains first so a notebook's own page/entry
-    // modules stream before anything else, then every other module — each group sorted alphabetically.
-    // Order depends only on the set of module names (not on the import graph), so re-exporting an
-    // unchanged notebook produces byte-identical block order. Each module's FileAttachment blocks
-    // already precede its source (see lopemodule), so define-time contentSync never misses.
+  return (mainNames, specByName, blockByName) => {
+    // Small blocks first, so each one unblocks the parser sooner: bootconf-declared mains lead (they
+    // boot the page), then every other module in ascending emitted-block size — the biggest module,
+    // which stalls the parser longest, lands last. `blockByName` holds each module's already-rendered
+    // block, which includes its FileAttachment blocks (they must stay adjacent to their module, see
+    // lopemodule), so an attachment-heavy module sorts by its real weight. Without it, fall back to
+    // the source length. Ties break alphabetically, so order depends only on content and re-exporting
+    // an unchanged notebook still produces byte-identical block order. The import graph is ignored:
+    // define-time contentSync only needs each module's own attachments to precede it.
+    const sizeOf = name => blockByName?.get(name)?.length ?? specByName.get(name)?.source?.length ?? 0;
+    const bySize = (a, b) => sizeOf(a) - sizeOf(b) || (a < b ? -1 : a > b ? 1 : 0);
     const mains = new Set(mainNames.filter(n => specByName.has(n)));
-    const lead = [...mains].sort();
-    const rest = [...specByName.keys()].filter(n => !mains.has(n)).sort();
+    const lead = [...mains].sort(bySize);
+    const rest = [...specByName.keys()].filter(n => !mains.has(n)).sort(bySize);
     return [
       ...lead,
       ...rest
@@ -12817,8 +12822,14 @@ const _e1usrg = function _book(task,inlineModule,inlineGzipModule,es_module_shim
       inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz),
       inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz)
     ].join('\n');
-    const orderedNames = streamingModuleOrder([...task.mains.keys()], module_specs);
-    const userBlocks = (await Promise.all(orderedNames.map(name => lopemodule(module_specs.get(name))))).join('');
+    // Render every block first (same total work — they already all rendered in parallel), so the
+    // order can be decided on the emitted byte size rather than an estimate.
+    const blockByName = new Map(await Promise.all([...module_specs.keys()].map(async name => [
+      name,
+      await lopemodule(module_specs.get(name))
+    ])));
+    const orderedNames = streamingModuleOrder([...task.mains.keys()], module_specs, blockByName);
+    const userBlocks = orderedNames.map(name => blockByName.get(name)).join('');
     const bootloader = task.options.bootloader || '@tomlarkworthy/bootloader';
     const tickLine = task.options.tick != null ? `,\n  "tick": ${ JSON.stringify(task.options.tick) }` : '';
     const tickDelayLine = task.options.tickDelayMs != null ? `,\n  "tickDelayMs": ${ JSON.stringify(task.options.tickDelayMs) }` : '';
@@ -13315,9 +13326,9 @@ const _13d3rb0 = function _test_streaming_order_prioritizes_mains(expect,streami
     '@u/lib',
     '@u/junk'
   ]);
-  // single main leads, then everything else alphabetically (imports are ignored)
+  // equal size (no blocks, no source) degrades to alphabetical; main still leads
   expect(streamingModuleOrder(['@u/app'], specByName).join(',')).toBe('@u/app,@u/junk,@u/lib');
-  // multiple mains are themselves alphabetical and still lead
+  // multiple mains lead, alphabetically among themselves at equal size
   expect(streamingModuleOrder([
     '@u/lib',
     '@u/app'
@@ -13330,6 +13341,80 @@ const _13d3rb0 = function _test_streaming_order_prioritizes_mains(expect,streami
   ])).join(',')).toBe('@u/app,@u/junk,@u/lib');
   // unknown main is ignored; every module still present exactly once
   expect(streamingModuleOrder(['@u/missing'], specByName).join(',')).toBe('@u/app,@u/junk,@u/lib');
+  return 'ok';
+};
+const _1pz36ta = function _test_streaming_order_smallest_first(expect,streamingModuleOrder)
+{
+  const specByName = new Map([
+    '@u/app',
+    '@u/big',
+    '@u/mid',
+    '@u/small'
+  ].map(n => [
+    n,
+    {
+      url: n,
+      imports: []
+    }
+  ]));
+  const blocks = new Map([
+    [
+      '@u/app',
+      'x'.repeat(10)
+    ],
+    [
+      '@u/big',
+      'x'.repeat(900)
+    ],
+    [
+      '@u/mid',
+      'x'.repeat(90)
+    ],
+    [
+      '@u/small',
+      'x'.repeat(9)
+    ]
+  ]);
+  // main leads regardless of size, then ascending block size — the biggest lands last
+  expect(streamingModuleOrder(['@u/app'], specByName, blocks).join(',')).toBe('@u/app,@u/small,@u/mid,@u/big');
+  // an attachment-heavy module sorts by the whole block, not by its source
+  const withFiles = new Map(blocks);
+  withFiles.set('@u/small', 'x'.repeat(5000));
+  expect(streamingModuleOrder(['@u/app'], specByName, withFiles).join(',')).toBe('@u/app,@u/mid,@u/big,@u/small');
+  // no blocks: fall back to source length
+  const sourced = new Map([
+    [
+      '@u/big',
+      {
+        url: '@u/big',
+        source: 'x'.repeat(900)
+      }
+    ],
+    [
+      '@u/small',
+      {
+        url: '@u/small',
+        source: 'x'.repeat(9)
+      }
+    ]
+  ]);
+  expect(streamingModuleOrder([], sourced).join(',')).toBe('@u/small,@u/big');
+  // equal sizes tie-break alphabetically, so the order stays deterministic
+  const tied = new Map([
+    [
+      '@u/b',
+      'x'.repeat(10)
+    ],
+    [
+      '@u/a',
+      'x'.repeat(10)
+    ]
+  ]);
+  const tiedSpecs = new Map([...tied.keys()].map(n => [
+    n,
+    { url: n }
+  ]));
+  expect(streamingModuleOrder([], tiedSpecs, tied).join(',')).toBe('@u/a,@u/b');
   return 'ok';
 };
 const _18z61zg = function _test_streaming_order_runtime(Runtime,streamingModuleOrder,expect)
@@ -13368,7 +13453,7 @@ const _18z61zg = function _test_streaming_order_runtime(Runtime,streamingModuleO
   }
   const order = streamingModuleOrder(['@u/app'], specByName);
   expect(order.join(',')).toBe('@u/app,@u/junk,@u/lib');
-  // main first, then the rest alphabetically
+  // main first, then the rest — no sizes available here, so alphabetical
   return 'ok';
 };
 const _1didxs7 = function _test_restoreCanonicalImports(restoreCanonicalImports,expect)
@@ -13972,6 +14057,7 @@ export default function define(runtime, observer) {
   $def("_1d9ux6v", "test_lopebook_main_at_top_with_sentinel", ["lopebook","expect"], _1d9ux6v);
   $def("_1c8v2ne", "test_lopebook_agent_orientation", ["lopebook","expect"], _1c8v2ne);
   $def("_13d3rb0", "test_streaming_order_prioritizes_mains", ["expect","streamingModuleOrder"], _13d3rb0);  
+  $def("_1pz36ta", "test_streaming_order_smallest_first", ["expect","streamingModuleOrder"], _1pz36ta);
   $def("_18z61zg", "test_streaming_order_runtime", ["Runtime","streamingModuleOrder","expect"], _18z61zg);  
   $def("_1didxs7", "test_restoreCanonicalImports", ["restoreCanonicalImports","expect"], _1didxs7);  
   $def("_ogm44p", "test_restoreCanonicalImports_preserves_source", ["expect","restoreCanonicalImports"], _ogm44p);  


### PR DESCRIPTION
Ordering of the content modules an exported notebook streams.

## Reported symptom

`@tomlarkworthy/exporter-3` serialises the bootconf `mains` first, to make the most of streaming loading, but everything after them is emitted alphabetically. Alphabetical order is unrelated to how long a block takes to parse, so a large module can land early and stall every small module queued behind it.

Block order in the pre-fix `@tomlarkworthy_exporter-3.html`, with emitted sizes, after the mains:

```
@mbostock/safe-local-storage          56K
@tomlarkworthy/acorn-8-11-3          357K   <- 357K parsed before ...
@tomlarkworthy/codemirror-6-v2        52K
@tomlarkworthy/dataflow-templating     37K
@tomlarkworthy/editor-5              171K
...
@tomlarkworthy/inspector             8.5K   <- ... an 8.5K module
```

## Root cause

`streamingModuleOrder` sorted both groups with a bare `.sort()`. The comment explained the choice as churn-avoidance: order depended only on the *set* of module names, so re-exporting an unchanged notebook was byte-identical. That property is preserved by any content-derived key, and size is a content-derived key that also tracks parse cost.

## Fix

Two cells in `@tomlarkworthy/exporter-3`:

- **`streamingModuleOrder`** takes a third argument, `blockByName`, and sorts each group by `blockByName.get(name).length` ascending, tie-breaking alphabetically. Mains still lead. Falls back to `spec.source.length`, then 0, when no blocks are supplied — so the two existing tests, which pass no sizes, still describe alphabetical order.
- **`book`** renders every module block before ordering, rather than rendering in already-decided order. Same total work — the blocks were already rendered concurrently under one `Promise.all` — but the sort now runs on exact emitted bytes rather than an estimate.

Sizing on the rendered block is what makes the size include file attachments: `lopemodule` emits a module's `FileAttachment` blocks immediately before its source, and they have to stay adjacent (define-time `contentSync` reads them), so the rendered block already is module + attachments. `@tomlarkworthy/codemirror-6-v2` is 6K of module and 233K of gzipped attachment; it sorts as 239K. Sorting whole rendered blocks also means a module can never be separated from its own attachments — a reordering that split them would drop the attachments silently, with no console error.

Determinism is unchanged: sizes come from content, ties break by name. A one-byte edit only reorders two modules if they were within a byte of each other.

## Files

- `notebooks/@tomlarkworthy_exporter-3.html` — the canonical.
- `notebooks/jumpgates.html` — the same module block. `jumpgates.html` hosts both `@tomlarkworthy/jumpgate` and `@tomlarkworthy/bulk-jumpgate` and bundles its own `exporter-3`; without this, every notebook jumpgated down would come back alphabetically ordered, undoing the fix.

## Verification

**Unit tests** (`run_tests`, on the canonical bundle):

- `test_streaming_order_prioritizes_mains` — unchanged expectations; no sizes supplied, so alphabetical
- `test_streaming_order_runtime` — unchanged
- `test_streaming_order_smallest_first` — new: size order, attachment weight, source fallback, alphabetical tie-break
- `test_lopebook_main_at_top_with_sentinel`, `test_lopebook_agent_orientation` — unchanged

**Real export from the live runtime**, mains supplied explicitly:

```
   10390  @tomlarkworthy/save-in-place        main
   85092  @tomlarkworthy/lopepage-2           main
  132118  @tomlarkworthy/exporter-3           main
    1484  @tomlarkworthy/dom-view
    2002  @mbostock/safe-local-storage
     ...  (ascending)
  239270  @tomlarkworthy/codemirror-6-v2
```

Block start offsets in the emitted file confirm each module's attachment blocks still sit immediately before its source (e.g. `@tomlarkworthy/inspector/inspector-5%401.0.1.js.gz` at 573175, `@tomlarkworthy/inspector` at 578841).

**Boot** — re-opened the exported file: 45 modules booted, console clean, no page errors.

## Pushed to ObservableHQ

`streamingModuleOrder`, `book` and the three streaming-order tests pushed via `lope-push-ws --cells` (4 modified in place, 1 inserted; version 17211 → 17216). Verified by loading Observable's recompiled `@tomlarkworthy/exporter-3.js` into a headless runtime and re-running the ordering cases — identical results, so the decompile/recompile round trip is clean.

## Jumpgate: exercised, output not committed

The fixed `exporter-3` was injected into `jumpgates.html` and `@tomlarkworthy/exporter-3` was jumpgated down from Observable v17216. The **module round-trips correctly**: the regenerated bundle boots (44 modules, console clean), all three streaming-order tests pass, and its own block layout is size-ordered — so the fix survives a full push/jumpgate cycle.

The **bundle**, however, regresses, so the jumpgated file is not what this PR ships:

| | committed canonical | jumpgated output |
|---|---|---|
| modules matching their declared canonical | 39 | 16 |
| modules differing | 1 (`observablejs-toolchain`) | 23 |
| modules dropped | — | `save-in-place`, `module-selection`, `golden-layout-2-6-0`, `import-notebook` |

The default `--frame @tomlarkworthy/lopepage` also downgrades the frame from `lopepage-2` and rewrites the bootconf hash; `--frame @tomlarkworthy/lopepage-2` fixes the frame but not the drops. `lope-jumpgate.js` has no way to declare extra mains, so it cannot reproduce this notebook's `[lopepage-2, exporter-3, save-in-place]` shape. The committed canonical is the `sync-module` result, which touches only the one module block.

## Not done

**No consumer sync** (requested). The notebooks that embed `@tomlarkworthy/exporter-3` still carry the alphabetical ordering and will pick this up on their next re-export or sweep.

Generated with [Claude Code](https://claude.com/claude-code)