### PR TITLE
spec-sync: resync bootconf from the HTML (38 specs)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,14 @@
 # invariant "in committed history, spec.hash matches the block" is established
 # here rather than by any individual writer.
 #
+# The same applies to `bootconf`, and it is the half other tools READ:
+# lope-jumpgate.js takes `mains` and `hash` from the spec to decide what to
+# re-export. Left unmaintained it went badly wrong -- on 2026-08-13, 187 of 229
+# specs recorded different `mains` than their own HTML, so a jumpgate
+# regeneration silently dropped mains and downgraded the frame. `theme` is the
+# one key the HTML cannot carry (the exporter never writes one into the block),
+# so spec-sync preserves it rather than overwriting.
+#
 # A notebook with no sibling spec FAILS rather than being skipped: otherwise
 # every new notebook silently opts out of the invariant. Mint one with
 #   bun tools/lope-sync.ts spec-sync --rebuild notebooks/<name>.html
@@ -19,7 +27,7 @@ repos:
   - repo: local
     hooks:
       - id: lope-spec-sync
-        name: notebook spec hashes
+        name: notebook spec hashes + bootconf
         entry: sh -c 'test -f ../tools/lope-sync.ts || exit 0; exec bun ../tools/lope-sync.ts spec-sync "$@"' --
         language: system
         files: ^notebooks/.*\.html$

--- a/notebooks/@tomlarkworthy_atlas.json
+++ b/notebooks/@tomlarkworthy_atlas.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/atlas",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/atlas"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/atlas",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/atlas,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_atproto-comments.json
+++ b/notebooks/@tomlarkworthy_atproto-comments.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/atproto-comments",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/atproto-comments"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/atproto-comments",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/atproto-comments,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_bootloader.json
+++ b/notebooks/@tomlarkworthy_bootloader.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/bootloader",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/bootloader"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/bootloader",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/bootloader,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_cell-map.json
+++ b/notebooks/@tomlarkworthy_cell-map.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/cell-map",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/cell-map"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/cell-map",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=R100(S70(@tomlarkworthy/cell-map),S30(@tomlarkworthy/module-selection))",
     "headless": true,

--- a/notebooks/@tomlarkworthy_cells-to-clipboard.json
+++ b/notebooks/@tomlarkworthy_cells-to-clipboard.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/cells-to-clipboard",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/cells-to-clipboard"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/cells-to-clipboard",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/cells-to-clipboard,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_codemirror-6-v2.json
+++ b/notebooks/@tomlarkworthy_codemirror-6-v2.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/codemirror-6-v2",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/codemirror-6-v2"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/codemirror-6-v2",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/codemirror-6-v2,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_dataflow-templating.json
+++ b/notebooks/@tomlarkworthy_dataflow-templating.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/dataflow-templating",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/dataflow-templating"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/dataflow-templating",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/dataflow-templating,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_debugger-2.json
+++ b/notebooks/@tomlarkworthy_debugger-2.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/debugger-2",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/debugger-2"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/debugger-2",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/debugger-2,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_debugger.json
+++ b/notebooks/@tomlarkworthy_debugger.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/debugger",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/debugger"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/debugger",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/debugger,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_dom-view.json
+++ b/notebooks/@tomlarkworthy_dom-view.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/dom-view",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/dom-view"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/dom-view",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/dom-view,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_exporter-2.json
+++ b/notebooks/@tomlarkworthy_exporter-2.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/exporter-2",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/exporter-2"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/exporter-2",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/exporter-2,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_exporter-3.json
+++ b/notebooks/@tomlarkworthy_exporter-3.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/exporter-3",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/exporter-3"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/exporter-3",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/exporter-3,@tomlarkworthy/module-selection)",
     "headless": true,
@@ -25,7 +26,7 @@
       "hash": "5658858e85affa2e1e5cd1052924c622"
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "10d706c73268dbdcfcdb09c667486651",
+      "hash": "45bb99911a9d6c776a3f215e7777d5e2",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",

