### PR TITLE
Fix: drive cellMap from the streaming @tomlarkworthy/modules, not module-map

### DIFF
--- a/notebooks/@tomlarkworthy_cell-map.html
+++ b/notebooks/@tomlarkworthy_cell-map.html
@@ -1454,14 +1454,25 @@ import {viewof cellMapViz, viewof detailViz, detailVizTitle} from "@tomlarkworth
 
 and then call them in your notebooks`
 )};
-const _17c6bac = function _cellMap(runtime,moduleMap,moduleVarInfo,importedModule,findModuleName,decompileImport){return(
+const _17c6bac = function _cellMap(runtime,modules,moduleSnapshot,moduleVarInfo,importedModule,findModuleName,decompileImport){return(
 async (variables, _moduleMap) => {
   const map = new Map();
   if (!variables) variables = runtime._variables;
   variables = [...variables];
   if (variables.length === 0) return map;
 
-  if (!_moduleMap) _moduleMap = await moduleMap(variables[0]._module._runtime);
+  // `modules` is @tomlarkworthy/modules' cumulative snapshot of the current runtime: it grows as
+  // modules resolve instead of blocking on a full load, so a still-loading page maps the cells it
+  // already has and this cell recomputes as the rest arrive. moduleMap used to fill this in, but it
+  // force-peeks every module before resolving, which gated liveCellMap on a near-complete load.
+  // Variables from another runtime have no reactive snapshot to ride, so take a one-off one.
+  if (!_moduleMap) {
+    const _runtime = variables[0]._module._runtime;
+    _moduleMap =
+      _runtime === runtime
+        ? modules
+        : await moduleSnapshot(_runtime, new Set(variables.map((v) => v._module)));
+  }
 
   const byNotebookModule = new Map();
   for (const v of variables) {
@@ -1838,8 +1849,26 @@ tests({
     t.name.includes("@tomlarkworthy/cell-map") || t.name.includes("main")
 })
 )};
-const _kdc1xp = function _modules(moduleMap,runtime){return(
-moduleMap(runtime)
+const _kdc1xp = function _modules(currentModules){return(
+currentModules
+)};
+const _1qy4mzs = function _moduleSnapshot(moduleStream){return(
+async (runtime, need, { timeoutMs = 5000 } = {}) => {
+  const it = moduleStream({ runtime });
+  const expired = new Promise((resolve) => setTimeout(resolve, timeoutMs, null));
+  let snapshot = new Map();
+  try {
+    while (true) {
+      const step = await Promise.race([it.next(), expired]);
+      if (!step || step.done) break;
+      snapshot = step.value;
+      if ([...need].every((m) => snapshot.has(m))) break;
+    }
+  } finally {
+    it.return?.(); // stops the stream's rescan loop
+  }
+  return snapshot;
+}
 )};
 const _jrvq7q = function _moduleLookup(modules){return(
 new Map([...modules.values()].map((info) => [info.name, info]))
@@ -1865,7 +1894,7 @@ Inputs.table(
     format: {
       _inputs: (i) => i.map((i) => i._name).join(", "),
       _observer: (i) => i.toString(),
-      _module: (m) => modules.get(m).name
+      _module: (m) => modules.get(m)?.name ?? "<unknown module>"
     }
   }
 )
@@ -1874,8 +1903,8 @@ const _pyrytd = function _unreached_main_import(toObject,lookupVariable,cellMapM
 toObject &&
   lookupVariable("repositionSetElement", cellMapModule)
 )};
-const _12euivr = function _reached_main_import(runtime,lookupVariable,cellMapModule){return(
-runtime && lookupVariable("runtime", cellMapModule)
+const _12euivr = function _reached_main_import(currentModules,lookupVariable,cellMapModule){return(
+currentModules && lookupVariable("currentModules", cellMapModule)
 )};
 const _1x88m7u = function _main_mutable(){return(
 "OK"
@@ -1885,7 +1914,7 @@ const _kbdqj3 = _ => _.generator;
 const _1q0qa04 = async function _test_importedModule(expect,modules,importedModule,reached_main_import,unreached_main_import)
 {
   expect(modules.get(await importedModule(reached_main_import)).name).toBe(
-    "@tomlarkworthy/module-map"
+    "@tomlarkworthy/modules"
   );
 
   expect(modules.get(await importedModule(unreached_main_import)).name).toBe(
@@ -1898,7 +1927,7 @@ const _1tqu9mu = async function _test_findModuleName(expect,findModuleName,impor
 {
   expect(
     findModuleName(await importedModule(reached_main_import), modules)
-  ).toBe("@tomlarkworthy/module-map");
+  ).toBe("@tomlarkworthy/modules");
 
   expect(
     findModuleName(await importedModule(unreached_main_import), modules)
@@ -2150,7 +2179,7 @@ export default function define(runtime, observer) {
   };
 
   main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
-  main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
+  main.define("module @tomlarkworthy/modules", async () => runtime.module((await import("/@tomlarkworthy/modules.js?v=4")).default));  
   main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
@@ -2173,7 +2202,7 @@ export default function define(runtime, observer) {
   $def("_14vvdt2", "liveCellMap", ["Generators","viewof liveCellMap"], _14vvdt2);  
   $def("_193osz9", "maintain_live_cell_map", ["runtime_variables","viewof liveCellMap","cellMap","Event"], _193osz9);  
   $def("_1vhxngh", "usage", ["md"], _1vhxngh);  
-  $def("_17c6bac", "cellMap", ["runtime","moduleMap","moduleVarInfo","importedModule","findModuleName","decompileImport"], _17c6bac);  
+  $def("_17c6bac", "cellMap", ["runtime","modules","moduleSnapshot","moduleVarInfo","importedModule","findModuleName","decompileImport"], _17c6bac);  
   $def("_1clgb7s", "test_cellmap_importInfo_on_real_import", ["cellMap","expect"], _1clgb7s);  
   $def("_yubgz5", null, ["md"], _yubgz5);  
   $def("_71n0hz", "cellMapCompat", ["cellMap"], _71n0hz);  
@@ -2194,8 +2223,9 @@ export default function define(runtime, observer) {
   $def("_10gdqhm", "edges", ["filteredMap","variableToCell","filter"], _10gdqhm);  
   main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("isOnObservableCom", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("isOnObservableCom", _));  
-  main.define("moduleMap", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("moduleMap", _));  
-  main.define("runtime", ["module @tomlarkworthy/module-map", "@variable"], (_, v) => v.import("runtime", _));  
+  main.define("currentModules", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("currentModules", _));  
+  main.define("moduleStream", ["module @tomlarkworthy/modules", "@variable"], (_, v) => v.import("modules", "moduleStream", _));  
+  main.define("runtime", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime", _));  
   main.define("keepalive", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("keepalive", _));  
   main.define("runtime_variables", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("runtime_variables", _));  
   main.define("lookupVariable", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("lookupVariable", _));  
@@ -2210,12 +2240,13 @@ export default function define(runtime, observer) {
   main.define("tests", ["module @tomlarkworthy/tests", "@variable"], (_, v) => v.import("tests", _));  
   $def("_2ufyg8", null, ["md"], _2ufyg8);  
   $def("_18tubss", null, ["tests"], _18tubss);  
-  $def("_kdc1xp", "modules", ["moduleMap","runtime"], _kdc1xp);  
+  $def("_kdc1xp", "modules", ["currentModules"], _kdc1xp);  
+  $def("_1qy4mzs", "moduleSnapshot", ["moduleStream"], _1qy4mzs);  
   $def("_jrvq7q", "moduleLookup", ["modules"], _jrvq7q);  
   $def("_rlmpw8", null, ["md"], _rlmpw8);  
   $def("_519lii", null, ["Inputs","runtime_variables","cellMapModule","toObject","modules"], _519lii);  
   $def("_pyrytd", "unreached_main_import", ["toObject","lookupVariable","cellMapModule"], _pyrytd);  
-  $def("_12euivr", "reached_main_import", ["runtime","lookupVariable","cellMapModule"], _12euivr);  
+  $def("_12euivr", "reached_main_import", ["currentModules","lookupVariable","cellMapModule"], _12euivr);  
   $def("_1x88m7u", "initial main_mutable", [], _1x88m7u);  
   $def("_1c3nv1y", "mutable main_mutable", ["Mutable","initial main_mutable"], _1c3nv1y);  
   $def("_kbdqj3", "main_mutable", ["mutable main_mutable"], _kbdqj3);  


### PR DESCRIPTION
**This PR is a proposal** — the canonical HTML has been updated with the new cells, but ObservableHQ has not been pushed and consumer notebooks have not been re-synced yet. After approval, those steps will run and additional commits will be pushed to this branch.

## Reported symptom

> cellMap is still using module-map to drive its latest cells, but this breaks streaming loads. It should use "modules" instead.

## Root cause

`cellMap()` filled its default module map with `await moduleMap(runtime)`, and the `modules` cell was `moduleMap(runtime)`. `moduleMap` force-peeks every module in the runtime before it resolves, so everything downstream of it — `liveCellMap`, and through it `editor-5`, `command-palette`, `visualizer`, `observablejs-toolchain` — was gated on a near-complete module load. `@tomlarkworthy/modules` exists precisely to avoid that: it is an async generator yielding a cumulative `Map` that grows as modules resolve.

## Fix

- `modules` is now the imported `currentModules` stream instead of `moduleMap(runtime)`.
- `cellMap()`'s default map is that live snapshot when the variables belong to the current runtime. Because `cellMap` now depends on `modules`, it recomputes as the map grows, so a partial early result converges instead of blocking.
- Variables from *another* runtime have no reactive snapshot to ride on, so a new `moduleSnapshot` cell drains `modules({runtime})` until it covers exactly the modules asked about, then stops the stream. Termination is coverage-based, not a fixed wait.
- `runtime` now comes from `@tomlarkworthy/runtime-sdk` (it was re-exported by module-map). The `@tomlarkworthy/module-map` import is gone from this module entirely.
- `reached_main_import` and its two tests re-point at the `@tomlarkworthy/modules` import, since that is now the reached cross-module import.
- `modules.get(m).name` in the low-level variables table is guarded — with a growing map it can legitimately miss.

Every notebook in `lopecode` and `lopebooks` that bundles `@tomlarkworthy/cell-map` (231 files) already bundles `@tomlarkworthy/modules`, so no bundle gains a module.

## Measured (rate-limited stream at 300 KB/s, `tools/probe-cellmap-streaming.mjs`)

Times are ms from navigation start; `liveCellMap` is stamped when it first holds a non-empty Map.

| | `@tomlarkworthy_cell-map.html` before | after | `quick_start.html` before | after |
|---|---|---|---|---|
| document parsed | 8005 | 8006 | 13182 | 13182 |
| streaming module map ready | 8130 | 8115 | 13563 | 13563 |
| `moduleMap` snapshot ready | 8565 | 8720 | 14422 | not observed in 20 s |
| **`liveCellMap` ready** | **8565** | **8115** | **14939** | **13563** |

`liveCellMap` lands in the same 25 ms poll tick as the streaming map instead of waiting for `moduleMap` — 450 ms earlier on the cell-map notebook, 1376 ms earlier on `quick_start`. On `quick_start` the blocking `moduleMap` force-load is no longer triggered at all within the probe window.

## Targeted QA (live runtime, regenerated bundle)

- `test_importedModule` OK, `test_findModuleName` OK, `test_cellmap_mutable` OK, `test_cellmap_importInfo_on_real_import` OK, `test_cell_map_covers_all_runtime_variables` OK (`coverage_failures` empty), `test_cell_map_no_variable_in_more_than_one_cell` OK
- Output parity against the unmodified notebook: 45 modules, 1721 to 1722 cells (the +1 is the new `moduleSnapshot` cell), 152 import cells, 0 with an unknown `module_name`. The 45 `importInfo.from` values reading `<unknown …>` are present in both — pre-existing, from `decompileImport` on builtin imports.
- Foreign-runtime path exercised directly: a fresh `Runtime` with `alpha`, `viewof beta` maps in 1 ms to the correct 2 cells (`simple`, `viewof` with 2 variables).
- Console: no errors. Warnings are the pre-existing `@import rules are not allowed here` from `@tomlarkworthy/themes`.

## Known limitation

`moduleSnapshot` races `it.next()` against a 5 s timeout. If that timeout wins, the generator is suspended at an `await` rather than a `yield`, so the queued `it.return()` cannot run its `finally` and that foreign runtime keeps a 1 s rescan loop. It only happens when a foreign runtime never resolves the requested modules; the coverage break, which is the normal path, always lands on a yield.