--- a/notebooks/@tomlarkworthy_fileattachments.json
+++ b/notebooks/@tomlarkworthy_fileattachments.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/fileattachments",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/fileattachments"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/fileattachments",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/fileattachments,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_flow-queue.json
+++ b/notebooks/@tomlarkworthy_flow-queue.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/flow-queue",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/flow-queue"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/flow-queue",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/flow-queue,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_golden-layout-2-6-0.json
+++ b/notebooks/@tomlarkworthy_golden-layout-2-6-0.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/golden-layout-2-6-0",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/golden-layout-2-6-0"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/golden-layout-2-6-0",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/golden-layout-2-6-0,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_import-notebook.json
+++ b/notebooks/@tomlarkworthy_import-notebook.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/import-notebook",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/import-notebook"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/import-notebook",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/import-notebook,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_jest-expect-standalone.json
+++ b/notebooks/@tomlarkworthy_jest-expect-standalone.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/jest-expect-standalone",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/jest-expect-standalone"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/jest-expect-standalone",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/jest-expect-standalone,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_local-storage-view.json
+++ b/notebooks/@tomlarkworthy_local-storage-view.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/local-storage-view",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/local-storage-view"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/local-storage-view",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/local-storage-view,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_lopecode-vision.json
+++ b/notebooks/@tomlarkworthy_lopecode-vision.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/lopecode-vision",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/lopecode-vision"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/lopecode-vision",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/lopecode-vision,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_lopepage-urls.json
+++ b/notebooks/@tomlarkworthy_lopepage-urls.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/lopepage-urls",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/lopepage-urls"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/lopepage-urls",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/lopepage-urls,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_modern-screenshot.json
+++ b/notebooks/@tomlarkworthy_modern-screenshot.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/modern-screenshot",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/modern-screenshot"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/modern-screenshot",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/modern-screenshot,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_module-selection.json
+++ b/notebooks/@tomlarkworthy_module-selection.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/module-selection",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/module-selection"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/module-selection",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/module-selection,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_notes.json
+++ b/notebooks/@tomlarkworthy_notes.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/notes",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/notes"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/notes",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/notes,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_observablehq-lezer.json
+++ b/notebooks/@tomlarkworthy_observablehq-lezer.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/observablehq-lezer",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/observablehq-lezer"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/observablehq-lezer",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/observablehq-lezer,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_observablejs-toolchain.json
+++ b/notebooks/@tomlarkworthy_observablejs-toolchain.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/observablejs-toolchain",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/observablejs-toolchain"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/observablejs-toolchain",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/observablejs-toolchain,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_openai-responses-api.json
+++ b/notebooks/@tomlarkworthy_openai-responses-api.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/openai-responses-api",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/openai-responses-api"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/openai-responses-api",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/openai-responses-api,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_reversible-attachment.json
+++ b/notebooks/@tomlarkworthy_reversible-attachment.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/reversible-attachment",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/reversible-attachment"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/reversible-attachment",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/reversible-attachment,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_robocoop-2.json
+++ b/notebooks/@tomlarkworthy_robocoop-2.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/robocoop-2",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/robocoop-2"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/robocoop-2",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/robocoop-2,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_robocoop-3.json
+++ b/notebooks/@tomlarkworthy_robocoop-3.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/robocoop-3",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/robocoop-3"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/robocoop-3",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/robocoop-3,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_runtime-sdk.json
+++ b/notebooks/@tomlarkworthy_runtime-sdk.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/runtime-sdk",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/runtime-sdk"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/runtime-sdk",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/runtime-sdk,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_secrets.json
+++ b/notebooks/@tomlarkworthy_secrets.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/secrets",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/secrets"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/secrets",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/secrets,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_tests.json
+++ b/notebooks/@tomlarkworthy_tests.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/tests",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/tests"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/tests",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/tests,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_themes.json
+++ b/notebooks/@tomlarkworthy_themes.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/themes",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/themes"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/themes",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/themes,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/@tomlarkworthy_visualizer.json
+++ b/notebooks/@tomlarkworthy_visualizer.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/visualizer",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/visualizer"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/visualizer",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/visualizer,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/atproto.json
+++ b/notebooks/atproto.json
@@ -3,11 +3,12 @@
   "title": "@tomlarkworthy/at-login",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
+      "@tomlarkworthy/lopepage-2",
       "@tomlarkworthy/at-login",
       "@tomlarkworthy/at-read",
       "@tomlarkworthy/at-write",
-      "@tomlarkworthy/atproto"
+      "@tomlarkworthy/atproto",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/at-login,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/jumpgates.json
+++ b/notebooks/jumpgates.json
@@ -207,7 +207,7 @@
       ]
     },
     "@tomlarkworthy/exporter-3": {
-      "hash": "10d706c73268dbdcfcdb09c667486651",
+      "hash": "45bb99911a9d6c776a3f215e7777d5e2",
       "dependsOn": [
         "@tomlarkworthy/lopepage-urls",
         "@tomlarkworthy/observable-runtime-v6",

--- a/notebooks/ledger.json
+++ b/notebooks/ledger.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/ledger",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/ledger"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/ledger",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/ledger,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/lopefeed.json
+++ b/notebooks/lopefeed.json
@@ -3,8 +3,9 @@
   "title": "@tomlarkworthy/lopefeed",
   "bootconf": {
     "mains": [
-      "@tomlarkworthy/lopepage",
-      "@tomlarkworthy/lopefeed"
+      "@tomlarkworthy/lopepage-2",
+      "@tomlarkworthy/lopefeed",
+      "@tomlarkworthy/save-in-place"
     ],
     "hash": "#view=S100(@tomlarkworthy/lopefeed,@tomlarkworthy/module-selection)",
     "headless": true,

--- a/notebooks/quick_start.json
+++ b/notebooks/quick_start.json
@@ -16,7 +16,11 @@
       "@tomlarkworthy/import-wizard-file",
       "@tomlarkworthy/import-wizard-notebook",
       "@tomlarkworthy/save-in-place",
-      "@tomlarkworthy/annotate"
+      "@tomlarkworthy/annotate",
+      "@tomlarkworthy/svg-lens",
+      "@tomlarkworthy/grid-container",
+      "@tomlarkworthy/sticky",
+      "@tomlarkworthy/debugger-2"
     ],
     "hash": "#view=S100(@tomlarkworthy/blank-notebook,@tomlarkworthy/at-write,@tomlarkworthy/claude-code-pairing,@tomlarkworthy/robocoop-5)",
     "headless": true


### PR DESCRIPTION
**Proposal — corpus half of tomlarkworthy/lopecode-dev#37.** Mechanical output of `bun tools/lope-sync.ts spec-sync notebooks/*.html`; no notebook HTML is touched.

The `.json` spec is written only by jumpgate, while `save-in-place` and `sync-module` rewrite the HTML's bootconf block without touching it. Corpus-wide on 2026-08-13, **187 of 229 specs recorded different `mains` than their own HTML** — 38 of them here.

That matters because `bootconf` is the half of the spec other tools *read*: `lope-jumpgate.js` takes `mains` and `hash` from it to decide what to re-export, so a regeneration silently dropped mains and downgraded the frame. `cell-map` is typical:

```
spec  ["@tomlarkworthy/lopepage",  "@tomlarkworthy/cell-map"]
html  ["@tomlarkworthy/lopepage-2","@tomlarkworthy/cell-map","@tomlarkworthy/save-in-place"]
```

`theme` is preserved, not overwritten — the exporter never writes one into the block, so the spec is its only record. All themes here survive, and a second `spec-sync --check` reports `specs up to date`.

The `.pre-commit-config.yaml` header is updated to say `bootconf` is now in scope; the hook entry itself is unchanged, since it already invokes `spec-sync`.

Depends on lopecode-dev#37 for the tool change — the hook calls the parent checkout's `tools/lope-sync.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)